### PR TITLE
Updating layout and pages to use new chroming service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,6 @@
       "version": "7.0.0-beta.51",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.51.tgz",
       "integrity": "sha1-zgBCgEX7t9XrwOp7+DV4nxU2arI=",
-      "dev": true,
       "requires": {
         "@babel/types": "7.0.0-beta.51",
         "lodash": "^4.17.5"
@@ -74,7 +73,6 @@
           "version": "7.0.0-beta.51",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
           "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.5",
@@ -84,15 +82,14 @@
         "to-fast-properties": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-          "dev": true
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
         }
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-rc.2.tgz",
-      "integrity": "sha512-kavwJYTgdd5W12MpfMJMznrfsx3sCl0HMSJ0vsPcbwT9jhF0EmYL1eyfeYbo4pToYmQgPKp+VGtSHQ3wL8N5lQ=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.0.0-beta.44",
@@ -243,6 +240,62 @@
         }
       }
     },
+    "@emotion/babel-utils": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-utils/-/babel-utils-0.6.9.tgz",
+      "integrity": "sha512-QN2+TP+x5QWuOGUv8TZwdMiF8PHgBQiLx646rKZBnakgc9gLYFi+gsROVxE6YTNHSaEv0fWsFjDasDyiWSJlDg==",
+      "requires": {
+        "@emotion/hash": "^0.6.5",
+        "@emotion/memoize": "^0.6.5",
+        "@emotion/serialize": "^0.9.0",
+        "convert-source-map": "^1.5.1",
+        "find-root": "^1.1.0",
+        "source-map": "^0.7.2"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        }
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.5.tgz",
+      "integrity": "sha512-JlZbn5+adseTdDPTUkx/O1/UZbhaGR5fCLLWQDCIJ4eP9fJcVdP/qjlTveEX6mkNoJHWFbZ47wArWQQ0Qk6nMA=="
+    },
+    "@emotion/memoize": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.5.tgz",
+      "integrity": "sha512-n1USr7yICA4LFIv7z6kKsXM8rZJxd1btKCBmDewlit+3OJ2j4bDfgXTAxTHYbPkHS/eztHmFWfsbxW2Pu5mDqA=="
+    },
+    "@emotion/serialize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.9.0.tgz",
+      "integrity": "sha512-ScuBRGxHCyAEN8YgQSsxtG5ddmP9+Of8WkxC7hidhGTxKhq3lgeCu5cFk2WdAMrpYgEd0U4g4QW/1YrCOGpAsA==",
+      "requires": {
+        "@emotion/hash": "^0.6.5",
+        "@emotion/memoize": "^0.6.5",
+        "@emotion/unitless": "^0.6.6",
+        "@emotion/utils": "^0.8.1"
+      }
+    },
+    "@emotion/stylis": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.0.tgz",
+      "integrity": "sha512-DTq3Wo4p63JoogA5TaVKZHj7QcU32kRF+iKLWJnfGlIw4S+v90rVHX8pLQETKILWXk05iZ2b0KUKFMTAHYbytw=="
+    },
+    "@emotion/unitless": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.6.tgz",
+      "integrity": "sha512-zbd1vXRpGWCgDLsXqITReL+eqYJ95PYyWrVCCuMLBDb2LGA/HdxrZHJri6Fe+tKHihBOiCK1kbu+3Ij8aNEjzA=="
+    },
+    "@emotion/utils": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.1.tgz",
+      "integrity": "sha512-dEv1n+IFtlvLQ8/FsTOtBCC1aNT4B5abE8ODF5wk2tpWnjvgGNRMvHCeJGbVHjFfer4h8MH2w9c2/6eoJHclMg=="
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -259,10 +312,15 @@
       "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A==",
       "dev": true
     },
+    "@patternfly/patternfly-next": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly-next/-/patternfly-next-1.0.41.tgz",
+      "integrity": "sha512-DgzY/K9Ihl3qEz6nMrZfSwqj27uncbLsYwGt1myWRHoA+c4VVzFvMCgV5Oz1VFR+9jmALrKI8aSXFrgC8eoThA=="
+    },
     "@patternfly/react-core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-1.8.1.tgz",
-      "integrity": "sha512-rc1vJsfulO6FHOv2LJvUKZReBQo8nTG3y7jPtTTFSE51s6pml3qSBW3mCaUMRZXFLAebGyPC/qLwaWL9AGDZWg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-1.11.1.tgz",
+      "integrity": "sha512-1eCOlofRplxJ8uRZpDDx1KsHyVRitFtFknqa+FrvkhIrv3y8Y6tHN3tA1T4FAu7d4Oc56LDM1fbH+95MMn6ugg==",
       "requires": {
         "@patternfly/react-icons": "^2.0.0",
         "@patternfly/react-styles": "^2.0.0",
@@ -271,25 +329,34 @@
       }
     },
     "@patternfly/react-icons": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-2.3.0.tgz",
-      "integrity": "sha512-57HgsVYV7lhFPXOST6CqqoKdzPI+EKRk/4jgwyW6spPSGVCziAPE3+nvrxENCtrN+4MdPH9WIhY2MMLLdl5pEQ=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-2.4.0.tgz",
+      "integrity": "sha512-7ezE1MrB3suuxpU0mP8Ye52p/ScLVCEwag1Ops9pAtZwyXR8dsv2Xsj/wM1RUUtKmNymiHkUSxYmvB1CCzZ96w=="
     },
     "@patternfly/react-styles": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-2.0.1.tgz",
-      "integrity": "sha512-jMDPKqt86dpa0i+pL90yR+jXJGQ7IRHXlNVTJW1Ihwm+IoRAPVj1jB0uefh3LX1/TUQf1OJ5xrqRyt1A7wBoEg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-2.1.1.tgz",
+      "integrity": "sha512-Qjm88oYue9PGHTgJMeD9a0xJSCsb4uet3/6q91SscdT6FlCHKtv7X4l+bqaBo1nZ98uNMUiV5Uoz0/Rc71JstA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0-beta.48",
-        "aphrodite": "^2.2.1",
         "camel-case": "^3.0.0",
         "css": "^2.2.3",
+        "cssom": "^0.3.4",
         "cssstyle": "^0.3.1",
+        "emotion": "^9.2.6",
+        "emotion-server": "^9.2.6",
         "fbjs-scripts": "^0.8.3",
         "fs-extra": "^6.0.1",
         "jsdom": "^11.11.0",
         "relative": "^3.0.2",
         "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.4",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
+          "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog=="
+        }
       }
     },
     "@patternfly/react-tokens": {
@@ -299,9 +366,9 @@
       "optional": true
     },
     "@red-hat-insights/insights-frontend-components": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.8.2.tgz",
-      "integrity": "sha512-q9rO6WoivQtlPYL9F39550sy5kUPujQQ762Y7Hc86E4sxcsReZsmbjjPQmodzsxvwqj1tv/Ug20XnrZriXBkmw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.11.0.tgz",
+      "integrity": "sha512-B05reCrtJnloDz8+pmae7k3eBzQRBQqZOU/3azJFLhRxNihaCqJivIo2srZ/GP8LzEGFE1PZBhDf1BPUoVgLPg==",
       "requires": {
         "@patternfly/react-core": "^1.5.0",
         "@patternfly/react-icons": "^2.3.0",
@@ -534,9 +601,9 @@
       "optional": true
     },
     "@types/d3-request": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-request/-/d3-request-1.0.2.tgz",
-      "integrity": "sha1-2524FU9HgWWEcGxub3Ar5m8i9L4=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-request/-/d3-request-1.0.3.tgz",
+      "integrity": "sha512-bopZVggPNk7RYeuktk8LA5wmqA+9wDZPA+g4kX79sHScjNR85cSDg9oK26k8QBtbCld+/gMD44aSzRRVWjkxGw==",
       "optional": true,
       "requires": {
         "@types/d3-dsv": "*"
@@ -1021,8 +1088,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
       "version": "1.3.5",
@@ -1121,7 +1187,8 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -1230,16 +1297,6 @@
         }
       }
     },
-    "aphrodite": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/aphrodite/-/aphrodite-2.2.3.tgz",
-      "integrity": "sha512-e09soRmp1MGzGibAzSOBMnIqq7zF9DwYM2d4jurnf9CKDGnJqQizGkUtwCIyodZv9tj2eIyGskeKA7RhUbXQrA==",
-      "requires": {
-        "asap": "^2.0.3",
-        "inline-style-prefixer": "^4.0.2",
-        "string-hash": "^1.1.3"
-      }
-    },
     "app-root-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.1.0.tgz",
@@ -1281,7 +1338,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -1829,6 +1885,33 @@
         "@babel/helper-module-imports": "^7.0.0-beta.33"
       }
     },
+    "babel-plugin-emotion": {
+      "version": "9.2.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-9.2.8.tgz",
+      "integrity": "sha512-m+M0Xim43+y3Egpl0C4Zz5dI0f7JaBi6GZF1vtr1IdODRpxWOx47uzr7qXyuBCG/U/nB2DGaU996of0nJjwWbw==",
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.51",
+        "@emotion/babel-utils": "^0.6.4",
+        "@emotion/hash": "^0.6.2",
+        "@emotion/memoize": "^0.6.1",
+        "@emotion/stylis": "^0.7.0",
+        "babel-core": "^6.26.3",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "find-root": "^1.1.0",
+        "mkdirp": "^0.5.1",
+        "source-map": "^0.5.7",
+        "touch": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
       "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
@@ -1877,6 +1960,14 @@
           "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
         }
+      }
+    },
+    "babel-plugin-macros": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.0.tgz",
+      "integrity": "sha512-flIBfrqAdHWn+4l2cS/4jZEyl+m5EaBHVzTb0aOF+eu/zR7E41/MoCFHPhDNL8Wzq1nyelnXeT+vcL2byFLSZw==",
+      "requires": {
+        "cosmiconfig": "^5.0.5"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -2480,9 +2571,9 @@
       }
     },
     "babel-preset-fbjs": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.2.0.tgz",
-      "integrity": "sha512-jj0KFJDioYZMtPtZf77dQuU+Ad/1BtN0UnAYlHDa8J8f4tGXr3YrPoJImD5MdueaOPeN/jUdrCgu330EfXr0XQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.3.0.tgz",
+      "integrity": "sha512-ZOpAI1/bN0Y3J1ZAK9gRsFkHy9gGgJoDRUjtUCla/129LC7uViq9nIK22YdHfey8szohYoZY3f9L2lGOv0Edqw==",
       "requires": {
         "babel-plugin-check-es2015-constants": "^6.8.0",
         "babel-plugin-syntax-class-properties": "^6.8.0",
@@ -2899,7 +2990,8 @@
     "bowser": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.3.tgz",
-      "integrity": "sha512-/gp96UlcFw5DbV2KQPCqTqi0Mb9gZRyDAHiDsGEH+4B/KOQjeoE5lM1PxlVX8DQDvfEfitmC1rW2Oy8fk/XBDg=="
+      "integrity": "sha512-/gp96UlcFw5DbV2KQPCqTqi0Mb9gZRyDAHiDsGEH+4B/KOQjeoE5lM1PxlVX8DQDvfEfitmC1rW2Oy8fk/XBDg==",
+      "dev": true
     },
     "boxen": {
       "version": "1.3.0",
@@ -4155,7 +4247,6 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.5.tgz",
       "integrity": "sha512-94j37OtvxS5w7qr7Ta6dt67tWdnOxigBVN4VnSxNXFez9o18PGQ0D33SchKP17r9LAcWVTYV72G6vDayAUBFIg==",
-      "dev": true,
       "requires": {
         "is-directory": "^0.3.1",
         "js-yaml": "^3.9.0",
@@ -4165,14 +4256,12 @@
         "esprima": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
         },
         "js-yaml": {
           "version": "3.12.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
           "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-          "dev": true,
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
@@ -4182,7 +4271,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
             "json-parse-better-errors": "^1.0.1"
@@ -4198,6 +4286,37 @@
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.0.0"
+      }
+    },
+    "create-emotion": {
+      "version": "9.2.6",
+      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.6.tgz",
+      "integrity": "sha512-4g46va26lw6DPfKF7HeWY3OI/qoaNSwpvO+li8dMydZfC6f6+ZffwlYHeIyAhGR8Z8C8c0H9J1pJbQRtb9LScw==",
+      "requires": {
+        "@emotion/hash": "^0.6.2",
+        "@emotion/memoize": "^0.6.1",
+        "@emotion/stylis": "^0.6.10",
+        "@emotion/unitless": "^0.6.2",
+        "csstype": "^2.5.2",
+        "stylis": "^3.5.0",
+        "stylis-rule-sheet": "^0.0.10"
+      },
+      "dependencies": {
+        "@emotion/stylis": {
+          "version": "0.6.12",
+          "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.6.12.tgz",
+          "integrity": "sha512-yS+t7l5FeYeiIyADyqjFBJvdotpphHb2S3mP4qak5BpV7ODvxuyAVF24IchEslW+A1MWHAhn5SiOW6GZIumiEQ=="
+        }
+      }
+    },
+    "create-emotion-server": {
+      "version": "9.2.8",
+      "resolved": "https://registry.npmjs.org/create-emotion-server/-/create-emotion-server-9.2.8.tgz",
+      "integrity": "sha512-Z8tq5vsEivwI3qSt7PKHCUMribt9NFOXgwsQTVzgc88caUG35v8iKw1EFOmSCqA8OjnKWywurRoHc3gKI74VAA==",
+      "requires": {
+        "html-tokenize": "^2.0.0",
+        "multipipe": "^1.0.2",
+        "through": "^2.3.8"
       }
     },
     "create-error-class": {
@@ -4309,13 +4428,13 @@
       "dev": true
     },
     "css": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.3.tgz",
-      "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
       "requires": {
-        "inherits": "^2.0.1",
-        "source-map": "^0.1.38",
-        "source-map-resolve": "^0.5.1",
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
         "urix": "^0.1.0"
       }
     },
@@ -4334,6 +4453,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
       "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+      "dev": true,
       "requires": {
         "hyphenate-style-name": "^1.0.2",
         "isobject": "^3.0.1"
@@ -4479,6 +4599,11 @@
       "requires": {
         "cssom": "0.3.x"
       }
+    },
+    "csstype": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.6.tgz",
+      "integrity": "sha512-tKPyhy0FmfYD2KQYXD5GzkvAYLYj96cMLXr648CKGd3wBe0QqoPipImjGiLze9c8leJK8J3n7ap90tpk3E6HGQ=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -5232,6 +5357,14 @@
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -5309,6 +5442,23 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
+    },
+    "emotion": {
+      "version": "9.2.8",
+      "resolved": "https://registry.npmjs.org/emotion/-/emotion-9.2.8.tgz",
+      "integrity": "sha512-4CT7S2+TDcd9qTSosd3VibERAsaZjhraeLxLWRuV6epX5XdHQjeLFqAlion/iT8M3UNQx9bqmlOTd+KaUj2M8Q==",
+      "requires": {
+        "babel-plugin-emotion": "^9.2.8",
+        "create-emotion": "^9.2.6"
+      }
+    },
+    "emotion-server": {
+      "version": "9.2.8",
+      "resolved": "https://registry.npmjs.org/emotion-server/-/emotion-server-9.2.8.tgz",
+      "integrity": "sha512-BIZlF++OwNdryoht5hBNDKo6YPtUILQq1/LxF3djGcJ5OuYOOGxQdymdySLd1Y6wXVCGo323d6asAN59cSWpiA==",
+      "requires": {
+        "create-emotion-server": "^9.2.8"
+      }
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -5460,7 +5610,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -6358,6 +6507,11 @@
         "make-dir": "^1.0.0",
         "pkg-dir": "^2.0.0"
       }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "find-up": {
       "version": "2.1.0",
@@ -7876,6 +8030,68 @@
       "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
       "dev": true
     },
+    "html-tokenize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.0.tgz",
+      "integrity": "sha1-izqaXetHXK5qb5ZxYA0sIKspglE=",
+      "requires": {
+        "buffer-from": "~0.1.1",
+        "inherits": "~2.0.1",
+        "minimist": "~0.0.8",
+        "readable-stream": "~1.0.27-1",
+        "through2": "~0.4.1"
+      },
+      "dependencies": {
+        "buffer-from": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+          "requires": {
+            "readable-stream": "~1.0.17",
+            "xtend": "~2.1.1"
+          }
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "requires": {
+            "object-keys": "~0.4.0"
+          }
+        }
+      }
+    },
     "html-webpack-plugin": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
@@ -7999,7 +8215,8 @@
     "hyphenate-style-name": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
-      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
+      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es=",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -8166,15 +8383,6 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
-    "inline-style-prefixer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-4.0.2.tgz",
-      "integrity": "sha512-N8nVhwfYga9MiV9jWlwfdj1UDIaZlBFu4cJSJkIr7tZX7sHpHhGR5su1qdpW+7KPL8ISTvCIkcaFi/JdBknvPg==",
-      "requires": {
-        "bowser": "^1.7.3",
-        "css-in-js-utils": "^2.0.0"
-      }
-    },
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
@@ -8330,8 +8538,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -8430,8 +8637,7 @@
     "is-directory": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-      "dev": true
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -8753,7 +8959,8 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -10096,8 +10303,7 @@
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -11456,6 +11662,15 @@
         "array-union": "^1.0.1",
         "arrify": "^1.0.0",
         "minimatch": "^3.0.0"
+      }
+    },
+    "multipipe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
+      "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
+      "requires": {
+        "duplexer2": "^0.1.2",
+        "object-assign": "^4.1.0"
       }
     },
     "mute-stream": {
@@ -14092,11 +14307,11 @@
           "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
         },
         "enzyme-adapter-react-16": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.3.1.tgz",
-          "integrity": "sha512-BFD5aBZwuN8buSPl5eZpYiqx6AqRgw2G/dP+P5/ttC8vxNpLTgpr7iHo1dszfFrA44d41S5SGdhE4mNdB4hZqA==",
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.5.0.tgz",
+          "integrity": "sha512-R2LcVvMB2UwPH763d5jDtVedAIcEj+uZjOnq0nd1sOUs6z8TDbyHDvt8VwfrS4wMt7CawoyPmH0XzC8MtEqqDw==",
           "requires": {
-            "enzyme-adapter-utils": "^1.6.0",
+            "enzyme-adapter-utils": "^1.8.0",
             "function.prototype.name": "^1.1.0",
             "object.assign": "^4.1.0",
             "object.values": "^1.0.4",
@@ -14106,9 +14321,9 @@
           }
         },
         "enzyme-adapter-utils": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.6.1.tgz",
-          "integrity": "sha512-MH8Tbe/e6UlVGBTxO5vb2gHv/wqAU2j/I72nuVGHyb0TxzfZOttJopJea7/5ZgmwBSeqqcaRnd/B87//RDJ9/w==",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.8.0.tgz",
+          "integrity": "sha512-K9U2RGr1pvWPGEAIRQRVH4UdlqzpfLsKonuHyAK6lxu46yfGsMDVlO3+YvQwQpVjVw8eviEVIOmlFAnMbIhv/w==",
           "requires": {
             "function.prototype.name": "^1.1.0",
             "object.assign": "^4.1.0",
@@ -15696,12 +15911,9 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-      "requires": {
-        "amdefine": ">=0.0.4"
-      }
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-loader": {
       "version": "0.2.3",
@@ -15825,8 +16037,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.14.2",
@@ -15959,11 +16170,6 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
-    },
-    "string-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
     },
     "string-length": {
       "version": "2.0.0",
@@ -16455,6 +16661,16 @@
         }
       }
     },
+    "stylis": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.3.tgz",
+      "integrity": "sha512-TxU0aAscJghF9I3V9q601xcK3Uw1JbXvpsBGj/HULqexKOKlOEzzlIpLFRbKkCK990ccuxfXUqmPbIIo7Fq/cQ=="
+    },
+    "stylis-rule-sheet": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
+    },
     "sugarss": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-1.0.1.tgz",
@@ -16718,8 +16934,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.3",
@@ -16870,6 +17085,24 @@
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
       "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
       "dev": true
+    },
+    "touch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
+      "integrity": "sha1-RJy+LbrlqMgDjjDXH6D/RklHxN4=",
+      "requires": {
+        "nopt": "~1.0.10"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "requires": {
+            "abbrev": "1"
+          }
+        }
+      }
     },
     "tough-cookie": {
       "version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.2.0",
   "private": false,
   "dependencies": {
-    "@patternfly/react-core": "1.8.1",
-    "@red-hat-insights/insights-frontend-components": "^3.8.2",
+    "@patternfly/react-core": "1.11.1",
+    "@red-hat-insights/insights-frontend-components": "^3.11.0",
+    "@patternfly/patternfly-next": "^1.0.38",
     "classnames": "^2.2.5",
     "create-react-class": "^15.6.3"
   },

--- a/src/App.scss
+++ b/src/App.scss
@@ -15,8 +15,8 @@ ul.navigation-secondary {
       span { margin-left: 50px; }
       &:active, &.active{
         background: #f5f5f5;
-        color: $ins-color--blue;
+        color: var(--pf-global--link--Color);
       }
-      &:hover { color: $ins-color--blue; }
+      &:hover { color: var(--pf-global--link--Color); }
     }
   }

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,2 +1,22 @@
 // Importing Global Variables
 @import '~@red-hat-insights/insights-frontend-components/index.css';
+@import '~@red-hat-insights/insights-frontend-components/Utilities/_variables';
+
+// Temp nav styles
+ul.navigation-secondary {
+    margin-top: 20px;
+    li {
+      cursor: pointer;
+      font-size: 15px;
+      width: 100%;
+      box-shadow: none;
+      padding: 5px 0;
+      color: #1d1d1d;
+      span { margin-left: 50px; }
+      &:active, &.active{
+        background: #f5f5f5;
+        color: $ins-color--blue;
+      }
+      &:hover { color: $ins-color--blue; }
+    }
+  }

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -32,7 +32,8 @@ type Props = {
 const InsightsRoute = ({ component: Component, rootClass, ...rest }) => {
     const root = document.getElementById('root');
     root.removeAttribute('class');
-    root.classList.add(`page__${rootClass}`);
+    root.classList.add(`page__${rootClass}`, 'pf-l-page__main');
+    root.setAttribute('role', 'main');
 
     return (<Component {...rest} />);
 };

--- a/src/SmartComponents/Actions/ActionsOverview.js
+++ b/src/SmartComponents/Actions/ActionsOverview.js
@@ -4,7 +4,7 @@ import asyncComponent from '../../Utilities/asyncComponent';
 import '../../App.scss';
 
 import { Card, CardHeader, CardBody, Grid, GridItem } from '@patternfly/react-core';
-import { PageHeader, PageHeaderTitle, Section, Donut } from '@red-hat-insights/insights-frontend-components';
+import { PageHeader, PageHeaderTitle, Donut, Main } from '@red-hat-insights/insights-frontend-components';
 
 const SummaryChart = asyncComponent(() => import('../../PresentationalComponents/SummaryChart/SummaryChart.js'));
 const SummaryChartItem = asyncComponent(() => import('../../PresentationalComponents/SummaryChartItem/SummaryChartItem.js'));
@@ -76,7 +76,7 @@ class ActionsOverview extends Component {
                 <PageHeader>
                     <PageHeaderTitle title='Actions'/>
                 </PageHeader>
-                <Section type='content'>
+                <Main>
                     <Grid gutter='md'>
                         <GridItem span={4}>
                             <Card>
@@ -97,7 +97,7 @@ class ActionsOverview extends Component {
                             </Card>
                         </GridItem>
                     </Grid>
-                </Section>
+                </Main>
             </React.Fragment>
         );
     }

--- a/src/SmartComponents/Actions/ActionsOverview.js
+++ b/src/SmartComponents/Actions/ActionsOverview.js
@@ -77,8 +77,8 @@ class ActionsOverview extends Component {
                     <PageHeaderTitle title='Actions'/>
                 </PageHeader>
                 <Main>
-                    <Grid gutter='md'>
-                        <GridItem span={4}>
+                    <Grid gutter='md' xl={4} sm={6}>
+                        <GridItem>
                             <Card>
                                 <CardHeader>Category Summary</CardHeader>
                                 <CardBody>
@@ -86,7 +86,7 @@ class ActionsOverview extends Component {
                                 </CardBody>
                             </Card>
                         </GridItem>
-                        <GridItem span={4}>
+                        <GridItem>
                             <Card>
                                 <CardHeader>Risk Summary</CardHeader>
                                 <CardBody>

--- a/src/SmartComponents/Actions/ListActions.js
+++ b/src/SmartComponents/Actions/ListActions.js
@@ -4,14 +4,14 @@ import './_actions.scss';
 import PropTypes from 'prop-types';
 
 import {
-    Section,
     PageHeader,
     PageHeaderTitle,
     Battery,
     Ansible,
     Table,
     SortDirection,
-    Pagination
+    Pagination,
+    Main
 } from '@red-hat-insights/insights-frontend-components';
 
 import {
@@ -134,7 +134,7 @@ class ListActions extends Component {
                 <PageHeader>
                     <PageHeaderTitle title= 'Actions' />
                 </PageHeader>
-                <Section type='content' className='actions__list'>
+                <Main className='actions__list'>
                     <Grid gutter='md'>
                         <GridItem md={8} sm={12}>
                             <Title size='xl'>
@@ -158,8 +158,6 @@ class ListActions extends Component {
                             </Grid>
                         </GridItem>
                     </Grid>
-                </Section>
-                <Section type='content'>
                     <Table
                         className='impacted-systems-table'
                         onItemSelect={ this.toggleCol }
@@ -178,7 +176,7 @@ class ListActions extends Component {
                             />
                         }
                     />
-                </Section>
+                </Main>
             </React.Fragment>
         );
     }

--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -10,10 +10,16 @@ import {
     PageHeader,
     PageHeaderTitle,
     Pagination,
-    Section,
     SortDirection,
-    Table
+    Table,
+    Main
 } from '@red-hat-insights/insights-frontend-components';
+
+import {
+    Stack,
+    StackItem
+} from '@patternfly/react-core';
+
 import mockData from '../../../mockData/medium-risk.json';
 
 class ViewActions extends Component {
@@ -115,32 +121,36 @@ class ViewActions extends Component {
                 <PageHeader>
                     <PageHeaderTitle title={ `${this.props.match.params.type} Risk Actions` } />
                 </PageHeader>
-                <Section type='content'>
-                    <p>{ this.state.summary }</p>
-                </Section>
-                <Section type='content'>
-                    Filters
-                </Section>
-                <Section type='content'>
-                    <Table
-                        className='rules-table'
-                        onItemSelect={ this.toggleCol }
-                        hasCheckbox={ false }
-                        header={ this.state.cols }
-                        sortBy={ this.state.sortBy }
-                        rows={ rows }
-                        onSort={ this.onSortChange }
-                        footer={
-                            <Pagination
-                                numberOfItems={ this.state.rows.length }
-                                onPerPageSelect={ this.setPerPage }
-                                page={ this.state.page }
-                                onSetPage={ this.setPage }
-                                itemsPerPage={ this.state.itemsPerPage }
+                <Main>
+                    <Stack gutter='md'>
+                        <StackItem>
+                            <p>{ this.state.summary }</p>
+                        </StackItem>
+                        <StackItem className='advisor-l-actions__filters'>
+                            Filters
+                        </StackItem>
+                        <StackItem className='advisor-l-actions__table'>
+                            <Table
+                                className='rules-table'
+                                onItemSelect={ this.toggleCol }
+                                hasCheckbox={ false }
+                                header={ this.state.cols }
+                                sortBy={ this.state.sortBy }
+                                rows={ rows }
+                                onSort={ this.onSortChange }
+                                footer={
+                                    <Pagination
+                                        numberOfItems={ this.state.rows.length }
+                                        onPerPageSelect={ this.setPerPage }
+                                        page={ this.state.page }
+                                        onSetPage={ this.setPage }
+                                        itemsPerPage={ this.state.itemsPerPage }
+                                    />
+                                }
                             />
-                        }
-                    />
-                </Section>
+                        </StackItem>
+                    </Stack>
+                </Main>
             </React.Fragment>
         );
     };

--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -119,7 +119,7 @@ class ViewActions extends Component {
         return (
             <React.Fragment>
                 <PageHeader>
-                    <PageHeaderTitle title={ `${this.props.match.params.type} Risk Actions` } />
+                    <PageHeaderTitle className='actions__view--title' title={ `${this.props.match.params.type} Risk Actions` } />
                 </PageHeader>
                 <Main>
                     <Stack gutter='md'>

--- a/src/SmartComponents/Actions/_actions.scss
+++ b/src/SmartComponents/Actions/_actions.scss
@@ -21,3 +21,7 @@
         @include rem('margin-top', 5px);
     }
 }
+
+table.impacted-systems-table {
+    margin: $ins-margin 0;
+}

--- a/src/SmartComponents/Actions/_actions.scss
+++ b/src/SmartComponents/Actions/_actions.scss
@@ -2,7 +2,7 @@
 @import '~@red-hat-insights/insights-frontend-components/Utilities/_mixins';
 
 .page__actions.actions__view {
-    .ins-p-page-header__title { text-transform: capitalize; }
+    .actions__view--title { text-transform: capitalize; }
 
     table.rules-table {
         th:first-child { width: 50%; }

--- a/src/SmartComponents/Rules/ListRules.js
+++ b/src/SmartComponents/Rules/ListRules.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Section, Pagination } from '@red-hat-insights/insights-frontend-components';
+import { Main, Pagination } from '@red-hat-insights/insights-frontend-components';
 
 import rulesCardSkeleton from '../../PresentationalComponents/Skeletons/RulesCard/RulesCardSkeleton.js';
 const RulesCard = rulesCardSkeleton(() => import('../../PresentationalComponents/RulesCard/RulesCard.js'));
@@ -75,7 +75,7 @@ class ListRules extends React.Component {
     render() {
         const cards = this.limitCards();
         return (
-            <Section type='content'>
+            <Main>
                 { cards }
                 <Pagination
                     numberOfItems={ this.state.cards.length }
@@ -84,7 +84,7 @@ class ListRules extends React.Component {
                     onSetPage={ this.setPage }
                     itemsPerPage={ this.state.itemsPerPage }
                 />
-            </Section>
+            </Main>
         );
 
     };

--- a/src/index.html
+++ b/src/index.html
@@ -6,8 +6,11 @@
         <esi:include src="/insights/static/chrome/snippets/head.html"/>
     </head>
     <body>
-        <esi:include src="/insights/static/chrome/snippets/header.html"/>
-        <esi:include src="/insights/static/chrome/snippets/footer.html"/>
-        <div id="root" />
+        <div class="pf-c-background-image"></div>        
+        <div class="pf-l-page" id="page">
+            <esi:include src="/insights/static/chrome/snippets/header.html"/>
+            <esi:include src="/insights/static/chrome/snippets/sidebar.html"/>
+            <main role="main" class="pf-l-page__main" id="root"/>
+        </div>
     </body>
 </html>


### PR DESCRIPTION
Relies on: [Insights-Chrome#24](https://github.com/RedHatInsights/insights-chrome/pull/24)

This introduces layouts with the new chroming service. Also introduces the `Main` component. This previously was held by the `<Section type='content>` (which is still valid), but not to be used to wrap the page. 

If you want to review this PR, you *must* be running that branch of chrome with `LOCAL_CHROME=true` until it gets merged into prod.