### PR TITLE
Use router params and set redux registry from frontend component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1505,7 +1505,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "requires": {
         "ansi-wrap": "^0.1.0"
@@ -3483,7 +3483,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -3520,7 +3520,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -3573,7 +3573,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -4419,7 +4419,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -4432,7 +4432,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -5251,7 +5251,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -6058,7 +6058,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
@@ -7706,7 +7706,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -11961,7 +11961,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -12029,7 +12029,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
@@ -13006,7 +13006,7 @@
     },
     "public-encrypt": {
       "version": "4.0.2",
-      "resolved": "http://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "dev": true,
       "requires": {
@@ -14432,7 +14432,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -714,25 +714,25 @@
       "integrity": "sha512-3H6cgNbp6jXkM9bX7vkl4iY6tLxMG5G33SQFlQxv2oZ81+1eBehdqYqOLIk8AbC/cmKqZ2Y/hf9k1DgLI2Nu0g=="
     },
     "@patternfly/react-core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-1.14.0.tgz",
-      "integrity": "sha512-9nN4fh3zuQWQkuC6ssdigTse7dD5OQZSt6qsxsD5k9vp2aTtAgy0mL9Qr2j0Nvr/E1Ze9s8XtIeabf61g62bgg==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-1.19.1.tgz",
+      "integrity": "sha512-e7DrOF78CF5D/hqGSCbOqC/Txxqu6OD2z8xDhjcl9JlNVIyIPdLKp4ksRMQ0vKj+ctQtAfWgsfTbduRCyo5L2g==",
       "requires": {
-        "@patternfly/react-icons": "^2.0.0",
-        "@patternfly/react-styles": "^2.0.0",
+        "@patternfly/react-icons": "^2.5.0",
+        "@patternfly/react-styles": "^2.2.0",
         "@patternfly/react-tokens": "^1.0.0",
         "exenv": "^1.2.2"
       }
     },
     "@patternfly/react-icons": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-2.4.0.tgz",
-      "integrity": "sha512-7ezE1MrB3suuxpU0mP8Ye52p/ScLVCEwag1Ops9pAtZwyXR8dsv2Xsj/wM1RUUtKmNymiHkUSxYmvB1CCzZ96w=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-2.5.0.tgz",
+      "integrity": "sha512-A+2+hZB+WFPlug/UWCTYEB0DRCyUjgf4tXf8jcanlsUON9mHAfcdWy4CvAxCLCUQHozn4efT1QWtGCLY+iW6zA=="
     },
     "@patternfly/react-styles": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-2.1.1.tgz",
-      "integrity": "sha512-Qjm88oYue9PGHTgJMeD9a0xJSCsb4uet3/6q91SscdT6FlCHKtv7X4l+bqaBo1nZ98uNMUiV5Uoz0/Rc71JstA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-2.2.0.tgz",
+      "integrity": "sha512-qRJryLSUSoraKNHzDH9x/JG78tKf6VtmIII89i5PrrNyAX//YJXPG61j5oia7HoowB2/1f4h0JGu3+JjBVvDKg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0-beta.48",
         "camel-case": "^3.0.0",
@@ -756,17 +756,17 @@
       }
     },
     "@patternfly/react-tokens": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-1.3.0.tgz",
-      "integrity": "sha512-xam7hcUZb4mIAYJnVZYwTJR3U5GaviVz9WJ9FVIIwrJZUR4tbzRokig20RbC12TJ8MfadbiKDHl/oEErcU0QEA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-1.5.1.tgz",
+      "integrity": "sha512-qu+He+tO3p7akte0K75DDhl+8FiSXdAKyos+UBPeB1tlHUAaOfKfve1k0ehjDI9IpVajxauC23ezg35iA+wwIw==",
       "optional": true
     },
     "@red-hat-insights/insights-frontend-components": {
-      "version": "3.19.10",
-      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.19.10.tgz",
-      "integrity": "sha512-XpLb9MenEE4MUeY9X1ApiksW9eozL9b6sQ759k+yh1958BRUjTUJ9pQDGwN9KOInOoHsr8FaUFGIeKFU7m0X0Q==",
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.20.2.tgz",
+      "integrity": "sha512-V8o5tAEDUKRDkbzads9WiAOBSFEzpmd9yj5sXNQcm8/UBAnm5gP2bNQOoLPusRVg2dJvlrpwB69kWCBHaoihpg==",
       "requires": {
-        "@patternfly/react-core": "^1.11.1",
+        "@patternfly/react-core": "^1.19.1",
         "@patternfly/react-icons": "^2.4.0",
         "bootstrap-sass": "^3.3.7",
         "c3": "^0.6.7",
@@ -870,9 +870,9 @@
       }
     },
     "@types/d3-array": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.2.tgz",
-      "integrity": "sha512-juoqZ4j/ZPC52AoCjbxiNOGAXudj+69w08ln4cpQIubQfIrHNIptPVYkG6IELEY9Iw/q/PMwKLhk6HYcYk7bOA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.3.tgz",
+      "integrity": "sha512-yTO4ws1jnWC7iSKK8j7sUAGKIcJ628ioiGTdyXmPd36cNnuY9fDcjgEW2r19yXWuQFLu61/JhHVZ8RYYTEzFSg==",
       "optional": true
     },
     "@types/d3-axis": {
@@ -1505,7 +1505,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "requires": {
         "ansi-wrap": "^0.1.0"
@@ -3303,7 +3303,7 @@
     },
     "bootstrap": {
       "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+      "resolved": "http://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
       "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
     },
     "bootstrap-datepicker": {
@@ -3483,7 +3483,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -3520,7 +3520,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -3573,7 +3573,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -3613,9 +3613,9 @@
       "dev": true
     },
     "c3": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/c3/-/c3-0.6.7.tgz",
-      "integrity": "sha512-2i21UifBzBv28AQjve8lEUkqgulOk4PaVMcA+bkxAdVCiobONbf0XL1zzJNyALlUvpJqaeLGVdWSMOyFPY4oaw==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/c3/-/c3-0.6.8.tgz",
+      "integrity": "sha512-HI1cAalsnwy9FJk8cywJ9jD0eIo8lb+9Ms2btz0bHVDU4UuGRPQcTcso2tCVg+Zdh6fa5vGkHcq/rVcSPo8a9w==",
       "requires": {
         "d3": "^5.0.0"
       }
@@ -4419,7 +4419,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -4432,7 +4432,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -5251,7 +5251,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -6058,7 +6058,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
@@ -6860,7 +6860,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7325,7 +7326,8 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7389,6 +7391,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7437,13 +7440,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7706,7 +7711,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -11961,7 +11966,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -12029,7 +12034,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
@@ -12239,9 +12244,9 @@
       }
     },
     "patternfly-react": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/patternfly-react/-/patternfly-react-2.19.1.tgz",
-      "integrity": "sha512-6mwQzP9aSIxbAVkEjX3I4jCuoBK4v8/ZmlJukzvKWFM6GRjl7ewzkeimpuRAxvyJYV3uliQpH7e8cTBjcbcn4A==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/patternfly-react/-/patternfly-react-2.20.3.tgz",
+      "integrity": "sha512-xsvqLcs1/No+FIcbBTwQbZOVmYDQx5JXzgYKL1NUURXHzyW+5/PtHdM2cwXKkAQ8dtodS/C9uWKl2YncRrnA2w==",
       "requires": {
         "bootstrap-slider-without-jquery": "^10.0.0",
         "breakjs": "^1.0.0",
@@ -12355,7 +12360,7 @@
         },
         "kind-of": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
           "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
         }
       }
@@ -13006,7 +13011,7 @@
     },
     "public-encrypt": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "dev": true,
       "requires": {
@@ -14432,7 +14437,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@patternfly/patternfly-next": "^1.0.52",
-    "@patternfly/react-core": "^1.14.0",
-    "@red-hat-insights/insights-frontend-components": "^3.19.10",
+    "@patternfly/react-core": "^1.19.1",
+    "@red-hat-insights/insights-frontend-components": "^3.20.2",
     "classnames": "^2.2.5",
     "create-react-class": "^15.6.3"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { withRouter } from 'react-router-dom';
+import { routerParams } from '@red-hat-insights/insights-frontend-components';
 import { connect } from 'react-redux';
 import { Routes } from './Routes';
 import './App.scss';
@@ -42,7 +42,7 @@ const mapDispatchToProps = dispatch => ({
     fetchMediumRiskRules: () => dispatch(AppActions.fetchMediumRiskRules())
 });
 
-export default withRouter(connect(
+export default routerParams(connect(
     null,
     mapDispatchToProps
 )(App));

--- a/src/SmartComponents/Actions/Actions.js
+++ b/src/SmartComponents/Actions/Actions.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withRouter, Route, Switch } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
+import { routerParams } from '@red-hat-insights/insights-frontend-components';
 import asyncComponent from '../../Utilities/asyncComponent';
 
 const ActionsOverview = asyncComponent(() => import(/* webpackChunkName: "ActionsOverview" */ './ActionsOverview'));
@@ -16,4 +17,4 @@ const Actions = () => {
     );
 };
 
-export default withRouter(Actions);
+export default routerParams(Actions);

--- a/src/SmartComponents/Actions/ActionsOverview.js
+++ b/src/SmartComponents/Actions/ActionsOverview.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
-import { Link, withRouter } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import asyncComponent from '../../Utilities/asyncComponent';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Card, CardBody, CardHeader, Grid, GridItem } from '@patternfly/react-core';
-import { Donut, Main, PageHeader, PageHeaderTitle } from '@red-hat-insights/insights-frontend-components';
+import { Donut, Main, PageHeader, PageHeaderTitle, routerParams } from '@red-hat-insights/insights-frontend-components';
 
 import * as AppActions from '../../AppActions';
 import Loading from '../../PresentationalComponents/Loading/Loading';
@@ -124,7 +124,7 @@ const mapDispatchToProps = dispatch => ({
     fetchStats: (url) => dispatch(AppActions.fetchStats(url))
 });
 
-export default withRouter(connect(
+export default routerParams(connect(
     mapStateToProps,
     mapDispatchToProps
 )(ActionsOverview));

--- a/src/SmartComponents/Actions/ListActions.js
+++ b/src/SmartComponents/Actions/ListActions.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { withRouter } from 'react-router-dom';
+import { routerParams } from '@red-hat-insights/insights-frontend-components';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -226,7 +226,7 @@ const mapStateToProps = (state, ownProps) => ({
     ...ownProps
 });
 
-export default withRouter(
+export default routerParams(
     connect(
         mapStateToProps
     )(ListActions)

--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
-import { Link, withRouter } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { routerParams } from '@red-hat-insights/insights-frontend-components';
 import PropTypes from 'prop-types';
 import { sortBy } from 'lodash';
 import { connect } from 'react-redux';
@@ -219,7 +220,7 @@ const mapDispatchToProps = dispatch => ({
     fetchRules: (url) => dispatch(AppActions.fetchRules(url))
 });
 
-export default withRouter(connect(
+export default routerParams(connect(
     mapStateToProps,
     mapDispatchToProps
 )(ViewActions));

--- a/src/SmartComponents/Rules/ListRules.js
+++ b/src/SmartComponents/Rules/ListRules.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Main, Pagination } from '@red-hat-insights/insights-frontend-components';
+import { Main, Pagination, routerParams } from '@red-hat-insights/insights-frontend-components';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import * as AppActions from '../../AppActions';
@@ -112,7 +111,7 @@ const mapDispatchToProps = dispatch => ({
     fetchRules: (url) => dispatch(AppActions.fetchRules(url))
 });
 
-export default withRouter(connect(
+export default routerParams(connect(
     mapStateToProps,
     mapDispatchToProps
 )(ListRules));


### PR DESCRIPTION
This PR is blocked by https://github.com/RedHatInsights/insights-frontend-components/pull/116

* Use router params - QE has easier definition where they are located so they have much easier job.
* Use component's registry - this way we don't have to take care of our registry, but this can be maintained from component's registry. So any changes did to this registry will take effect in this one as well.