### PR TITLE
Allow lists to show with no items

### DIFF
--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -43,19 +43,21 @@ class ViewActions extends Component {
         this.setState({ summary: response.summary });
 
         let rows = [];
-        for (let i = 0;i < response.rules.length;i++) {
-            rows.push(
-                { cells: [
-                    <Link key={ i } to={ `/actions/${this.props.match.params.type}/${response.rules[i].rule_id}` }>
-                        { response.rules[i].description }
-                    </Link>,
-                    <Battery key={ i } label='Likelihood' labelHidden severity={ response.rules[i].rec_likelihood } />,
-                    <Battery key={ i } label='Impact' labelHidden severity={ response.rules[i].rec_impact } />,
-                    <Battery key={ i } label='Total Risk' labelHidden severity={ response.rules[i].resolution_risk } />,
-                    <div key={ i }>{ response.rules[i].hitCount }</div>,
-                    <Ansible key={ i } unsupported={ response.rules[i].ansible === 1 ? true : false } />
-                ] }
-            );
+        if (response.rules) {
+            for (let i = 0;i < response.rules.length;i++) {
+                rows.push(
+                    { cells: [
+                        <Link key={ i } to={ `/actions/${this.props.match.params.type}/${response.rules[i].rule_id}` }>
+                            { response.rules[i].description }
+                        </Link>,
+                        <Battery key={ i } label='Likelihood' labelHidden severity={ response.rules[i].rec_likelihood } />,
+                        <Battery key={ i } label='Impact' labelHidden severity={ response.rules[i].rec_impact } />,
+                        <Battery key={ i } label='Total Risk' labelHidden severity={ response.rules[i].resolution_risk } />,
+                        <div key={ i }>{ response.rules[i].hitCount }</div>,
+                        <Ansible key={ i } unsupported={ response.rules[i].ansible === 1 ? true : false } />
+                    ] }
+                );
+            }
         }
 
         this.setState({ rows });

--- a/src/SmartComponents/Rules/ListRules.js
+++ b/src/SmartComponents/Rules/ListRules.js
@@ -26,24 +26,26 @@ class ListRules extends React.Component {
         const response = JSON.parse(JSON.stringify(mockData));
 
         let cards = [];
-        for (let i = 0; i < response.rules.length; i++) {
-            cards.push(
-                <RulesCard
-                    key = { i }
-                    ruleID = { response.rules[i].rule_id }
-                    category= { response.rules[i].category }
-                    description= { response.rules[i].description }
-                    summary= { response.rules[i].summary_html }
-                    impact = { response.rules[i].rec_impact }
-                    likelihood = { response.rules[i].rec_likelihood }
-                    totalRisk = { response.rules[i].resolution_risk }
-                    riskOfChange = { 3 }
-                    ansible = { response.rules[i].ansible }
-                    hitCount = { response.rules[i].hitCount }
-                />
-            );
+        if (response.rules) {
+            for (let i = 0; i < response.rules.length; i++) {
+                cards.push(
+                    <RulesCard
+                        key = { i }
+                        ruleID = { response.rules[i].rule_id }
+                        category= { response.rules[i].category }
+                        description= { response.rules[i].description }
+                        summary= { response.rules[i].summary_html }
+                        impact = { response.rules[i].rec_impact }
+                        likelihood = { response.rules[i].rec_likelihood }
+                        totalRisk = { response.rules[i].resolution_risk }
+                        riskOfChange = { 3 }
+                        ansible = { response.rules[i].ansible }
+                        hitCount = { response.rules[i].hitCount }
+                    />
+                );
 
-            this.setState({ cards });
+                this.setState({ cards });
+            }
         }
     }
 


### PR DESCRIPTION
Currently, if I run this app just cloned from the repo, response.rules
is empty. Therefore when I visit the Actions or Rules pages I don't see
anything but an error message that you can't call .length on an
undefined method. This commit fixes that problem.