### PR TITLE
Adds action url title helper, ensures urls match beta 

### DIFF
--- a/src/SmartComponents/Actions/ActionsOverview.js
+++ b/src/SmartComponents/Actions/ActionsOverview.js
@@ -45,7 +45,7 @@ class ActionsOverview extends Component {
                     key={ i }
                     condition={ this.state.severity[i] }
                     wrap={ children =>
-                        <Link to= { `/actions/${sevNames[i].toLowerCase()}` }>
+                        <Link to= { `/actions/${sevNames[i].toLowerCase()}-risk` }>
                             { children }
                         </Link>
                     }>

--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -136,6 +136,11 @@ class ViewActions extends Component {
         });
     }
 
+    parseUrlTitle(title = '') {
+        const parsedTitle = title.split('-');
+        return parsedTitle.length > 1 ? `${parsedTitle[0]} ${parsedTitle[1]} Actions` : `${parsedTitle}`;
+    }
+
     render() {
         const rows = this.limitRows();
         return (
@@ -143,7 +148,7 @@ class ViewActions extends Component {
                 <PageHeader>
                     <PageHeaderTitle
                         className='actions__view--title'
-                        title={ `${this.props.match.params.type} Risk Actions` }
+                        title={ this.parseUrlTitle(this.props.match.params.type) }
                     />
                 </PageHeader>
                 <Main>


### PR DESCRIPTION
fixes RHIADVISOR-196

### looks like
<img width="1299" alt="screen shot 2018-09-18 at 11 30 42 am" src="https://user-images.githubusercontent.com/6640236/45698593-6318d500-bb36-11e8-8aba-975f10a24759.png">
<img width="1297" alt="screen shot 2018-09-18 at 11 30 29 am" src="https://user-images.githubusercontent.com/6640236/45698594-6318d500-bb36-11e8-8cbc-ccae9b1b3cf1.png">


unlike the beta tho,` https://foo.com/morefoo/actions/` will just redirect you home to advisor so we don't so much need to worry about the titleless case (though, just in case 's set to an empty string)