### PR TITLE
This header stub is no longer required for successful api interactions!😁

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ In order to consume the latest n greatest api work be to clear the [prod base ur
 
 It should read `const BASE_URL = '';`
 
-Also you are gonna have to stub the following header `x-rh-auth-identity:{ "identity": { "account_number": "1234567"}}`
+Also you are gonna have to stub the following header `x-rh-identity:{ "identity": { "account_number": "1234567"}}`
 else you'll likely get a bunch of `{"detail":"You do not have permission to perform this action."}`
 

--- a/README.md
+++ b/README.md
@@ -37,3 +37,6 @@ In order to consume the latest n greatest api work be to clear the [prod base ur
 
 It should read `const BASE_URL = '';`
 
+Also you are gonna have to stub the following header `x-rh-auth-identity:{ "identity": { "account_number": "1234567"}}`
+else you'll likely get a bunch of `{"detail":"You do not have permission to perform this action."}`
+

--- a/src/Utilities/Api.js
+++ b/src/Utilities/Api.js
@@ -1,7 +1,5 @@
 import axios from 'axios';
 
-axios.defaults.headers.common = { 'x-rh-auth-identity': '{ "identity": { "account_number": "1234567"}}' };
-
 export default {
     get(url, headers = {}, params = {}) {
         return axios.get(url, {


### PR DESCRIPTION
fixes #86

A note about this... yer gonna have to stub the `x-rh-auth-identity:{ "identity": { "account_number": "1234567"}}` header for this to be agreeable on dev