### PR TITLE
Imports ReducerRegistry from insights-frontend-component, fixes devtools

### DIFF
--- a/src/Store/index.js
+++ b/src/Store/index.js
@@ -1,8 +1,42 @@
-import ReducerRegistry from '@red-hat-insights/insights-frontend-components/Utilities/ReducerRegistry';
+import { applyMiddleware, combineReducers, createStore, compose } from 'redux';
 import promiseMiddleware from 'redux-promise-middleware';
 import { AdvisorStore } from '../AppReducer';
 
 let registry;
+
+class ReducerRegistry {
+    constructor(initState = {}, middlewares = [], composeEnhancersDefault = compose) {
+        const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || composeEnhancersDefault;
+        this.store = createStore(
+            (state = initState) => state,
+            initState,
+            composeEnhancers(applyMiddleware(...middlewares))
+        );
+        this.reducers = {};
+    }
+
+    on(event, callback) {
+        this.listenerMiddleware.addNew({ on: event, callback });
+    }
+
+    getListenerMiddleware() {
+        return this.listenerMiddleware;
+    }
+
+    getStore() {
+        return this.store;
+    }
+
+    /**
+     * Adds new reducers to the store
+     *
+     * @param newReducers the object of new reducers.
+     */
+    register(newReducers) {
+        this.reducers = { ...this.reducers, ...newReducers };
+        this.store.replaceReducer(combineReducers({ ...this.reducers }));
+    }
+}
 
 export function init (...middleware) {
     if (registry) {


### PR DESCRIPTION
Its a bummer not being able to use redux-devtools so till a day comes when a solution can be found whilst importing this class, gonna copy n paste it here (cuz this works) https://github.com/RedHatInsights/insights-frontend-components/blob/master/src/Utilities/ReducerRegistry.js#L25

### see, look, they work now
<img width="1133" alt="screen shot 2018-10-01 at 4 41 46 pm" src="https://user-images.githubusercontent.com/6640236/46314772-7a75aa80-c599-11e8-8822-9205a586a4de.png">
