### PR TITLE
Supports category queries by id# rather than string

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -18,3 +18,9 @@ export const RULE_CATEGORIES = {
     stability: 3,
     performance: 4
 };
+export const SEVERITY_MAP = {
+    'critical-risk': 4,
+    'high-risk': 3,
+    'medium-risk': 2,
+    'low-risk': 1
+};

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -12,3 +12,9 @@ export const STATS_FETCH_URL = `${BASE_URL}/stats/`;
 export const SYSTEM_FETCH_URL = `${BASE_URL}/system/`;
 
 export const SYSTEM_TYPES = { rhel: 105 };
+export const RULE_CATEGORIES = {
+    availability: 1,
+    security: 2,
+    stability: 3,
+    performance: 4
+};

--- a/src/SmartComponents/Actions/ActionsOverview.js
+++ b/src/SmartComponents/Actions/ActionsOverview.js
@@ -5,9 +5,12 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Card, CardBody, CardHeader, Grid, GridItem } from '@patternfly/react-core';
 import { Main, PageHeader, PageHeaderTitle, routerParams } from '@red-hat-insights/insights-frontend-components';
+import { invert, capitalize } from 'lodash';
 
 import * as AppActions from '../../AppActions';
 import Loading from '../../PresentationalComponents/Loading/Loading';
+import { SEVERITY_MAP } from '../../AppConstants';
+
 import '../../App.scss';
 
 const SummaryChart = asyncComponent(() => import('../../PresentationalComponents/SummaryChart/SummaryChart'));
@@ -17,10 +20,9 @@ const ActionsOverviewDonut = asyncComponent(() => import('../../PresentationalCo
 
 class ActionsOverview extends Component {
    state = {
-       severity: [],
+       totalRisk: {},
        total: 0,
-       category: [],
-       sevNames: [ 'Low', 'Medium', 'High', 'Critical' ]
+       category: []
    };
 
    async componentDidMount () {
@@ -32,7 +34,7 @@ class ActionsOverview extends Component {
    componentDidUpdate (prevProps) {
        if (this.props.stats !== prevProps.stats) {
            const rules = this.props.stats.rules;
-           this.setState({ severity: [ rules.severity.Info, rules.severity.Warn, rules.severity.Error, rules.severity.Critical ]});
+           this.setState({ totalRisk: rules.total_risk });
            this.setState({
                category: [ rules.category.Availability, rules.category.Security, rules.category.Stability, rules.category.Performance ]
            });
@@ -40,63 +42,66 @@ class ActionsOverview extends Component {
        }
    }
 
-   render () {
-       const {
-           statsFetchStatus
-       } = this.props;
+     summaryChart = Object.entries(this.state.totalRisk).map(([ key, value ]) => {
+         const riskName = invert(SEVERITY_MAP)[key];
+         const normalizedRiskName = capitalize(riskName.split('-')[0]);
 
-       const SummaryChartItems = this.state.severity.map((value, key) =>
-           <ConditionalLink
-               key={ key }
-               condition={ value }
-               wrap={ children =>
-                   <Link to={ `/actions/${this.state.sevNames[key].toLowerCase()}-risk` }>
-                       { children }
-                   </Link>
-               }>
-               <SummaryChartItem
-                   name={ this.state.sevNames[key] }
-                   numIssues={ value }
-                   totalIssues={ this.state.total }/>
-           </ConditionalLink>
-       );
+         return  <ConditionalLink
+             key={ key }
+             condition={ value }
+             wrap={ children =>
+                 <Link to={ `/actions/${riskName}` }>
+                     { children }
+                 </Link>
+             }>
+             <SummaryChartItem
+                 name={ normalizedRiskName }
+                 numIssues={ value }
+                 totalIssues={ 5 }/>
+         </ConditionalLink>;
+     });
 
-       return (
-           <React.Fragment>
-               <PageHeader>
-                   <PageHeaderTitle title='Actions'/>
-               </PageHeader>
-               <Main>
-                   <Grid gutter='lg' xl={ 5 } lg={ 8 } md={ 2 } sm={ 1 }>
-                       <GridItem  xl={ 5 } lg={ 6 } md={ 9 } sm={ 6 }>
-                           <Card className='pf-t-light  pf-m-opaque-100'>
-                               <CardHeader>Category Summary</CardHeader>
-                               <CardBody>
-                                   { statsFetchStatus === 'fulfilled' && (
-                                       <ActionsOverviewDonut category={ this.state.category }/>
-                                   ) }
-                                   { statsFetchStatus === 'pending' && (<Loading/>) }
-                               </CardBody>
-                           </Card>
-                       </GridItem>
-                       <GridItem xl={ 3 } lg={ 4 } md={ 5 } sm={ 4 }>
-                           <Card className='pf-t-light  pf-m-opaque-100'>
-                               <CardHeader>Risk Summary</CardHeader>
-                               <CardBody>
-                                   { statsFetchStatus === 'fulfilled' && (
-                                       <SummaryChart>
-                                           { SummaryChartItems }
-                                       </SummaryChart>
-                                   ) }
-                                   { statsFetchStatus === 'pending' && (<Loading/>) }
-                               </CardBody>
-                           </Card>
-                       </GridItem>
-                   </Grid>
-               </Main>
-           </React.Fragment>
-       );
-   }
+     render () {
+         const {
+             statsFetchStatus
+         } = this.props;
+
+         return (
+             <React.Fragment>
+                 <PageHeader>
+                     <PageHeaderTitle title='Actions'/>
+                 </PageHeader>
+                 <Main>
+                     <Grid gutter='lg' xl={ 5 } lg={ 8 } md={ 2 } sm={ 1 }>
+                         <GridItem  xl={ 5 } lg={ 6 } md={ 9 } sm={ 6 }>
+                             <Card className='pf-t-light  pf-m-opaque-100'>
+                                 <CardHeader>Category Summary</CardHeader>
+                                 <CardBody>
+                                     { statsFetchStatus === 'fulfilled' && (
+                                         <ActionsOverviewDonut category={ this.state.category }/>
+                                     ) }
+                                     { statsFetchStatus === 'pending' && (<Loading/>) }
+                                 </CardBody>
+                             </Card>
+                         </GridItem>
+                         <GridItem xl={ 3 } lg={ 4 } md={ 5 } sm={ 4 }>
+                             <Card className='pf-t-light  pf-m-opaque-100'>
+                                 <CardHeader>Risk Summary</CardHeader>
+                                 <CardBody>
+                                     { statsFetchStatus === 'fulfilled' && (
+                                         <SummaryChart>
+                                             { this.summaryChart }
+                                         </SummaryChart>
+                                     ) }
+                                     { statsFetchStatus === 'pending' && (<Loading/>) }
+                                 </CardBody>
+                             </Card>
+                         </GridItem>
+                     </Grid>
+                 </Main>
+             </React.Fragment>
+         );
+     }
 }
 
 ActionsOverview.propTypes = {

--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -13,14 +13,14 @@ import {
     Table
 } from '@red-hat-insights/insights-frontend-components';
 import PropTypes from 'prop-types';
-import { sortBy, debounce } from 'lodash';
+import { debounce, sortBy } from 'lodash';
 import { connect } from 'react-redux';
 import { Stack, StackItem } from '@patternfly/react-core';
 import * as AppActions from '../../AppActions';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import Failed from '../../PresentationalComponents/Loading/Failed';
 import Breadcrumbs, { buildBreadcrumbs } from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
-import { RULE_CATEGORIES } from '../../AppConstants';
+import { RULE_CATEGORIES, SEVERITY_MAP } from '../../AppConstants';
 
 import './_actions.scss';
 
@@ -53,18 +53,12 @@ class ViewActions extends Component {
 
     componentDidMount () {
         document.getElementById('root').classList.add('actions__view');
-        const severityMap = {
-            'critical-risk': 4,
-            'high-risk': 3,
-            'medium-risk': 2,
-            'low-risk': 1
-        };
         const options = { page_size: this.state.itemsPerPage, impacting: true };
 
         if (this.props.match.params.type.includes('-risk')) {
-            const severity = severityMap[this.props.match.params.type];
-            this.setState({ filters: { severity }});
-            options.severity = severity;
+            const totalRisk = SEVERITY_MAP[this.props.match.params.type];
+            this.setState({ filters: { total_risk: totalRisk }});
+            options.total_risk = totalRisk;
         } else {
             this.setState({ filters: { category: RULE_CATEGORIES[this.props.match.params.type] }});
             options.category = RULE_CATEGORIES[this.props.match.params.type];
@@ -83,7 +77,7 @@ class ViewActions extends Component {
                     cells: [
                         <Link
                             key={ key }
-                            to={ `/actions/${this.props.match.params.type }/${
+                            to={ `/actions/${this.props.match.params.type}/${
                                 value.rule_id
                             }` }
                         >

--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -13,14 +13,15 @@ import {
     Table
 } from '@red-hat-insights/insights-frontend-components';
 import PropTypes from 'prop-types';
-import { sortBy } from 'lodash';
+import { sortBy, debounce } from 'lodash';
 import { connect } from 'react-redux';
 import { Stack, StackItem } from '@patternfly/react-core';
 import * as AppActions from '../../AppActions';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import Failed from '../../PresentationalComponents/Loading/Failed';
 import Breadcrumbs, { buildBreadcrumbs } from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
-import debounce from 'lodash/debounce';
+import { RULE_CATEGORIES } from '../../AppConstants';
+
 import './_actions.scss';
 
 class ViewActions extends Component {
@@ -65,8 +66,8 @@ class ViewActions extends Component {
             this.setState({ filters: { severity }});
             options.severity = severity;
         } else {
-            this.setState({ filters: { category: this.props.match.params.type }});
-            options.category = this.props.match.params.type;
+            this.setState({ filters: { category: RULE_CATEGORIES[this.props.match.params.type] }});
+            options.category = RULE_CATEGORIES[this.props.match.params.type];
         }
 
         this.props.fetchRules(options);


### PR DESCRIPTION
to be merged with https://github.com/RedHatInsights/insights-advisor-api/pull/183

TODO: build the constant by querying `.../v1/rulecategory/`


### Just so you believe me... here's what this does
<img width="1203" alt="screen shot 2019-02-11 at 9 15 29 am" src="https://user-images.githubusercontent.com/6640236/52570027-7e83c580-2de0-11e9-939c-f282e36978b8.png">

### for that second commit, just so you believe me, cc @dkuc 
<img width="1060" alt="screen shot 2019-02-11 at 10 00 23 am" src="https://user-images.githubusercontent.com/6640236/52571635-edaee900-2de3-11e9-9f23-86141852b327.png">


### and because we now updated the dashboard to support total risk... this was done with mock data n such
<img width="1131" alt="screen shot 2019-02-11 at 1 49 55 pm" src="https://user-images.githubusercontent.com/6640236/52585952-31b1e600-2e04-11e9-8e50-9a00fee1dc88.png">
