### PR TITLE
Adds breadcrumbs and additional visual enhancements to inv details

### DIFF
--- a/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
+++ b/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
@@ -26,7 +26,7 @@ export function buildBreadcrumbs(match, options) {
     if (match.params.inventoryId !== undefined) {
         crumbs.push({
             title: match.params.id,
-            navigate: crumbs[0].navigate + '/' + crumbs[1].navigate + '/' + match.params.id
+            navigate: crumbs[1].navigate + '/' + match.params.id
         });
     }
 

--- a/src/PresentationalComponents/Inventory/InventoryDetails.js
+++ b/src/PresentationalComponents/Inventory/InventoryDetails.js
@@ -2,49 +2,85 @@ import React from 'react';
 import * as reactRouterDom from 'react-router-dom';
 import * as reactCore from '@patternfly/react-core';
 import * as reactIcons from '@patternfly/react-icons';
-import { Main, registry as registryDecorator } from '@red-hat-insights/insights-frontend-components';
-import Loading from '../../PresentationalComponents/Loading/Loading';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Main, PageHeader, registry as registryDecorator, routerParams } from '@red-hat-insights/insights-frontend-components';
 import { entitiesDetailsReducer } from '../../AppReducer';
+import Breadcrumbs, { buildBreadcrumbs } from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
+import Loading from '../../PresentationalComponents/Loading/Loading';
 
 @registryDecorator()
 class InventoryDetails extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            InventoryDetails: () => <Loading />
-        };
+    state = { InventoryDetails: () => <Loading/> };
 
+    componentDidMount () {
         this.fetchInventoryDetails();
     }
 
-    async fetchInventoryDetails() {
+    async fetchInventoryDetails () {
         const { inventoryConnector, mergeWithDetail, INVENTORY_ACTION_TYPES } = await insights.loadInventory({
             react: React,
             reactRouterDom,
             reactCore,
             reactIcons
         });
+        const { InventoryDetailHead, AppInfo, VulnerabilitiesStore } = inventoryConnector();
 
         this.getRegistry().register({
             ...mergeWithDetail(entitiesDetailsReducer(INVENTORY_ACTION_TYPES))
         });
-
-        const { InventoryDetail, VulnerabilitiesStore } = inventoryConnector();
         VulnerabilitiesStore && this.getRegistry().register({ VulnerabilitiesStore });
-
         this.setState({
-            InventoryDetails: InventoryDetail
+            InventoryDetail: InventoryDetailHead, AppInfo
         });
     }
 
-    render() {
-        const { InventoryDetails } = this.state;
+    onNavigate (navigateTo) {
+        const { history } = this.props;
+        history.push(`/${navigateTo}`);
+    }
+
+    render () {
+        const { InventoryDetail, AppInfo } = this.state;
+        const { breadcrumbs, entity } = this.props;
         return (
-            <Main>
-                <InventoryDetails root='/actions/:type/:id' />
-            </Main>
+            <>
+                <PageHeader className="pf-m-light ins-inventory-detail">
+                    { entity && <Breadcrumbs
+                        current={ entity.display_name || entity.id }
+                        items={ buildBreadcrumbs(this.props.match, { breadcrumbs }) }
+                    /> }
+                    { InventoryDetail && <InventoryDetail hideBack/> }
+                </PageHeader>
+                <Main>
+                    <reactCore.Grid gutter="md">
+                        <reactCore.GridItem span={ 12 }>
+                            { AppInfo && <AppInfo/> }
+                        </reactCore.GridItem>
+                    </reactCore.Grid>
+                </Main>
+            </>
         );
     }
 }
 
-export default InventoryDetails;
+InventoryDetails.contextTypes = {
+    store: PropTypes.object
+};
+
+InventoryDetails.propTypes = {
+    history: PropTypes.object,
+    entity: PropTypes.object,
+    addAlert: PropTypes.func,
+    breadcrumbs: PropTypes.array,
+    match: PropTypes.any
+};
+
+function mapStateToProps (store) {
+    return {
+        entity: store.entityDetails && store.entityDetails.entity,
+        breadcrumbs: store.AdvisorStore.breadcrumbs
+    };
+}
+
+export default routerParams(connect(mapStateToProps, null)(InventoryDetails));


### PR DESCRIPTION
### here's what we look like!! breadcrumbs by hostname when available, uuid when not 
<img width="1106" alt="screen shot 2019-01-22 at 3 25 59 pm" src="https://user-images.githubusercontent.com/6640236/51563372-3bc27380-1e5a-11e9-9e06-b6b543e5c688.png">
<img width="1102" alt="screen shot 2019-01-22 at 3 25 45 pm" src="https://user-images.githubusercontent.com/6640236/51563373-3bc27380-1e5a-11e9-9864-2440947ff7ca.png">
