### PR TITLE
Adding widget attributes

### DIFF
--- a/src/PresentationalComponents/RulesCard/RulesCard.js
+++ b/src/PresentationalComponents/RulesCard/RulesCard.js
@@ -48,7 +48,7 @@ const RulesCard =
     }
 
     return (
-        <Card { ...props } className = { rulesCardClasses }>
+        <Card { ...props } className = { rulesCardClasses } widget-type='InsightsRulesCard'>
             <CardHeader>
                 <Split>
                     <SplitItem> { category } &gt; </SplitItem>

--- a/src/PresentationalComponents/RulesCard/RulesCard.js
+++ b/src/PresentationalComponents/RulesCard/RulesCard.js
@@ -48,7 +48,7 @@ const RulesCard =
     }
 
     return (
-        <Card { ...props } className = { rulesCardClasses } widget-type='InsightsRulesCard'>
+        <Card { ...props } className = { rulesCardClasses }>
             <CardHeader>
                 <Split>
                     <SplitItem> { category } &gt; </SplitItem>

--- a/src/PresentationalComponents/Skeletons/RulesCard/RulesCardSkeleton.js
+++ b/src/PresentationalComponents/Skeletons/RulesCard/RulesCardSkeleton.js
@@ -32,7 +32,7 @@ export default function RulesCardSkeleton(importComponent) {
             const C = this.state.component;
 
             return C ? <C { ...this.props } /> :
-                <Card className='ins-c-rules-card ins-c-card__skeleton' widget-type='InsightsRulesCardSkeleton'>
+                <Card className='ins-c-rules-card ins-c-card__skeleton'>
                     <CardHeader>
                         <div className='skeleton skeleton-md'>&nbsp;</div>
                     </CardHeader>

--- a/src/PresentationalComponents/Skeletons/RulesCard/RulesCardSkeleton.js
+++ b/src/PresentationalComponents/Skeletons/RulesCard/RulesCardSkeleton.js
@@ -32,7 +32,7 @@ export default function RulesCardSkeleton(importComponent) {
             const C = this.state.component;
 
             return C ? <C { ...this.props } /> :
-                <Card className='ins-c-rules-card ins-c-card__skeleton'>
+                <Card className='ins-c-rules-card ins-c-card__skeleton' widget-type='InsightsRulesCardSkeleton'>
                     <CardHeader>
                         <div className='skeleton skeleton-md'>&nbsp;</div>
                     </CardHeader>

--- a/src/PresentationalComponents/SummaryChart/SummaryChart.js
+++ b/src/PresentationalComponents/SummaryChart/SummaryChart.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const SummaryChart = (props) => {
     return (
-        <div className='summary-chart'>
+        <div className='summary-chart' widget-type='InsightsSummaryChart'>
             <ul> { props.children } </ul>
         </div>
     );

--- a/src/PresentationalComponents/SummaryChartItem/SummaryChartItem.js
+++ b/src/PresentationalComponents/SummaryChartItem/SummaryChartItem.js
@@ -10,7 +10,7 @@ const SummaryChartItem = (props) => {
     let barWidth = { width: percentage + '%' };
 
     return (
-        <li>
+        <li widget-type='InsightsSummaryChartItem'>
             { numIssues > 0 &&
             <React.Fragment>
                 <div className='metrics'>

--- a/src/PresentationalComponents/SummaryChartItem/SummaryChartItem.js
+++ b/src/PresentationalComponents/SummaryChartItem/SummaryChartItem.js
@@ -10,7 +10,7 @@ const SummaryChartItem = (props) => {
     let barWidth = { width: percentage + '%' };
 
     return (
-        <li widget-type={ `InsightsSummaryChartItem-${props.name}` }>
+        <li widget-type='InsightsSummaryChartItem' widget-id={ props.name }>
             { numIssues > 0 &&
             <React.Fragment>
                 <div className='metrics'>

--- a/src/PresentationalComponents/SummaryChartItem/SummaryChartItem.js
+++ b/src/PresentationalComponents/SummaryChartItem/SummaryChartItem.js
@@ -10,7 +10,7 @@ const SummaryChartItem = (props) => {
     let barWidth = { width: percentage + '%' };
 
     return (
-        <li widget-type='InsightsSummaryChartItem'>
+        <li widget-type={ `InsightsSummaryChartItem-${props.name}` }>
             { numIssues > 0 &&
             <React.Fragment>
                 <div className='metrics'>

--- a/src/SmartComponents/Rules/ListRules.js
+++ b/src/SmartComponents/Rules/ListRules.js
@@ -33,6 +33,7 @@ class ListRules extends React.Component {
                 cards.push(
                     <RulesCard
                         key = { i }
+                        widget-type= { `InsightsRulesCard-${i}` }
                         ruleID = { response.rules[i].rule_id }
                         category= { response.rules[i].category }
                         description= { response.rules[i].description }

--- a/src/SmartComponents/Rules/ListRules.js
+++ b/src/SmartComponents/Rules/ListRules.js
@@ -33,7 +33,7 @@ class ListRules extends React.Component {
                 cards.push(
                     <RulesCard
                         key = { i }
-                        widget-type= { `InsightsRulesCard-${i}` }
+                        widget-id= { i }
                         ruleID = { response.rules[i].rule_id }
                         category= { response.rules[i].category }
                         description= { response.rules[i].description }


### PR DESCRIPTION
QE wants us to add `widget-type='InsightsFoo'` to any presentational components on the top level tag. This way they can use their DOM scanner appropriately. 

If there are multiple instances of the same widget on a page, there needs to be a separate `widget-id` that can identify it.

These only need to be applies to Insights specific components. Patternfly is doing the same thing. I will also be updating the component library to follow the same pattern.