### PR TITLE
Removes depreciate _html attribute and process md/html on client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2329,7 +2329,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "requires": {
         "ansi-wrap": "^0.1.0"
@@ -2598,7 +2598,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -3132,17 +3132,17 @@
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
       "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -4056,7 +4056,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
         }
       }
@@ -4187,7 +4187,7 @@
     },
     "cheerio": {
       "version": "1.0.0-rc.2",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
       "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
       "dev": true,
       "requires": {
@@ -4201,7 +4201,7 @@
       "dependencies": {
         "domhandler": {
           "version": "2.4.2",
-          "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/domhandler/-/domhandler-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
           "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "dev": true,
           "requires": {
@@ -4224,7 +4224,7 @@
         },
         "parse5": {
           "version": "3.0.3",
-          "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/parse5/-/parse5-3.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
           "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
           "dev": true,
           "requires": {
@@ -4462,7 +4462,7 @@
     },
     "colors": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
       "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
       "dev": true
     },
@@ -5661,7 +5661,7 @@
     },
     "discontinuous-range": {
       "version": "1.0.0",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
       "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
       "dev": true
     },
@@ -7801,7 +7801,7 @@
     },
     "function.prototype.name": {
       "version": "1.1.0",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
       "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
       "dev": true,
       "requires": {
@@ -8055,7 +8055,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -8343,6 +8343,55 @@
       "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
       "dev": true
     },
+    "html-to-react": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.3.4.tgz",
+      "integrity": "sha512-/tWDdb/8Koi/QEP5YUY1653PcDpBnnMblXRhotnTuhFDjI1Fc6Wzox5d4sw73Xk5rM2OdM5np4AYjT/US/Wj7Q==",
+      "dev": true,
+      "requires": {
+        "domhandler": "^2.4.2",
+        "escape-string-regexp": "^1.0.5",
+        "htmlparser2": "^3.10.0",
+        "lodash.camelcase": "^4.3.0",
+        "ramda": "^0.26"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+          "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^3.0.6"
+          }
+        },
+        "readable-stream": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "html-tokenize": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.0.tgz",
@@ -8367,7 +8416,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -8378,7 +8427,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -8875,7 +8924,7 @@
     },
     "is-boolean-object": {
       "version": "1.0.0",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
       "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
       "dev": true
     },
@@ -9049,13 +9098,13 @@
     },
     "is-number-object": {
       "version": "1.0.3",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/is-number-object/-/is-number-object-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
       "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
       "dev": true
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -9138,13 +9187,13 @@
     },
     "is-string": {
       "version": "1.0.4",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/is-string/-/is-string-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
       "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
       "dev": true
     },
     "is-subset": {
       "version": "0.1.1",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/is-subset/-/is-subset-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
       "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
       "dev": true
     },
@@ -10615,6 +10664,12 @@
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -10635,7 +10690,7 @@
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
@@ -10873,6 +10928,23 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "mdast-add-list-metadata": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz",
+      "integrity": "sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==",
+      "dev": true,
+      "requires": {
+        "unist-util-visit-parents": "1.1.2"
+      },
+      "dependencies": {
+        "unist-util-visit-parents": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz",
+          "integrity": "sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q==",
+          "dev": true
+        }
       }
     },
     "mdast-util-compact": {
@@ -11280,7 +11352,7 @@
     },
     "multipipe": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
       "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
       "requires": {
         "duplexer2": "^0.1.2",
@@ -11772,13 +11844,13 @@
     },
     "object-inspect": {
       "version": "1.6.0",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/object-inspect/-/object-inspect-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
       "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
       "dev": true
     },
     "object-is": {
       "version": "1.0.1",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/object-is/-/object-is-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
       "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
       "dev": true
     },
@@ -11811,7 +11883,7 @@
     },
     "object.entries": {
       "version": "1.0.4",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/object.entries/-/object.entries-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
       "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
       "dev": true,
       "requires": {
@@ -11875,7 +11947,7 @@
     },
     "object.values": {
       "version": "1.0.4",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/object.values/-/object.values-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
       "dev": true,
       "requires": {
@@ -12194,7 +12266,7 @@
     },
     "path-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
@@ -12437,7 +12509,7 @@
         },
         "kind-of": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
           "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
         }
       }
@@ -13161,13 +13233,19 @@
     },
     "railroad-diagrams": {
       "version": "1.0.0",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
       "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
       "dev": true
     },
     "randexp": {
       "version": "0.4.6",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/randexp/-/randexp-0.4.6.tgz",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
       "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
       "dev": true,
       "requires": {
@@ -13422,6 +13500,21 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-markdown": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.0.6.tgz",
+      "integrity": "sha512-E1d/q+OBk5eumId42oYqVrJRB/+whrZdk+YHqUBCCNeWxqeV+Qzt+yLTsft9+4HRDj89Od7eAbUPQBYq8ZwShQ==",
+      "dev": true,
+      "requires": {
+        "html-to-react": "^1.3.4",
+        "mdast-add-list-metadata": "1.0.1",
+        "prop-types": "^15.6.1",
+        "remark-parse": "^5.0.0",
+        "unified": "^6.1.5",
+        "unist-util-visit": "^1.3.0",
+        "xtend": "^4.0.1"
+      }
     },
     "react-motion": {
       "version": "0.5.2",
@@ -14169,7 +14262,7 @@
     },
     "rst-selector-parser": {
       "version": "2.2.3",
-      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
       "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
       "dev": true,
       "requires": {
@@ -14459,7 +14552,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -15106,7 +15199,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
@@ -15436,7 +15529,7 @@
         },
         "globby": {
           "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "dev": true,
           "requires": {
@@ -15845,7 +15938,7 @@
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
@@ -16122,7 +16215,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "xtend": {
@@ -16362,7 +16455,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
@@ -16441,7 +16534,7 @@
     },
     "underscore": {
       "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
       "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
       "dev": true
     },
@@ -17186,7 +17279,7 @@
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "react": "16.7.0",
     "react-content-loader": "3.4.2",
     "react-dom": "16.7.0",
+    "react-markdown": "4.0.6",
     "react-redux": "5.1.0",
     "react-router-dom": "4.3.1",
     "react-test-renderer": "16.7.0",

--- a/src/PresentationalComponents/Cards/RulesCard.js
+++ b/src/PresentationalComponents/Cards/RulesCard.js
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 
 import { Ansible, Battery, Section } from '@red-hat-insights/insights-frontend-components';
 import { Card, CardHeader, CardBody, CardFooter, Split, SplitItem } from '@patternfly/react-core';
+import ReactMarkdown from 'react-markdown/with-html';
 
 import './_RulesCard.scss';
 
@@ -49,7 +50,7 @@ const RulesCard =
                 </Split>
             </CardHeader>
             <CardBody>
-                <div dangerouslySetInnerHTML={ { __html: summary } }/>
+                <ReactMarkdown source={ summary } escapeHtml={ false }/>
             </CardBody>
             <CardFooter>
                 <div className='space-between'>

--- a/src/SmartComponents/Actions/ListActions.js
+++ b/src/SmartComponents/Actions/ListActions.js
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import { Card, CardBody, CardHeader, Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
 import { buildBreadcrumbs, onNavigate, parseBreadcrumbs } from '../../Helpers/breadcrumbs.js';
 import { addNotification } from '@red-hat-insights/insights-frontend-components/components/Notifications';
+import ReactMarkdown from 'react-markdown/with-html';
 
 import * as AppActions from '../../AppActions';
 import Loading from '../../PresentationalComponents/Loading/Loading';
@@ -99,7 +100,9 @@ class ListActions extends Component {
                                     <Grid gutter='md'>
                                         <GridItem md={ 8 } sm={ 12 }>
                                             <Grid>
-                                                <GridItem className='actions__description' dangerouslySetInnerHTML={ { __html: rule.summary_html } }/>
+                                                <GridItem className='actions__description'>
+                                                    <ReactMarkdown source={ rule.summary }   escapeHtml={ false }/>
+                                                </GridItem>
                                                 { kbaDetails.view_uri && (
                                                     <GridItem>
                                                         <a href={ kbaDetails.view_uri }>

--- a/src/SmartComponents/Rules/ListRules.js
+++ b/src/SmartComponents/Rules/ListRules.js
@@ -39,7 +39,7 @@ class ListRules extends React.Component {
                     ruleID = { value.rule_id }
                     category= { value.category.name }
                     description= { value.description }
-                    summary= { value.summary_html }
+                    summary= { value.summary }
                     impact = { value.impact.impact }
                     likelihood = { value.likelihood }
                     totalRisk = { value.severity }


### PR DESCRIPTION
In response to https://github.com/RedHatInsights/insights-advisor-api/pull/165
This will also be added https://github.com/RedHatInsights/insights-frontend-components/tree/master/src/SmartComponents/Inventory/applications/advisor

### Here's the two instances demonstrating success
<img width="1214" alt="screen shot 2019-01-14 at 8 54 56 am" src="https://user-images.githubusercontent.com/6640236/51116962-7b45eb80-17da-11e9-9000-9bbbd6f6fdac.png">
<img width="1217" alt="screen shot 2019-01-14 at 8 53 37 am" src="https://user-images.githubusercontent.com/6640236/51116963-7b45eb80-17da-11e9-8619-67176975e7c8.png">

