### PR TITLE
Revert "Refactor breadcrumbs to make them match based"

### DIFF
--- a/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
+++ b/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
@@ -4,27 +4,36 @@ import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import './_breadcrumbs.scss';
 
-export function buildBreadcrumbs(match, options) {
-    let crumbs = [];
+export function buildBreadcrumbs(match, hops) {
+    let breadcrumbs = [];
+    breadcrumbs.push({
+        title: match.path.split('/')[1],
+        navigate: '/' + match.path.split('/')[1]
+    });
+    return parseBreadcrumbs(breadcrumbs, match.params, hops);
+}
 
-    // add actions/rules base breadcrumb
-    if (match.params.type !== undefined) {
-        if (options.breadcrumbs[0].navigate !== undefined) {
-            crumbs.push(options.breadcrumbs[0]);
-        } else {
-            crumbs.push({ title: 'Actions', navigate: '/actions' });
+export function parseBreadcrumbs(breadcrumbs, params, hops) {
+    if (breadcrumbs[0].navigate === '/rules') {
+        return breadcrumbs;
+    } else {
+        let crumbs = [];
+        if (hops >= 1) {
+            crumbs.push({
+                title: breadcrumbs[0].title,
+                navigate: breadcrumbs[0].navigate
+            });
         }
-    }
 
-    // add :type breadcrumb (exception: Rules based breadcrumbs)
-    if (match.params.id !== undefined && crumbs[0].title !== 'Rules') {
-        crumbs.push({
-            title: match.params.type.replace('-', ' '),
-            navigate: crumbs[0].navigate + '/' + match.params.type
-        });
-    }
+        if (hops === 2) {
+            crumbs.push({
+                title: params.type.replace('-', ' '),
+                navigate: breadcrumbs[0].navigate + '/' + params.type
+            });
+        }
 
-    return crumbs;
+        return crumbs;
+    }
 }
 
 const Breadcrumbs = ({ items, current }) => (
@@ -34,12 +43,12 @@ const Breadcrumbs = ({ items, current }) => (
                 <Link to={ oneLink.navigate }>{ oneLink.title }</Link>
             </BreadcrumbItem>
         )) }
-        <BreadcrumbItem to='' isActive>{ current }</BreadcrumbItem>
+        <BreadcrumbItem isActive>{ current }</BreadcrumbItem>
     </Breadcrumb>
 );
 
 Breadcrumbs.propTypes = {
-    items: PropTypes.array,
+    items: PropTypes.arrayOf(PropTypes.any),
     current: PropTypes.string
 };
 

--- a/src/SmartComponents/Actions/ListActions.js
+++ b/src/SmartComponents/Actions/ListActions.js
@@ -4,7 +4,7 @@ import { Ansible, Battery, Main, PageHeader, PageHeaderTitle, RemediationButton,
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Card, CardBody, CardHeader, Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
-import Breadcrumbs, { buildBreadcrumbs } from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
+import Breadcrumbs, { buildBreadcrumbs, parseBreadcrumbs } from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
 import { addNotification } from '@red-hat-insights/insights-frontend-components/components/Notifications';
 import ReactMarkdown from 'react-markdown/with-html';
 
@@ -78,7 +78,11 @@ class ListActions extends Component {
                 <PageHeader>
                     <Breadcrumbs
                         current={ rule.description || '' }
-                        items={ buildBreadcrumbs(this.props.match, { breadcrumbs }) }
+                        items={
+                            breadcrumbs[0] !== undefined ?
+                                parseBreadcrumbs(breadcrumbs, this.props.match.params, 2) :
+                                buildBreadcrumbs(this.props.match, 2)
+                        }
                     />
                     <PageHeaderTitle title={ rule.description || '' }/>
                 </PageHeader>

--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -163,7 +163,7 @@ class ViewActions extends Component {
                 <PageHeader>
                     <Breadcrumbs
                         current={ this.parseUrlTitle(this.props.match.params.type) }
-                        items={ buildBreadcrumbs(this.props.match, { breadcrumbs }) }
+                        items={ breadcrumbs[0] !== undefined ? breadcrumbs : buildBreadcrumbs(this.props.match, 1) }
                     />
                     <PageHeaderTitle
                         className='actions__view--title'


### PR DESCRIPTION
Reverts RedHatInsights/insights-advisor-frontend#149

This pr ended up being a regression, upon refreshing the page, breadcrumbs will break the app, `Uncaught TypeError: Cannot read property 'navigate' of undefined`