### PR TITLE
Spaces are bad. We get rid of them so the get doesn't have `+`s

### DIFF
--- a/src/PresentationalComponents/Filters/Filters.js
+++ b/src/PresentationalComponents/Filters/Filters.js
@@ -23,7 +23,7 @@ class Filters extends Component {
     );
 
     addFilter = (param, value) => {
-        const newFilter = this.props.filters[param] ? { [param]: `${this.props.filters[param]}, ${value}` } : { [param]: value };
+        const newFilter = this.props.filters[param] ? { [param]: `${this.props.filters[param]},${value}` } : { [param]: value };
         this.props.setFilters({ ...this.props.filters, ...newFilter });
         this.props.fetchAction({ ...this.props.filters, ...newFilter });
     };


### PR DESCRIPTION
### see no spaces
<img width="1047" alt="screen shot 2019-02-14 at 3 44 56 pm" src="https://user-images.githubusercontent.com/6640236/52816548-82794700-306f-11e9-9232-222653cae1fb.png">
