### PR TITLE
Adds api support to listactions component

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,6 +8,7 @@
     "@babel/plugin-transform-runtime",
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-proposal-object-rest-spread",
-    "lodash"
+    "lodash",
+    ["@babel/plugin-proposal-decorators", { "legacy": true }]
   ]
 }

--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ docker run -v $PWD/config:/config --rm --net='host' -p1337:1337 -e PLATFORM=linu
 ## Build app
 1. ```npm install```
 
-2. ```npm run start```
+2. ```npm start```
     - starts webpack bundler and serves the files with webpack dev server
+    
+## Notes for Devs..   
+In order to consume the latest n greatest api work be sure to start your server with the flag `IS_DEV=true`.
+so instead of `npm start` you would run `IS_DEV=true npm start`
 
 ### Testing
 - Travis is used to test the build for this code.

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -1,5 +1,5 @@
 /* global exports */
-const openShiftAppsHost = `https://access.redhat.com/r/insights/platform/advisor/v1`;
+const openShiftAppsHost = `https://advisor-api-advisor-ci.5a9f.insights-dev.openshiftapps.com/v1`;
 
 exports.routes = {
     '/rule/': { host: openShiftAppsHost },

--- a/package-lock.json
+++ b/package-lock.json
@@ -580,6 +580,18 @@
         "@babel/plugin-syntax-async-generators": "^7.0.0"
       }
     },
+    "@babel/plugin-proposal-decorators": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.1.2.tgz",
+      "integrity": "sha512-YooynBO6PmBgHvAd0fl5e5Tq/a0pEC6RqF62ouafme8FzdIVH41Mz/u1dn8fFVm4jzEJ+g/MsOxouwybJPuP8Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/plugin-syntax-decorators": "^7.1.0"
+      }
+    },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz",
@@ -662,6 +674,15 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz",
       "integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-decorators": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.1.0.tgz",
+      "integrity": "sha512-uQvRSbgQ0nQg3jsmIixXXDCgSpkBolJ9X7NYThMKCcjvE8dN2uWJUzTUNNAeuKOjARTd+wUQV0ztXpgunZYKzQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.1.2",
+    "@babel/plugin-proposal-decorators": "^7.1.2",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0",
     "@babel/plugin-syntax-dynamic-import": "7.0.0",
     "@babel/plugin-transform-runtime": "7.1.0",

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,6 @@ import { routerParams } from '@red-hat-insights/insights-frontend-components';
 import { connect } from 'react-redux';
 import { Routes } from './Routes';
 import './App.scss';
-import * as AppActions from './AppActions';
 
 class App extends Component {
     componentDidMount () {
@@ -14,9 +13,6 @@ class App extends Component {
 
         this.appNav = insights.chrome.on('APP_NAVIGATION', event => this.props.history.push(`/${event.navId}`));
         this.buildNav = this.props.history.listen(() => insights.chrome.navigation(buildNavigation()));
-
-        this.props.fetchImpactedSystems();
-        this.props.fetchMediumRiskRules();
     }
 
     componentWillUnmount () {
@@ -26,25 +22,18 @@ class App extends Component {
 
     render () {
         return (
-            <Routes childProps={ this.props } />
+            <Routes childProps={ this.props }/>
         );
     }
 }
 
 App.propTypes = {
-    history: PropTypes.object,
-    fetchImpactedSystems: PropTypes.func,
-    fetchMediumRiskRules: PropTypes.func
+    history: PropTypes.object
 };
-
-const mapDispatchToProps = dispatch => ({
-    fetchImpactedSystems: () => dispatch(AppActions.fetchImpactedSystems()),
-    fetchMediumRiskRules: () => dispatch(AppActions.fetchMediumRiskRules())
-});
 
 export default routerParams(connect(
     null,
-    mapDispatchToProps
+    null
 )(App));
 
 function buildNavigation () {

--- a/src/AppActions.js
+++ b/src/AppActions.js
@@ -39,6 +39,16 @@ export const fetchRules = (options) => ({
         .catch(e => reject(e));
     })
 });
+export const fetchRule = (options) => ({
+    type: ActionTypes.RULE_FETCH,
+    payload: new Promise((resolve, reject) => {
+        API.get(`${ActionTypes.RULES_FETCH_URL}${options.rule_id}/`)
+        .then(response => {
+            resolve(response.data);
+        })
+        .catch(e => reject(e));
+    })
+});
 export const setBreadcrumbs = (breadcrumbObj) => ({
     type: ActionTypes.BREADCRUMBS_SET,
     payload: breadcrumbObj

--- a/src/AppActions.js
+++ b/src/AppActions.js
@@ -1,24 +1,6 @@
 import * as ActionTypes from './AppConstants';
 import API from './Utilities/Api';
 
-import impactedSystemsData from '../mockData/actions-types-ids_impacted-systems';
-import mediumRiskRulesData from '../mockData/medium-risk';
-
-const impactedSystems = () => JSON.parse(JSON.stringify(impactedSystemsData));
-const mediumRiskRules = () => JSON.parse(JSON.stringify(mediumRiskRulesData));
-
-export const fetchImpactedSystems = ()  => ({
-    type: ActionTypes.IMPACTED_SYSTEMS_FETCH,
-    payload: new Promise(resolve => {
-        resolve(impactedSystems);
-    })
-});
-export const fetchMediumRiskRules = ()  => ({
-    type: ActionTypes.MEDIUM_RISK_RULES_FETCH,
-    payload: new Promise(resolve => {
-        resolve(mediumRiskRules);
-    })
-});
 export const fetchStats = () => ({
     type: ActionTypes.STATS_FETCH,
     payload: new Promise((resolve, reject) => {

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -1,3 +1,4 @@
+export const RULE_FETCH = 'RULE_FETCH';
 export const RULES_FETCH = 'RULES_FETCH';
 export const SYSTEM_FETCH = 'SYSTEM_FETCH';
 export const SYSTEMTYPE_FETCH = 'SYSTEMTYPE_FETCH';
@@ -6,7 +7,7 @@ export const IMPACTED_SYSTEMS_FETCH = 'IMPACTED_SYSTEMS_FETCH';
 export const STATS_FETCH = 'STATS_FETCH';
 export const BREADCRUMBS_SET = 'BREADCRUMBS_SET';
 
-export const BASE_URL = '/r/insights/platform/advisor/v1';
+const BASE_URL = process.env.IS_DEV ? '/r/insights/platform/advisor/v1' : '';
 export const RULES_FETCH_URL = `${BASE_URL}/rule/`;
 export const STATS_FETCH_URL = `${BASE_URL}/stats/`;
 export const SYSTEM_FETCH_URL = `${BASE_URL}/system/`;

--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -7,6 +7,8 @@ const initialState = Immutable({
     mediumRiskRulesFetchStatus: '',
     impactedSystems: [],
     impactedSystemsFetchStatus: '',
+    rule: {},
+    ruleFetchStatus: '',
     rules: {},
     rulesFetchStatus: '',
     stats: {},
@@ -20,7 +22,7 @@ const initialState = Immutable({
 
 export const AdvisorStore = (state = initialState, action) => {
     switch (action.type) {
-
+        //The following two case blocks and constants will be removed when we no longer use mock jsons
         case `${ActionTypes.MEDIUM_RISK_RULES_FETCH}_PENDING`:
             return state.set('mediumRiskRulesFetchStatus', 'pending');
         case `${ActionTypes.MEDIUM_RISK_RULES_FETCH}_FULFILLED`:
@@ -38,6 +40,15 @@ export const AdvisorStore = (state = initialState, action) => {
                 impactedSystemsFetchStatus: 'fulfilled' });
         case `${ActionTypes.IMPACTED_SYSTEMS_FETCH}_REJECTED`:
             return state.set('impactedSystemsFetchStatus', 'rejected');
+
+        case `${ActionTypes.RULE_FETCH}_PENDING`:
+            return state.set('ruleFetchStatus', 'pending');
+        case `${ActionTypes.RULE_FETCH}_FULFILLED`:
+            return Immutable.merge(state, {
+                rule: action.payload,
+                ruleFetchStatus: 'fulfilled' });
+        case `${ActionTypes.RULE_FETCH}_REJECTED`:
+            return state.set('ruleFetchStatus', 'rejected');
 
         case `${ActionTypes.RULES_FETCH}_PENDING`:
             return state.set('rulesFetchStatus', 'pending');

--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -3,10 +3,6 @@ import * as ActionTypes from './AppConstants';
 
 // eslint-disable-next-line new-cap
 const initialState = Immutable({
-    mediumRiskRules: {},
-    mediumRiskRulesFetchStatus: '',
-    impactedSystems: [],
-    impactedSystemsFetchStatus: '',
     rule: {},
     ruleFetchStatus: '',
     rules: {},
@@ -22,25 +18,6 @@ const initialState = Immutable({
 
 export const AdvisorStore = (state = initialState, action) => {
     switch (action.type) {
-        //The following two case blocks and constants will be removed when we no longer use mock jsons
-        case `${ActionTypes.MEDIUM_RISK_RULES_FETCH}_PENDING`:
-            return state.set('mediumRiskRulesFetchStatus', 'pending');
-        case `${ActionTypes.MEDIUM_RISK_RULES_FETCH}_FULFILLED`:
-            return Immutable.merge(state, {
-                mediumRiskRules: action.payload,
-                mediumRiskRulesFetchStatus: 'fulfilled' });
-        case `${ActionTypes.MEDIUM_RISK_RULES_FETCH}_REJECTED`:
-            return state.set('mediumRiskRulesFetchStatus', 'rejected');
-
-        case `${ActionTypes.IMPACTED_SYSTEMS_FETCH}_PENDING`:
-            return state.set('impactedSystemsFetchStatus', 'pending');
-        case `${ActionTypes.IMPACTED_SYSTEMS_FETCH}_FULFILLED`:
-            return Immutable.merge(state, {
-                impactedSystems: action.payload.resources,
-                impactedSystemsFetchStatus: 'fulfilled' });
-        case `${ActionTypes.IMPACTED_SYSTEMS_FETCH}_REJECTED`:
-            return state.set('impactedSystemsFetchStatus', 'rejected');
-
         case `${ActionTypes.RULE_FETCH}_PENDING`:
             return state.set('ruleFetchStatus', 'pending');
         case `${ActionTypes.RULE_FETCH}_FULFILLED`:

--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import * as reactRouterDom from 'react-router-dom';
+import * as reactCore from '@patternfly/react-core';
+import * as reactIcons from '@patternfly/react-icons';
+import { registry } from '@red-hat-insights/insights-frontend-components';
+import Loading from '../../PresentationalComponents/Loading/Loading';
+
+@registry()
+class Inventory extends React.Component {
+    constructor (props) {
+        super(props);
+        this.state = {
+            Inventory: () => <Loading/>
+        };
+
+        this.fetchInventory = this.fetchInventory.bind(this);
+        this.fetchInventory();
+    }
+
+    async fetchInventory () {
+        const { inventoryConnector, mergeWithEntities, mergeWithDetail } = await window.insights.loadInventory({
+            react: React,
+            reactRouterDom,
+            reactCore,
+            reactIcons
+        });
+
+        this.getRegistry().register({
+            ...mergeWithEntities(),
+            ...mergeWithDetail()
+        });
+
+        this.setState({
+            Inventory: inventoryConnector()
+        });
+    }
+
+    render () {
+        const { Inventory } = this.state;
+        return (
+            <Inventory/>
+        );
+    }
+}
+
+export default Inventory;

--- a/src/PresentationalComponents/RulesCard/RulesCard.js
+++ b/src/PresentationalComponents/RulesCard/RulesCard.js
@@ -54,7 +54,7 @@ const RulesCard =
             <CardFooter>
                 <div className='space-between'>
                     <Section type='icon-group__with-major'>
-                        <Battery label='Impact' severity={ impact.impact }/>
+                        <Battery label='Impact' severity={ impact }/>
                         <Battery label='Likelihood' severity={ likelihood }/>
                         <Battery label='Total Risk' severity={ totalRisk }/>
                         <Battery label='Risk Of Change' severity={ riskOfChange }/>

--- a/src/SmartComponents/Actions/Actions.js
+++ b/src/SmartComponents/Actions/Actions.js
@@ -12,7 +12,7 @@ const Actions = () => {
         <Switch>
             <Route exact path='/actions' component={ ActionsOverview } />
             <Route exact path='/actions/:type' component={ ViewActions }/>
-            <Route exact path='/actions/:type/:id' component={ ListActions }/>
+            <Route path='/actions/:type/:id' component={ ListActions }/>
         </Switch>
     );
 };

--- a/src/SmartComponents/Actions/ActionsOverview.js
+++ b/src/SmartComponents/Actions/ActionsOverview.js
@@ -83,14 +83,12 @@ class ActionsOverview extends Component {
                         <GridItem>
                             <Card className='pf-t-light  pf-m-opaque-100'>
                                 <CardHeader>Category Summary</CardHeader>
-
                                 <CardBody>
                                     { statsFetchStatus === 'fulfilled' && (
                                         renderDonut(donutValues)
                                     ) }
                                     { statsFetchStatus === 'pending' && (<Loading/>) }
                                 </CardBody>
-
                             </Card>
                         </GridItem>
                         <GridItem>

--- a/src/SmartComponents/Actions/ListActions.js
+++ b/src/SmartComponents/Actions/ListActions.js
@@ -4,9 +4,11 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
 import { buildBreadcrumbs, onNavigate, parseBreadcrumbs } from '../../Helpers/breadcrumbs.js';
-import './_actions.scss';
+
 import * as AppActions from '../../AppActions';
 import Loading from '../../PresentationalComponents/Loading/Loading';
+import Inventory from '../../PresentationalComponents/Inventory/Inventory';
+import './_actions.scss';
 
 class ListActions extends Component {
     componentDidMount () {

--- a/src/SmartComponents/Actions/ListActions.js
+++ b/src/SmartComponents/Actions/ListActions.js
@@ -1,169 +1,25 @@
 import React, { Component } from 'react';
-import { routerParams } from '@red-hat-insights/insights-frontend-components';
+import { Ansible, Battery, Breadcrumbs, Main, PageHeader, PageHeaderTitle, routerParams } from '@red-hat-insights/insights-frontend-components';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-
-import {
-    Ansible,
-    Battery,
-    Breadcrumbs,
-    Main,
-    Pagination,
-    SimpleTableFilter,
-    SortDirection,
-    Table,
-    PageHeader,
-    PageHeaderTitle
-} from '@red-hat-insights/insights-frontend-components';
-import {
-    Grid,
-    GridItem,
-    Stack,
-    StackItem
-} from '@patternfly/react-core';
-import { sortBy } from 'lodash';
-import TimeAgo from 'react-timeago';
-import { onNavigate, parseBreadcrumbs, buildBreadcrumbs } from '../../Helpers/breadcrumbs.js';
+import { Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
+import { buildBreadcrumbs, onNavigate, parseBreadcrumbs } from '../../Helpers/breadcrumbs.js';
 import './_actions.scss';
+import * as AppActions from '../../AppActions';
+import Loading from '../../PresentationalComponents/Loading/Loading';
 
 class ListActions extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            cols: [ 'Type', 'Name', 'Reported' ],
-            unfilteredRows: [],
-            rows: [],
-            rule: {
-                description: ''
-            },
-            sortBy: {},
-            itemsPerPage: 10,
-            page: 1
-        };
-        this.onSortChange = this.onSortChange.bind(this);
-        this.toggleCol = this.toggleCol.bind(this);
-        this.limitRows = this.limitRows.bind(this);
-        this.setPage = this.setPage.bind(this);
-        this.setPerPage = this.setPerPage.bind(this);
-        this.parseProductCode = this.parseProductCode.bind(this);
-        this.onSearch = this.onSearch.bind(this);
+    componentDidMount () {
+        this.props.fetchRule({ rule_id: this.props.match.params.id }); // eslint-disable-line camelcase
     }
 
-    componentDidMount() {
-        const response = this.props.AdvisorStore.mediumRiskRules;
-        document.getElementById('root').classList.add('actions__list');
-
-        let rule = response.rules.find(obj => {
-            return obj.rule_id === this.props.match.params.id;
-        });
-        this.setState({ rule });
-
-        const response2 = this.props.AdvisorStore.impactedSystems;
-        let rows = [];
-        for (let i = 0;i < response2.length;i++) {
-            rows.push(
-                { cells: [
-                    this.parseProductCode(response2[i].product_code),
-                    (response2[i].hostname === '' ? response2[i].system_id : response2[i].hostname),
-                    <TimeAgo key={ i } date={ response2[i].created_at } />
-                ]}
-            );
-        }
-
-        this.setState({ unfilteredRows: rows });
-        this.setState({ rows });
-    }
-
-    componentDidUnMount() {
-        document.getElementById('root').classList.remove('actions__list');
-    }
-
-    onSearch(value) {
-        const lowerCaseValue = value.toLowerCase();
-        const rows = this.state.unfilteredRows.filter(row =>  row.cells[0].toLowerCase().indexOf(lowerCaseValue) !== -1 ||
-                                                              row.cells[1].toLowerCase().indexOf(lowerCaseValue) !== -1);
-        this.setState({
-            ...this.state,
-            rows
-        });
-    }
-
-    parseProductCode(productCode) {
-        let productName = '';
-        switch (productCode) {
-            case 'rhel':
-                productName = 'RHEL Server';
-                break;
-            default:
-                productName = 'Undefined';
-        }
-
-        return productName;
-    }
-
-    toggleCol(_event, key, selected) {
-        let { rows, page, itemsPerPage } = this.state;
-        const firstIndex = page === 1 ? 0 : page * itemsPerPage - itemsPerPage;
-        rows[firstIndex + key].selected = selected;
-        this.setState({
-            ...this.state,
-            rows
-        });
-    }
-
-    onSortChange(_event, key, direction) {
-        const sortedRows = sortBy(this.state.rows, [ e => e.cells[key] ]);
-        this.setState({
-            ...this.state,
-            rows: SortDirection.up === direction ? sortedRows : sortedRows.reverse(),
-            sortBy: {
-                index: key,
-                direction
-            }
-        });
-    }
-
-    limitRows() {
-        const { page, itemsPerPage } = this.state;
-        const numberOfItems = this.state.rows.length;
-        const lastPage = Math.ceil(numberOfItems / itemsPerPage);
-        const lastIndex = page === lastPage ? numberOfItems : page * itemsPerPage;
-        const firstIndex = page === 1 ? 0 : page * itemsPerPage - itemsPerPage;
-
-        switch (this.state.rows.length === 0) {
-            case true:
-                this.setState({
-                    ...this.state,
-                    rows: [{ cells: [ 'No Results' ]}]
-                });
-                break;
-            default:
-                return this.state.rows.slice(firstIndex, lastIndex);
-        }
-    }
-
-    setPage(page) {
-        this.setState({
-            ...this.state,
-            page
-        });
-    }
-
-    setPerPage(amount) {
-        this.setState({
-            ...this.state,
-            itemsPerPage: amount
-        });
-    }
-
-    render() {
-        const { breadcrumbs } = this.props;
-        const rows = this.limitRows();
+    render () {
+        const { breadcrumbs, ruleFetchStatus, rule } = this.props;
 
         return (
             <React.Fragment>
                 <Breadcrumbs
-                    current={ this.state.rule.description }
+                    current={ rule.description || '' }
                     items={
                         breadcrumbs[0] !== undefined ?
                             parseBreadcrumbs(breadcrumbs, this.props.match.params, 2) :
@@ -172,56 +28,41 @@ class ListActions extends Component {
                     onNavigate={ onNavigate }
                 />
                 <PageHeader>
-                    <PageHeaderTitle title={ this.state.rule.description }/>
+                    <PageHeaderTitle title={ rule.description || '' }/>
                 </PageHeader>
                 <Main className='actions__list'>
-                    <Stack gutter='md'>
-                        <StackItem>
-                            <Grid gutter='md'>
-                                <GridItem md={ 8 } sm={ 12 }>
-                                    <div className='actions__description' dangerouslySetInnerHTML={ { __html: this.state.rule.summary_html } }/>
-                                </GridItem>
-                                <GridItem md={ 4 } sm={ 12 }>
-                                    <Grid gutter='sm' className='actions__detail'>
-                                        <GridItem sm={ 12 } md={ 12 }> <Ansible unsupported = { this.state.rule.ansible }/> </GridItem>
-                                        <GridItem sm={ 8 } md={ 12 }>
-                                            <Grid className='ins-l-icon-group__vertical' sm={ 4 } md={ 12 }>
-                                                <GridItem> <Battery label='Impact' severity={ this.state.rule.impact.impact }/> </GridItem>
-                                                <GridItem> <Battery label='Likelihood' severity={ this.state.rule.likelihood }/> </GridItem>
-                                                <GridItem> <Battery label='Total Risk' severity={ this.state.rule.severity }/> </GridItem>
+                    <React.Fragment>
+                        { ruleFetchStatus === 'fulfilled' && (
+                            <Stack gutter='md'>
+                                <StackItem>
+                                    <Grid gutter='md'>
+                                        <GridItem md={ 8 } sm={ 12 }>
+                                            <div className='actions__description' dangerouslySetInnerHTML={ { __html: rule.summary_html } }/>
+                                        </GridItem>
+                                        <GridItem md={ 4 } sm={ 12 }>
+                                            <Grid gutter='sm' className='actions__detail'>
+                                                <GridItem sm={ 12 } md={ 12 }> <Ansible unsupported={ rule.ansible }/> </GridItem>
+                                                <GridItem sm={ 8 } md={ 12 }>
+                                                    <Grid className='ins-l-icon-group__vertical' sm={ 4 } md={ 12 }>
+                                                        <GridItem> <Battery label='Impact' severity={ rule.impact.impact }/> </GridItem>
+                                                        <GridItem> <Battery label='Likelihood' severity={ rule.likelihood }/> </GridItem>
+                                                        <GridItem> <Battery label='Total Risk' severity={ rule.severity }/> </GridItem>
+                                                    </Grid>
+                                                </GridItem>
+                                                <GridItem sm={ 4 } md={ 12 }>
+                                                    <Battery label='Risk Of Change' severity={ rule.resolution_risk  }/>
+                                                </GridItem>
                                             </Grid>
                                         </GridItem>
-                                        <GridItem sm={ 4 } md={ 12 }>
-                                            <Battery label='Risk Of Change' severity={ this.state.rule.resolution_risk }/>
-                                        </GridItem>
                                     </Grid>
-                                </GridItem>
-                            </Grid>
-                        </StackItem>
-                        <StackItem>
-                            <SimpleTableFilter onFilterChange={ this.onSearch } placeholder='Find a system' buttonTitle='Search' />
-                        </StackItem>
-                        <StackItem>
-                            <Table
-                                className='impacted-systems-table'
-                                onItemSelect={ this.toggleCol }
-                                hasCheckbox={ true }
-                                header={ this.state.cols }
-                                sortBy={ this.state.sortBy }
-                                rows={ rows }
-                                onSort={ this.onSortChange }
-                                footer={
-                                    <Pagination
-                                        numberOfItems={ this.state.rows.length }
-                                        onPerPageSelect={ this.setPerPage }
-                                        page={ this.state.page }
-                                        onSetPage={ this.setPage }
-                                        itemsPerPage={ this.state.itemsPerPage }
-                                    />
-                                }
-                            />
-                        </StackItem>
-                    </Stack>
+                                </StackItem>
+                                <StackItem>
+                                    <Inventory/>
+                                </StackItem>
+                            </Stack>
+                        ) }
+                        { ruleFetchStatus === 'pending' && (<Loading/>) }
+                    </React.Fragment>
                 </Main>
             </React.Fragment>
         );
@@ -231,18 +72,24 @@ class ListActions extends Component {
 ListActions.propTypes = {
     breadcrumbs: PropTypes.array,
     match: PropTypes.any,
-    AdvisorStore: PropTypes.object
+    fetchRule: PropTypes.func,
+    ruleFetchStatus: PropTypes.string,
+    rule: PropTypes.object
 };
 
 const mapStateToProps = (state, ownProps) => ({
+    rule: state.AdvisorStore.rule,
+    ruleFetchStatus: state.AdvisorStore.ruleFetchStatus,
     breadcrumbs: state.AdvisorStore.breadcrumbs,
     ...state,
     ...ownProps
 });
 
-export default routerParams(
-    connect(
-        mapStateToProps
-    )(ListActions)
-);
+const mapDispatchToProps = dispatch => ({
+    fetchRule: (url) => dispatch(AppActions.fetchRule(url))
+});
 
+export default routerParams(connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(ListActions));

--- a/src/SmartComponents/Rules/ListRules.js
+++ b/src/SmartComponents/Rules/ListRules.js
@@ -72,19 +72,22 @@ class ListRules extends React.Component {
 
         return (
             <Main>
-                { rulesFetchStatus === 'fulfilled' && (
-                    <React.Fragment>
-                        { this.state.cards }
-                        <Pagination
-                            numberOfItems={ rules.count }
-                            onPerPageSelect={ this.setPerPage }
-                            page={ this.state.page }
-                            onSetPage={ this.setPage }
-                            itemsPerPage={ this.state.itemsPerPage }
-                        />
-                    </React.Fragment>
-                ) }
-                { rulesFetchStatus === 'pending' && (<Loading />) }
+                <React.Fragment>
+                    { rulesFetchStatus === 'fulfilled' && (
+                        <React.Fragment>
+                            { this.state.cards }
+                            <Pagination
+                                numberOfItems={ rules.count }
+                                onPerPageSelect={ this.setPerPage }
+                                page={ this.state.page }
+                                onSetPage={ this.setPage }
+                                itemsPerPage={ this.state.itemsPerPage }
+                            />
+                        </React.Fragment>
+                    ) }
+                    { rulesFetchStatus === 'pending' && (<Loading />) }
+                </React.Fragment>
+
             </Main>
         );
 


### PR DESCRIPTION
we need 
* ~~https://github.com/RedHatInsights/insights-advisor-api/issues/92~~ https://github.com/RedHatInsights/insights-advisor-api/pull/106
* ~~RHIADVISOR-216 Return system list for a given rule~~ https://github.com/RedHatInsights/insights-advisor-api/pull/107
* we also need this https://ansible.slack.com/archives/CADT032B0/p1539553048000200 which is a 

> For an individual rule, we can include a list of system UUIDs that are affected by that rule.  That's not too difficult, it's a query on the reports.


* ~~consume https://github.com/RedHatInsights/insights-frontend-components/tree/master/src/SmartComponents/Inventory to display affected systems~~
* ~~and we need https://github.com/RedHatInsights/insights-frontend-components/pull/139/ https://github.com/RedHatInsights/insights-chrome/pull/56~~




before this can be donnnnnneeeeeee 🍷🏓

## Updates!

So a few notes about this, gonna unwip cuz there's notta lot left for us to do but wait and this is far enough along to stop waiting for it...

all rules will have an impacted systems of 0 (cuz our mock data doesn't have anything in there) to view a specific rule yer gonna wanta change https://github.com/RedHatInsights/insights-advisor-frontend/blob/ee7f811dcb7d50cdce36f8e514c87b1fa0a7df7e/src/SmartComponents/Rules/ListRules.js#L49 to some value...

once in there, you'll notice the impacted systems data is a lil mocky, again, that'll change once that whole thing comes online, we do still need the thing above, https://ansible.slack.com/archives/CADT032B0/p1539553048000200, but again, that'll be a simple drop in once its avaliable