### PR TITLE
Reconfigure all Actions table filters to configurable (including url)

### DIFF
--- a/src/PresentationalComponents/Filters/Filters.js
+++ b/src/PresentationalComponents/Filters/Filters.js
@@ -14,6 +14,13 @@ class Filters extends Component {
         this.props.setFilters({ });
     }
 
+    componentDidUpdate (prevProps) {
+        if (this.props.externalFilters !== prevProps.externalFilters) {
+            const filterKey = Object.keys(this.props.externalFilters)[0];
+            this.props.setFilters({ [filterKey]: `${this.props.externalFilters[filterKey]}` });
+        }
+    }
+
     changeSearchValue = debounce(
         value => {
             this.props.setFilters({ ...this.props.filters, text: value });
@@ -89,7 +96,8 @@ Filters.propTypes = {
     searchPlaceholder: PropTypes.string,
     filters: PropTypes.object,
     setFilters: PropTypes.func,
-    fetchAction: PropTypes.func
+    fetchAction: PropTypes.func,
+    externalFilters: PropTypes.object
 };
 
 const mapStateToProps = (state, ownProps) => ({

--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -39,7 +39,8 @@ class ViewActions extends Component {
         ],
         rows: [],
         sortBy: {},
-        localFilters: {},
+        sort: 'rule_id',
+        urlFilters: {},
         impacting: true,
         pageSize: 10,
         page: 1
@@ -51,10 +52,10 @@ class ViewActions extends Component {
 
         if (this.props.match.params.type.includes('-risk')) {
             const totalRisk = SEVERITY_MAP[this.props.match.params.type];
-            this.setState({ localFilters: { total_risk: totalRisk }});
+            this.setState({ urlFilters: { total_risk: totalRisk }});
             options.total_risk = totalRisk;
         } else {
-            this.setState({ localFilters: { category: RULE_CATEGORIES[this.props.match.params.type] }});
+            this.setState({ urlFilters: { category: RULE_CATEGORIES[this.props.match.params.type] }});
             options.category = RULE_CATEGORIES[this.props.match.params.type];
         }
 
@@ -121,14 +122,13 @@ class ViewActions extends Component {
                 index,
                 direction
             },
-            localFilters: { ...this.state.localFilters, sort: orderParam }
+            sort: orderParam
         });
         this.props.fetchRules({
             ...this.props.filters,
             page: 1,
             page_size: this.state.pageSize,
             impacting: this.state.impacting,
-            ...this.state.localFilters,
             sort: orderParam
         });
     };
@@ -146,14 +146,14 @@ class ViewActions extends Component {
                 page: newPage,
                 page_size: this.state.pageSize,
                 impacting: this.state.impacting,
-                ...this.state.localFilters
+                sort: this.state.sort
             });
         }
     };
 
     setPerPage = (pageSize) => {
         this.setState({ pageSize });
-        this.props.fetchRules({ ...this.props.filters, page: 1, page_size: pageSize, impacting: this.state.impacting, ...this.state.localFilters });
+        this.props.fetchRules({ ...this.props.filters, page: 1, page_size: pageSize, impacting: this.state.impacting, sort: this.state.sort });
     };
 
     parseUrlTitle = (title = '') => {
@@ -163,7 +163,7 @@ class ViewActions extends Component {
 
     render () {
         const { rulesFetchStatus, rules } = this.props;
-        const { localFilters, pageSize, page, impacting, sortBy, cols, rows } = this.state;
+        const { urlFilters, sort, pageSize, page, impacting, sortBy, cols, rows } = this.state;
         return (
             <React.Fragment>
                 <PageHeader>
@@ -184,10 +184,10 @@ class ViewActions extends Component {
                         <StackItem>
                             <TableToolbar>
                                 <Filters
-                                    fetchAction={ (filters) => this.props.fetchRules({ ...filters, pageSize, page, impacting, ...localFilters }) }
+                                    fetchAction={ (filters) => this.props.fetchRules({ ...filters, pageSize, page, impacting, sort }) }
                                     searchPlaceholder='Find a Rule'
                                     resultsCount={ rules.count }
-                                    hideCategories={ localFilters.total_risk ? [ 'total_risk' ] : [ 'category' ] }
+                                    externalFilters={ urlFilters }
                                 >
                                 </Filters>
                             </TableToolbar>


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHIADVISOR-446

Default sorting of rules is by rule_id ascending, `sort` hates empty params, so we pass the default in to keep it happy


tl;dr you can now clear filters set by the overview page (total_risk and category) this work does not include RHIADVISOR-445 

🌮 💃 