### PR TITLE
Ensure prop type passed is one expected

### DIFF
--- a/src/PresentationalComponents/Cards/RulesCard.js
+++ b/src/PresentationalComponents/Cards/RulesCard.js
@@ -84,7 +84,7 @@ RulesCard.propTypes = {
     category: propTypes.string,
     description: propTypes.string,
     summary: propTypes.string,
-    ansible: propTypes.number,
+    ansible: propTypes.bool,
     impact: propTypes.number,
     likelihood: propTypes.number,
     totalRisk: propTypes.number,


### PR DESCRIPTION
Rids us of that icky warning. 