### PR TITLE
Fixing class on ViewActions not always loading

### DIFF
--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -16,8 +16,6 @@ import {
 } from '@red-hat-insights/insights-frontend-components';
 import mockData from '../../../mockData/medium-risk.json';
 
-document.getElementById('root').classList.add('actions__view');
-
 class ViewActions extends Component {
     constructor(props) {
         super(props);

--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -36,6 +36,9 @@ class ViewActions extends Component {
     }
 
     componentDidMount() {
+
+        document.getElementById('root').classList.add('actions__view');
+
         const response = JSON.parse(JSON.stringify(mockData));
         this.setState({ summary: response.summary });
 

--- a/src/SmartComponents/Actions/_actions.scss
+++ b/src/SmartComponents/Actions/_actions.scss
@@ -1,7 +1,7 @@
 @import '~@red-hat-insights/insights-frontend-components/Utilities/_variables';
 @import '~@red-hat-insights/insights-frontend-components/Utilities/_mixins';
 
-.page__actions {
+.page__actions.actions__view {
     .ins-p-page-header__title { text-transform: capitalize; }
 
     table.rules-table {

--- a/src/SmartComponents/Actions/_actions.scss
+++ b/src/SmartComponents/Actions/_actions.scss
@@ -1,7 +1,7 @@
 @import '~@red-hat-insights/insights-frontend-components/Utilities/_variables';
 @import '~@red-hat-insights/insights-frontend-components/Utilities/_mixins';
 
-.page__actions.actions__view {
+.page__actions {
     .ins-p-page-header__title { text-transform: capitalize; }
 
     table.rules-table {


### PR DESCRIPTION
When `componentDidMount()` fires, the class is taken away. Moving that statement inside that function so it doesn't get overwritten.