### PR TITLE
Update hotloading inventory as per new docs

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -2,12 +2,11 @@ import React from 'react';
 import * as reactRouterDom from 'react-router-dom';
 import * as reactCore from '@patternfly/react-core';
 import * as reactIcons from '@patternfly/react-icons';
-import { registry } from '@red-hat-insights/insights-frontend-components';
+import { registry as registryDecorator } from '@red-hat-insights/insights-frontend-components';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import PropTypes from 'prop-types';
-import { entitiesDetailsReducer } from '../../AppReducer';
 
-@registry()
+@registryDecorator()
 class Inventory extends React.Component {
     constructor (props) {
         super(props);
@@ -15,7 +14,6 @@ class Inventory extends React.Component {
             Inventory: () => <Loading/>
         };
 
-        this.fetchInventory = this.fetchInventory.bind(this);
         this.fetchInventory();
     }
 
@@ -23,10 +21,8 @@ class Inventory extends React.Component {
         const items = this.props.items;
         const {
             inventoryConnector,
-            INVENTORY_ACTION_TYPES,
-            mergeWithEntities,
-            mergeWithDetail
-        } = await window.insights.loadInventory({
+            mergeWithEntities
+        } = await insights.loadInventory({
             react: React,
             reactRouterDom,
             reactCore,
@@ -34,12 +30,11 @@ class Inventory extends React.Component {
         });
 
         this.getRegistry().register({
-            ...mergeWithEntities(),
-            ...mergeWithDetail(entitiesDetailsReducer(INVENTORY_ACTION_TYPES))
+            ...mergeWithEntities()
         });
 
         this.setState({
-            Inventory: inventoryConnector(),
+            Inventory: inventoryConnector().InventoryTable,
             items
         });
     }

--- a/src/PresentationalComponents/Inventory/InventoryDetails.js
+++ b/src/PresentationalComponents/Inventory/InventoryDetails.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import * as reactRouterDom from 'react-router-dom';
+import * as reactCore from '@patternfly/react-core';
+import * as reactIcons from '@patternfly/react-icons';
+import { Main, registry as registryDecorator } from '@red-hat-insights/insights-frontend-components';
+import Loading from '../../PresentationalComponents/Loading/Loading';
+import { entitiesDetailsReducer } from '../../AppReducer';
+
+@registryDecorator()
+class InventoryDetails extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            InventoryDetails: () => <Loading />
+        };
+
+        this.fetchInventoryDetails();
+    }
+
+    async fetchInventoryDetails() {
+        const { inventoryConnector, mergeWithDetail, INVENTORY_ACTION_TYPES } = await insights.loadInventory({
+            react: React,
+            reactRouterDom,
+            reactCore,
+            reactIcons
+        });
+
+        this.getRegistry().register({
+            ...mergeWithDetail(entitiesDetailsReducer(INVENTORY_ACTION_TYPES))
+        });
+
+        this.setState({
+            InventoryDetails: inventoryConnector().InventoryDetail
+        });
+    }
+
+    render() {
+        const { InventoryDetails } = this.state;
+        return (
+            <Main>
+                <InventoryDetails root='/actions/:type/:id' />
+            </Main>
+        );
+    }
+}
+
+export default InventoryDetails;

--- a/src/PresentationalComponents/Inventory/InventoryRuleList.js
+++ b/src/PresentationalComponents/Inventory/InventoryRuleList.js
@@ -20,9 +20,7 @@ class InventoryRuleList extends React.Component {
             inventoryRules: []
         };
 
-        this.fetchEntityRules = this.fetchEntityRules.bind(this);
         this.fetchEntityRules();
-        this.expandAll = this.expandAll.bind(this);
     }
 
     async fetchEntityRules () {

--- a/src/SmartComponents/Actions/Actions.js
+++ b/src/SmartComponents/Actions/Actions.js
@@ -6,13 +6,16 @@ import asyncComponent from '../../Utilities/asyncComponent';
 const ActionsOverview = asyncComponent(() => import(/* webpackChunkName: "ActionsOverview" */ './ActionsOverview'));
 const ViewActions = asyncComponent(() => import(/* webpackChunkName: "ListActions" */ './ViewActions'));
 const ListActions = asyncComponent(() => import(/* webpackChunkName: "ListActions" */ './ListActions'));
+const InventoryDetails = asyncComponent(() =>
+    import(/* webpackChunkName: "InventoryDetails" */ '../../PresentationalComponents/Inventory/InventoryDetails'));
 
 const Actions = () => {
     return (
         <Switch>
             <Route exact path='/actions' component={ ActionsOverview } />
             <Route exact path='/actions/:type' component={ ViewActions }/>
-            <Route path='/actions/:type/:id' component={ ListActions }/>
+            <Route exact path='/actions/:type/:id' component={ ListActions }/>
+            <Route path='/actions/:type/:id/:inventoryId/' component={ InventoryDetails }/>
         </Switch>
     );
 };


### PR DESCRIPTION
updated inventory component means details view is no longer a tab, its it's own page https://github.com/RedHatInsights/insights-frontend-components/blob/master/doc/components/inventory.md#usage-of-hot-loading

[**to get this alive follow the steps drawn out here** 
](https://github.com/RedHatInsights/insights-advisor-frontend/pull/100)
### whats this look like? 
<img width="1650" alt="screen shot 2018-12-17 at 12 42 44 pm" src="https://user-images.githubusercontent.com/6640236/50105041-95030b80-01f9-11e9-8376-349389dcc133.png">
<img width="1655" alt="screen shot 2018-12-17 at 12 42 38 pm" src="https://user-images.githubusercontent.com/6640236/50105042-95030b80-01f9-11e9-874a-91c66f451909.png">
<img width="1310" alt="screen shot 2018-12-17 at 12 45 26 pm" src="https://user-images.githubusercontent.com/6640236/50105072-a5b38180-01f9-11e9-97f7-9f7ac4a55795.png">
