### PR TITLE
Fixes breadcrumb using rule.id

### DIFF
--- a/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
+++ b/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
@@ -47,7 +47,7 @@ class Breadcrumbs extends React.Component {
         }
 
         // add :type breadcrumb (exception: Rules based breadcrumbs)
-        if (match.params.id !== undefined && crumbs[0].title !== 'Rules') {
+        if (match.params.type !== undefined && match.params.id !== undefined && crumbs[0].title !== 'Rules') {
             const title = this.getReadableType(match.params.type);
             crumbs.push({
                 title,
@@ -55,7 +55,7 @@ class Breadcrumbs extends React.Component {
             });
         }
 
-        if (match.params.inventoryId !== undefined) {
+        if (match.params.id !== undefined && match.params.inventoryId !== undefined) {
             crumbs.push({
                 title: this.props.rule.description,
                 navigate: crumbs[1].navigate + '/' + match.params.id

--- a/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
+++ b/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
@@ -77,7 +77,7 @@ class Breadcrumbs extends React.Component {
                                 <Link to={ oneLink.navigate }>{ oneLink.title }</Link>
                             </BreadcrumbItem>
                         )) }
-                        <BreadcrumbItem to='' isActive>{ this.props.current }</BreadcrumbItem>
+                        <BreadcrumbItem isActive>{ this.props.current }</BreadcrumbItem>
                     </Breadcrumb>
                 ) }
                 { ruleFetchStatus === 'pending' && ('Loading...') }

--- a/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
+++ b/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
@@ -1,52 +1,113 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
+import { routerParams } from '@red-hat-insights/insights-frontend-components';
+import { connect } from 'react-redux';
+import * as AppActions from '../../AppActions';
 import PropTypes from 'prop-types';
 import './_breadcrumbs.scss';
 
-export function buildBreadcrumbs(match, options) {
-    let crumbs = [];
+class Breadcrumbs extends React.Component {
+    state = {
+        items: [],
+        ruleDescriptionLoaded: false
+    };
 
-    // add actions/rules base breadcrumb
-    if (options === undefined || options.breadcrummbs === undefined || options.breadcrumbs[0] === undefined) {
-        crumbs.push({ title: 'Actions', navigate: '/actions' });
-    } else {
-        crumbs.push(options.breadcrumbs[0]);
+    componentDidMount () {
+        if (this.props.match.params.inventoryId !== undefined) {
+            this.props.fetchRule({ rule_id: this.props.match.params.id }); // eslint-disable-line camelcase
+        } else {
+            this.buildBreadcrumbs();
+        }
     }
 
-    // add :type breadcrumb (exception: Rules based breadcrumbs)
-    if (match.params.id !== undefined && crumbs[0].title !== 'Rules') {
-        const title = match.params.type.indexOf('-') > -1 ? `${match.params.type.replace('-', ' ')} Actions` : match.params.type ;
-        crumbs.push({
-            title,
-            navigate: crumbs[0].navigate + '/' + match.params.type
-        });
+    componentDidUpdate () {
+        if (this.props.ruleFetchStatus === 'fulfilled' && !this.state.ruleDescriptionLoaded) {
+            this.setState({ ruleDescriptionLoaded: true });
+            this.buildBreadcrumbs();
+        }
     }
 
-    if (match.params.inventoryId !== undefined) {
-        crumbs.push({
-            title: match.params.id,
-            navigate: crumbs[1].navigate + '/' + match.params.id
-        });
+    getReadableType = (type) => (
+        type.indexOf('-') > -1 ? `${type.replace('-', ' ')} Actions` : type
+    );
+
+    buildBreadcrumbs () {
+        const { breadcrumbs, match } = this.props;
+        let crumbs = [];
+
+        // add actions/rules base breadcrumb
+        if (match.params.type !== undefined) {
+            if (breadcrumbs[0] !== undefined) {
+                crumbs.push(breadcrumbs[0]);
+            } else {
+                const title = match.url.split('/')[1];
+                crumbs.push({ title, navigate: `/${title}` });
+            }
+        }
+
+        // add :type breadcrumb (exception: Rules based breadcrumbs)
+        if (match.params.id !== undefined && crumbs[0].title !== 'Rules') {
+            const title = this.getReadableType(match.params.type);
+            crumbs.push({
+                title,
+                navigate: crumbs[0].navigate + '/' + match.params.type
+            });
+        }
+
+        if (match.params.inventoryId !== undefined) {
+            crumbs.push({
+                title: this.props.rule.description,
+                navigate: crumbs[1].navigate + '/' + match.params.id
+            });
+        }
+
+        this.setState({ items: crumbs });
     }
 
-    return crumbs;
+    render () {
+        const { ruleFetchStatus } = this.props;
+        const { items } = this.state;
+        return (
+            <React.Fragment>
+                { (ruleFetchStatus === 'fulfilled' || items.length > 0) && (
+                    <Breadcrumb>
+                        { items.map((oneLink, key) => (
+                            <BreadcrumbItem key={ key }>
+                                <Link to={ oneLink.navigate }>{ oneLink.title }</Link>
+                            </BreadcrumbItem>
+                        )) }
+                        <BreadcrumbItem to='' isActive>{ this.props.current }</BreadcrumbItem>
+                    </Breadcrumb>
+                ) }
+                { ruleFetchStatus === 'pending' && ('Loading...') }
+            </React.Fragment>
+        );
+    }
 }
 
-const Breadcrumbs = ({ items, current }) => (
-    <Breadcrumb>
-        { items.map((oneLink, key) => (
-            <BreadcrumbItem key={ key }>
-                <Link to={ oneLink.navigate }>{ oneLink.title }</Link>
-            </BreadcrumbItem>
-        )) }
-        <BreadcrumbItem to='' isActive>{ current }</BreadcrumbItem>
-    </Breadcrumb>
-);
-
 Breadcrumbs.propTypes = {
-    items: PropTypes.array,
-    current: PropTypes.string
+    breadcrumbs: PropTypes.arrayOf(Object),
+    current: PropTypes.string,
+    fetchRule: PropTypes.func,
+    match: PropTypes.object,
+    rule: PropTypes.object,
+    ruleFetchStatus: PropTypes.string
 };
 
-export default Breadcrumbs;
+const mapStateToProps = (state, ownProps) => ({
+    breadcrumbs: state.AdvisorStore.breadcrumbs,
+    rule: state.AdvisorStore.rule,
+    ruleFetchStatus: state.AdvisorStore.ruleFetchStatus,
+    ...state,
+    ...ownProps
+});
+
+const mapDispatchToProps = dispatch => ({
+    fetchRule: (url) => dispatch(AppActions.fetchRule(url))
+});
+
+export default routerParams(connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(Breadcrumbs));

--- a/src/PresentationalComponents/Inventory/InventoryDetails.js
+++ b/src/PresentationalComponents/Inventory/InventoryDetails.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Main, PageHeader, registry as registryDecorator, routerParams } from '@red-hat-insights/insights-frontend-components';
 import { entitiesDetailsReducer } from '../../AppReducer';
-import Breadcrumbs, { buildBreadcrumbs } from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
+import Breadcrumbs from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import '@red-hat-insights/insights-frontend-components/components/Advisor.css';
 
@@ -42,13 +42,13 @@ class InventoryDetails extends React.Component {
 
     render () {
         const { InventoryDetail, AppInfo } = this.state;
-        const { breadcrumbs, entity } = this.props;
+        const { entity } = this.props;
         return (
             <>
                 <PageHeader className="pf-m-light ins-inventory-detail">
                     { entity && <Breadcrumbs
                         current={ entity.display_name || entity.id }
-                        items={ buildBreadcrumbs(this.props.match, { breadcrumbs }) }
+                        match={ this.props.match }
                     /> }
                     { InventoryDetail && <InventoryDetail hideBack/> }
                 </PageHeader>
@@ -72,14 +72,12 @@ InventoryDetails.propTypes = {
     history: PropTypes.object,
     entity: PropTypes.object,
     addAlert: PropTypes.func,
-    breadcrumbs: PropTypes.array,
     match: PropTypes.any
 };
 
 function mapStateToProps (store) {
     return {
-        entity: store.entityDetails && store.entityDetails.entity,
-        breadcrumbs: store.AdvisorStore.breadcrumbs
+        entity: store.entityDetails && store.entityDetails.entity
     };
 }
 

--- a/src/SmartComponents/Actions/ActionsOverview.js
+++ b/src/SmartComponents/Actions/ActionsOverview.js
@@ -107,6 +107,7 @@ class ActionsOverview extends Component {
 }
 
 ActionsOverview.propTypes = {
+    match: PropTypes.object,
     breadcrumbs: PropTypes.array,
     fetchStats: PropTypes.func,
     setBreadcrumbs: PropTypes.func,

--- a/src/SmartComponents/Actions/ListActions.js
+++ b/src/SmartComponents/Actions/ListActions.js
@@ -75,13 +75,16 @@ class ListActions extends Component {
         const { kbaDetails } = this.state;
         return (
             <React.Fragment>
-                <PageHeader>
-                    <Breadcrumbs
-                        current={ rule.description || '' }
-                        match={ match }
-                    />
-                    <PageHeaderTitle title={ rule.description || '' }/>
-                </PageHeader>
+                { ruleFetchStatus === 'fulfilled' && (
+                    <PageHeader>
+                        <Breadcrumbs
+                            current={ rule.description || '' }
+                            match={ match }
+                        />
+                        <PageHeaderTitle title={ rule.description || '' }/>
+                    </PageHeader>
+                ) }
+                { ruleFetchStatus === 'pending' && (<Loading/>) }
                 <Main className='actions__list'>
                     <React.Fragment>
                         { ruleFetchStatus === 'fulfilled' && (

--- a/src/SmartComponents/Actions/ListActions.js
+++ b/src/SmartComponents/Actions/ListActions.js
@@ -4,7 +4,7 @@ import { Ansible, Battery, Main, PageHeader, PageHeaderTitle, RemediationButton,
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Card, CardBody, CardHeader, Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
-import Breadcrumbs, { buildBreadcrumbs } from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
+import Breadcrumbs from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
 import { addNotification } from '@red-hat-insights/insights-frontend-components/components/Notifications';
 import ReactMarkdown from 'react-markdown/with-html';
 
@@ -71,14 +71,14 @@ class ListActions extends Component {
     }
 
     render () {
-        const { breadcrumbs, ruleFetchStatus, rule, systemFetchStatus, system } = this.props;
+        const { match, ruleFetchStatus, rule, systemFetchStatus, system } = this.props;
         const { kbaDetails } = this.state;
         return (
             <React.Fragment>
                 <PageHeader>
                     <Breadcrumbs
                         current={ rule.description || '' }
-                        items={ buildBreadcrumbs(this.props.match, { breadcrumbs }) }
+                        match={ match }
                     />
                     <PageHeaderTitle title={ rule.description || '' }/>
                 </PageHeader>
@@ -165,7 +165,6 @@ class ListActions extends Component {
 }
 
 ListActions.propTypes = {
-    breadcrumbs: PropTypes.array,
     match: PropTypes.any,
     fetchRule: PropTypes.func,
     ruleFetchStatus: PropTypes.string,
@@ -180,7 +179,6 @@ ListActions.propTypes = {
 const mapStateToProps = (state, ownProps) => ({
     rule: state.AdvisorStore.rule,
     ruleFetchStatus: state.AdvisorStore.ruleFetchStatus,
-    breadcrumbs: state.AdvisorStore.breadcrumbs,
     system: state.AdvisorStore.system,
     systemFetchStatus: state.AdvisorStore.systemFetchStatus,
     entities: state.entities,

--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -19,7 +19,7 @@ import { Stack, StackItem } from '@patternfly/react-core';
 import * as AppActions from '../../AppActions';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import Failed from '../../PresentationalComponents/Loading/Failed';
-import Breadcrumbs, { buildBreadcrumbs } from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
+import Breadcrumbs from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
 import { RULE_CATEGORIES, SEVERITY_MAP } from '../../AppConstants';
 import Filters from '../../PresentationalComponents/Filters/Filters';
 
@@ -157,14 +157,14 @@ class ViewActions extends Component {
     };
 
     render () {
-        const { rulesFetchStatus, rules, breadcrumbs } = this.props;
+        const { rulesFetchStatus, rules } = this.props;
         const { localFilters, pageSize, page, impacting } = this.state;
         return (
             <React.Fragment>
                 <PageHeader>
                     <Breadcrumbs
                         current={ this.parseUrlTitle(this.props.match.params.type) }
-                        items={ buildBreadcrumbs(this.props.match, { breadcrumbs }) }
+                        match={ this.props.match }
                     />
                     <PageHeaderTitle
                         className='actions__view--title'
@@ -217,7 +217,6 @@ class ViewActions extends Component {
 }
 
 ViewActions.propTypes = {
-    breadcrumbs: PropTypes.array,
     fetchRules: PropTypes.func,
     match: PropTypes.any,
     rulesFetchStatus: PropTypes.string,
@@ -226,7 +225,6 @@ ViewActions.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => ({
-    breadcrumbs: state.AdvisorStore.breadcrumbs,
     rules: state.AdvisorStore.rules,
     rulesFetchStatus: state.AdvisorStore.rulesFetchStatus,
     filters: state.AdvisorStore.filters,


### PR DESCRIPTION
Refactored Breadcrumb is now class-based and reduces the dependencies required of parent components.  On Inventory page, breadcrumbs now use the Rule description instead of the id 

Fixes RHIADVISOR-401

Before:
![breadcrumbs-before](https://user-images.githubusercontent.com/1630348/52496632-e4ced500-2ba1-11e9-916f-d5681c4e797c.png)

After:
![breadcrumbs-after](https://user-images.githubusercontent.com/1630348/52496643-ea2c1f80-2ba1-11e9-827d-d6f3cebf84f6.png)
