### PR TITLE
Update routing so refreshing does not redirect to root everytime

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { routerParams } from '@red-hat-insights/insights-frontend-components';
+import { matchPath } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { Routes } from './Routes';
 import './App.scss';
@@ -10,7 +11,11 @@ class App extends Component {
         insights.chrome.init();
         insights.chrome.identifyApp('advisor');
         insights.chrome.navigation(buildNavigation());
-        this.appNav = insights.chrome.on('APP_NAVIGATION', event => this.props.history.push(`/${event.navId}`));
+        this.appNav = insights.chrome.on('APP_NAVIGATION', event => {
+            if (!matchPath(location.href, { path: `${document.baseURI}platform/advisor/${event.navId}` })) {
+                this.props.history.push(`/${event.navId}`);
+            }
+        });
         this.buildNav = this.props.history.listen(() => insights.chrome.navigation(buildNavigation()));
     }
 


### PR DESCRIPTION
This will allow users to bookmark and refresh without redirecting to root URL. If there are some malicious data or wrong URL that does match `/actions` or `/rules` but has something wrong after it we have to react to it and either show some error msg or redirect them to correct URL, but that is not part of this PR.