### PR TITLE
Change battery icon to use total_risk rather than severity

### DIFF
--- a/src/SmartComponents/Actions/ListActions.js
+++ b/src/SmartComponents/Actions/ListActions.js
@@ -115,7 +115,7 @@ class ListActions extends Component {
                                                     <Grid className='ins-l-icon-group__vertical' sm={ 4 } md={ 12 }>
                                                         <GridItem> <Battery label='Impact' severity={ rule.impact.impact }/> </GridItem>
                                                         <GridItem> <Battery label='Likelihood' severity={ rule.likelihood }/> </GridItem>
-                                                        <GridItem> <Battery label='Total Risk' severity={ rule.severity }/> </GridItem>
+                                                        <GridItem> <Battery label='Total Risk' severity={ rule.total_risk }/> </GridItem>
                                                     </Grid>
                                                 </GridItem>
                                                 <GridItem sm={ 4 } md={ 12 }>

--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -104,7 +104,7 @@ class ViewActions extends Component {
                             key={ key }
                             label='Total Risk'
                             labelHidden
-                            severity={ value.severity }
+                            severity={ value.total_risk }
                         />,
                         <div key={ key }>{ value.impacted_systems_count }</div>,
                         <Ansible

--- a/src/SmartComponents/Rules/ListRules.js
+++ b/src/SmartComponents/Rules/ListRules.js
@@ -42,7 +42,7 @@ class ListRules extends Component {
                     summary={ value.summary }
                     impact={ value.impact.impact }
                     likelihood={ value.likelihood }
-                    totalRisk={ value.severity }
+                    totalRisk={ value.total_risk }
                     riskOfChange={ value.resolution_set.find(resolution => resolution.system_type === SYSTEM_TYPES.rhel).resolution_risk.risk }
                     ansible={ value.has_playbook }
                     hitCount={ value.impacted_systems_count }


### PR DESCRIPTION
Updated all Total Risk battery icons to be bound to `total_risk` rather than `severity`.

Fixes RHIADVISOR-414