### PR TITLE
Update resolution_risk to use rhel .risk value

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -10,3 +10,5 @@ const BASE_URL = '/r/insights/platform/advisor/v1';
 export const RULES_FETCH_URL = `${BASE_URL}/rule/`;
 export const STATS_FETCH_URL = `${BASE_URL}/stats/`;
 export const SYSTEM_FETCH_URL = `${BASE_URL}/system/`;
+
+export const SYSTEM_TYPES = { rhel: 105 };

--- a/src/SmartComponents/Actions/ListActions.js
+++ b/src/SmartComponents/Actions/ListActions.js
@@ -1,14 +1,6 @@
 /* eslint camelcase: 0 */
 import React, { Component } from 'react';
-import {
-    Ansible,
-    Battery,
-    Main,
-    PageHeader,
-    PageHeaderTitle,
-    RemediationButton,
-    routerParams
-} from '@red-hat-insights/insights-frontend-components';
+import { Ansible, Battery, Main, PageHeader, PageHeaderTitle, RemediationButton, routerParams } from '@red-hat-insights/insights-frontend-components';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Card, CardBody, CardHeader, Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
@@ -17,6 +9,7 @@ import { addNotification } from '@red-hat-insights/insights-frontend-components/
 import ReactMarkdown from 'react-markdown/with-html';
 
 import * as AppActions from '../../AppActions';
+import { SYSTEM_TYPES } from '../../AppConstants';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import Failed from '../../PresentationalComponents/Loading/Failed';
 import Inventory from '../../PresentationalComponents/Inventory/Inventory';
@@ -130,7 +123,12 @@ class ListActions extends Component {
                                                     </Grid>
                                                 </GridItem>
                                                 <GridItem sm={ 4 } md={ 12 }>
-                                                    <Battery label='Risk Of Change' severity={ rule.resolution_risk }/>
+                                                    <Battery
+                                                        label='Risk Of Change'
+                                                        severity={ rule.resolution_set.find(resolution =>
+                                                            resolution.system_type === SYSTEM_TYPES.rhel).resolution_risk.risk
+                                                        }
+                                                    />
                                                 </GridItem>
                                                 { rule.has_playbook && (
                                                     <GridItem>

--- a/src/SmartComponents/Rules/ListRules.js
+++ b/src/SmartComponents/Rules/ListRules.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import * as AppActions from '../../AppActions';
+import { SYSTEM_TYPES } from '../../AppConstants';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import rulesCardSkeleton from '../../PresentationalComponents/Skeletons/RulesCard/RulesCardSkeleton.js';
 
@@ -43,7 +44,7 @@ class ListRules extends React.Component {
                     impact = { value.impact.impact }
                     likelihood = { value.likelihood }
                     totalRisk = { value.severity }
-                    riskOfChange = { value.resolution_risk }
+                    riskOfChange = { value.resolution_set.find(resolution => resolution.system_type === SYSTEM_TYPES.rhel).resolution_risk.risk }
                     ansible = { value.has_playbook }
                     hitCount = { value.impacted_systems_count }
                 />


### PR DESCRIPTION
Cuz the work making this attribute available was merged https://github.com/RedHatInsights/insights-advisor-api/pull/169/files

### yup now we're cookin
<img width="1531" alt="screen shot 2019-01-17 at 12 12 16 pm" src="https://user-images.githubusercontent.com/6640236/51335941-514a2e80-1a51-11e9-80eb-77471f8f6cbc.png">

<img width="1560" alt="screen shot 2019-01-17 at 12 14 34 pm" src="https://user-images.githubusercontent.com/6640236/51335998-7a6abf00-1a51-11e9-9be3-3e7174c509bd.png">

