### PR TITLE
Abstracts ruletable to component, sets rules/actions lists to consume

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -1,0 +1,225 @@
+/* eslint camelcase: 0 */
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import { Ansible, Battery, Main, Pagination, routerParams, TableToolbar } from '@red-hat-insights/insights-frontend-components';
+import PropTypes from 'prop-types';
+import { debounce } from 'lodash';
+import { connect } from 'react-redux';
+import { Checkbox, Stack, StackItem } from '@patternfly/react-core';
+import { sortable, Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
+
+import * as AppActions from '../../AppActions';
+import Loading from '../../PresentationalComponents/Loading/Loading';
+import Failed from '../../PresentationalComponents/Loading/Failed';
+import Filters from '../../PresentationalComponents/Filters/Filters';
+
+class RulesTable extends Component {
+    state = {
+        summary: '',
+        cols: [
+            'Rule',
+            { title: 'Likelihood', transforms: [ sortable ]},
+            { title: 'Impact', transforms: [ sortable ]},
+            { title: 'Total Risk', transforms: [ sortable ]},
+            'Systems Exposed',
+            'Ansible'
+        ],
+        rows: [],
+        sortBy: {},
+        sort: 'rule_id',
+        urlFilters: {},
+        impacting: false,
+        pageSize: 10,
+        page: 1
+    };
+
+    async componentDidMount () {
+        const { page, pageSize } = this.state;
+        const impacting = this.props.impacting || this.state.impacting;
+        await insights.chrome.auth.getUser();
+        const options = { page, page_size: pageSize, impacting, ...this.props.urlFilters || {}};
+
+        this.props.fetchRules(options);
+        this.setState({ impacting, urlFilters: this.props.urlFilters || {}});
+    }
+
+    componentDidUpdate (prevProps) {
+        if (this.props.rules !== prevProps.rules) {
+            const rules = this.props.rules.results;
+            this.setState({ summary: this.props.rules.summary });
+
+            let rows = rules.map((value, key) => {
+                const linkTo = `/actions/${value.category.name.toLowerCase()}/${value.rule_id}`;
+
+                return {
+                    cells: [
+                        <>
+                            <Link key={ key } to={ linkTo }>
+                                { value.description }
+                            </Link>
+                        </>,
+                        <div className="pf-m-center" key={ key }>
+                            <Battery
+                                label='Likelihood'
+                                labelHidden
+                                severity={ value.likelihood }
+                            /></div>,
+                        <div className="pf-m-center" key={ key }>
+                            <Battery
+                                label='Impact'
+                                labelHidden
+                                severity={ value.impact.impact }
+                            />
+                        </div>,
+                        <div className="pf-m-center" key={ key }>
+                            <Battery
+                                label='Total Risk'
+                                labelHidden
+                                severity={ value.total_risk }
+                            />
+                        </div>,
+                        <div key={ key }>{ value.impacted_systems_count }</div>,
+                        <div className="pf-m-center" key={ key }>
+                            <Ansible unsupported={ !value.has_playbook }/>
+                        </div>
+                    ]
+                };
+            });
+
+            this.setState({ rows });
+        }
+    }
+
+    onSort = (_event, index, direction) => {
+        const attrIndex = {
+            1: 'likelihood',
+            2: 'impact',
+            3: 'total_risk'
+        };
+        const orderParam = `${direction === 'asc' ? '' : '-'}${attrIndex[index]}`;
+
+        this.setState({
+            sortBy: {
+                index,
+                direction
+            },
+            sort: orderParam,
+            page: 1
+        });
+        this.props.fetchRules({
+            ...this.props.filters,
+            page: 1,
+            page_size: this.state.pageSize,
+            impacting: this.state.impacting,
+            sort: orderParam
+        });
+    };
+
+    setPage = (newPage, textInput) => {
+        if (textInput) {
+            this.setState(
+                () => ({ page: newPage }),
+                debounce(() => this.setPage(newPage), 800)
+            );
+        } else {
+            this.setState({ page: newPage });
+            this.props.fetchRules({
+                ...this.props.filters,
+                page: newPage,
+                page_size: this.state.pageSize,
+                impacting: this.state.impacting,
+                sort: this.state.sort
+            });
+        }
+    };
+
+    setPerPage = (pageSize) => {
+        const { impacting, sort, page } = this.state;
+        this.setState({ pageSize });
+        this.props.fetchRules({ ...this.props.filters, page, page_size: pageSize, impacting, sort });
+    };
+
+    parseUrlTitle = (title = '') => {
+        const parsedTitle = title.split('-');
+        return parsedTitle.length > 1 ? `${parsedTitle[0]} ${parsedTitle[1]} Actions` : `${parsedTitle}`;
+    };
+
+    toggleRulesWithHits = (showRulesWithHits) => {
+        const { pageSize } = this.state;
+        this.setState({ impacting: showRulesWithHits });
+        this.props.fetchRules({
+            ...this.props.filters,
+            page_size: pageSize,
+            impacting: showRulesWithHits
+        });
+    };
+
+    render () {
+        const { rulesFetchStatus, rules } = this.props;
+        const { urlFilters, sort, pageSize, page, impacting, sortBy, cols, rows } = this.state;
+        return <Main>
+            <Stack gutter='md'>
+                <StackItem>
+                    <p>{ this.state.summary }</p>
+                </StackItem>
+                <StackItem>
+                    <TableToolbar>
+                        <Filters
+                            fetchAction={ (filters) => this.props.fetchRules({ ...filters, pageSize, page, impacting, sort }) }
+                            searchPlaceholder='Find a Rule'
+                            resultsCount={ rules.count }
+                            externalFilters={ urlFilters }
+                        >
+                            <Checkbox
+                                label="Show Rules With Hits"
+                                isChecked={ impacting }
+                                onChange={ this.toggleRulesWithHits }
+                                aria-label="InsightsRulesHideHits"
+                                id="InsightsRulesHideHits"
+                            />
+                        </Filters>
+                    </TableToolbar>
+                    { rulesFetchStatus === 'fulfilled' &&
+                    <Table variant={ TableVariant.compact } sortBy={ sortBy } onSort={ this.onSort } cells={ cols } rows={ rows }>
+                        <TableHeader/>
+                        <TableBody/>
+                    </Table> }
+                    { rulesFetchStatus === 'pending' && (<Loading/>) }
+                    { rulesFetchStatus === 'failed' && (<Failed message={ `There was an error fetching rules list.` }/>) }
+                    <TableToolbar>
+                        <Pagination
+                            numberOfItems={ rules.count || 0 }
+                            onPerPageSelect={ this.setPerPage }
+                            page={ page }
+                            onSetPage={ this.setPage }
+                            itemsPerPage={ pageSize }
+                        />
+                    </TableToolbar>
+                </StackItem>
+            </Stack>
+        </Main>;
+    }
+}
+
+RulesTable.propTypes = {
+    fetchRules: PropTypes.func,
+    rulesFetchStatus: PropTypes.string,
+    rules: PropTypes.object,
+    filters: PropTypes.object,
+    impacting: PropTypes.bool,
+    urlFilters: PropTypes.object
+};
+
+const mapStateToProps = (state, ownProps) => ({
+    rules: state.AdvisorStore.rules,
+    rulesFetchStatus: state.AdvisorStore.rulesFetchStatus,
+    filters: state.AdvisorStore.filters,
+    ...ownProps
+});
+
+const mapDispatchToProps = dispatch => ({ fetchRules: (url) => dispatch(AppActions.fetchRules(url)) });
+
+export default routerParams(connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(RulesTable));

--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -1,185 +1,35 @@
 /* eslint camelcase: 0 */
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
-import {
-    Ansible,
-    Battery,
-    Main,
-    PageHeader,
-    PageHeaderTitle,
-    Pagination,
-    routerParams,
-    TableToolbar
-} from '@red-hat-insights/insights-frontend-components';
+import { PageHeader, PageHeaderTitle } from '@red-hat-insights/insights-frontend-components';
 import PropTypes from 'prop-types';
-import { debounce } from 'lodash';
-import { connect } from 'react-redux';
-import { Checkbox, Stack, StackItem } from '@patternfly/react-core';
-import { sortable, Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
 
-import * as AppActions from '../../AppActions';
-import Loading from '../../PresentationalComponents/Loading/Loading';
-import Failed from '../../PresentationalComponents/Loading/Failed';
 import Breadcrumbs from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
 import { RULE_CATEGORIES, SEVERITY_MAP } from '../../AppConstants';
-import Filters from '../../PresentationalComponents/Filters/Filters';
-
-import './_actions.scss';
+import RulesTable from '../../PresentationalComponents/RulesTable/RulesTable';
 
 class ViewActions extends Component {
     state = {
-        summary: '',
-        cols: [
-            'Rule',
-            { title: 'Likelihood', transforms: [ sortable ]},
-            { title: 'Impact', transforms: [ sortable ]},
-            { title: 'Total Risk', transforms: [ sortable ]},
-            'Systems Exposed',
-            'Ansible'
-        ],
-        rows: [],
-        sortBy: {},
-        sort: 'rule_id',
         urlFilters: {},
-        impacting: true,
-        pageSize: 10,
-        page: 1
+        impacting: true
     };
 
     async componentDidMount () {
-        const { page, pageSize, impacting } = this.state;
-        await insights.chrome.auth.getUser();
-        const options = { page, page_size: pageSize, impacting };
-
         if (this.props.match.params.type.includes('-risk')) {
             const totalRisk = SEVERITY_MAP[this.props.match.params.type];
             this.setState({ urlFilters: { total_risk: totalRisk }});
-            options.total_risk = totalRisk;
         } else {
             this.setState({ urlFilters: { category: RULE_CATEGORIES[this.props.match.params.type] }});
-            options.category = RULE_CATEGORIES[this.props.match.params.type];
-        }
-
-        this.props.fetchRules(options);
-    }
-
-    componentDidUpdate (prevProps) {
-        if (this.props.rules !== prevProps.rules) {
-            const rules = this.props.rules.results;
-            this.setState({ summary: this.props.rules.summary });
-
-            let rows = rules.map((value, key) => {
-                return {
-                    cells: [
-                        <>
-                            <Link
-                                key={ key }
-                                to={ `/actions/${this.props.match.params.type}/${
-                                    value.rule_id
-                                }` }
-                            >
-                                { value.description }
-                            </Link>
-                        </>,
-                        <div className="pf-m-center" key={ key }>
-                            <Battery
-                                label='Likelihood'
-                                labelHidden
-                                severity={ value.likelihood }
-                            /></div>,
-                        <div className="pf-m-center" key={ key }>
-                            <Battery
-                                label='Impact'
-                                labelHidden
-                                severity={ value.impact.impact }
-                            />
-                        </div>,
-                        <div className="pf-m-center" key={ key }>
-                            <Battery
-                                label='Total Risk'
-                                labelHidden
-                                severity={ value.total_risk }
-                            />
-                        </div>,
-                        <div key={ key }>{ value.impacted_systems_count }</div>,
-                        <div className="pf-m-center" key={ key }>
-                            <Ansible unsupported={ !value.has_playbook }/>
-                        </div>
-                    ]
-                };
-            });
-
-            this.setState({ rows });
         }
     }
-
-    onSort = (_event, index, direction) => {
-        const attrIndex = {
-            1: 'likelihood',
-            2: 'impact',
-            3: 'total_risk'
-        };
-        const orderParam = `${direction === 'asc' ? '' : '-'}${attrIndex[index]}`;
-
-        this.setState({
-            sortBy: {
-                index,
-                direction
-            },
-            sort: orderParam,
-            page: 1
-        });
-        this.props.fetchRules({
-            ...this.props.filters,
-            page: 1,
-            page_size: this.state.pageSize,
-            impacting: this.state.impacting,
-            sort: orderParam
-        });
-    };
-
-    setPage = (newPage, textInput) => {
-        if (textInput) {
-            this.setState(
-                () => ({ page: newPage }),
-                debounce(() => this.setPage(newPage), 800)
-            );
-        } else {
-            this.setState({ page: newPage });
-            this.props.fetchRules({
-                ...this.props.filters,
-                page: newPage,
-                page_size: this.state.pageSize,
-                impacting: this.state.impacting,
-                sort: this.state.sort
-            });
-        }
-    };
-
-    setPerPage = (pageSize) => {
-        const { impacting, sort, page } = this.state;
-        this.setState({ pageSize });
-        this.props.fetchRules({ ...this.props.filters, page, page_size: pageSize, impacting, sort });
-    };
 
     parseUrlTitle = (title = '') => {
         const parsedTitle = title.split('-');
         return parsedTitle.length > 1 ? `${parsedTitle[0]} ${parsedTitle[1]} Actions` : `${parsedTitle}`;
     };
 
-    toggleRulesWithHits = (showRulesWithHits) => {
-        const { pageSize } = this.state;
-        this.setState({ impacting: showRulesWithHits });
-        this.props.fetchRules({
-            ...this.props.filters,
-            page_size: pageSize,
-            impacting: showRulesWithHits
-        });
-    };
-
     render () {
-        const { rulesFetchStatus, rules } = this.props;
-        const { urlFilters, sort, pageSize, page, impacting, sortBy, cols, rows } = this.state;
+        const { urlFilters, impacting } = this.state;
+
         return (
             <React.Fragment>
                 <PageHeader>
@@ -192,70 +42,14 @@ class ViewActions extends Component {
                         title={ this.parseUrlTitle(this.props.match.params.type) }
                     />
                 </PageHeader>
-                <Main>
-                    <Stack gutter='md'>
-                        <StackItem>
-                            <p>{ this.state.summary }</p>
-                        </StackItem>
-                        <StackItem>
-                            <TableToolbar>
-                                <Filters
-                                    fetchAction={ (filters) => this.props.fetchRules({ ...filters, pageSize, page, impacting, sort }) }
-                                    searchPlaceholder='Find a Rule'
-                                    resultsCount={ rules.count }
-                                    externalFilters={ urlFilters }
-                                >
-                                    <Checkbox
-                                        label="Show Rules With Hits"
-                                        isChecked={ impacting }
-                                        onChange={ this.toggleRulesWithHits }
-                                        aria-label="InsightsRulesHideHits"
-                                        id="InsightsRulesHideHits"
-                                    />
-                                </Filters>
-                            </TableToolbar>
-                            { rulesFetchStatus === 'fulfilled' &&
-                            <Table variant={ TableVariant.compact } sortBy={ sortBy } onSort={ this.onSort } cells={ cols } rows={ rows }>
-                                <TableHeader/>
-                                <TableBody/>
-                            </Table> }
-                            { rulesFetchStatus === 'pending' && (<Loading/>) }
-                            { rulesFetchStatus === 'failed' && (<Failed message={ `There was an error fetching rules list.` }/>) }
-                            <TableToolbar>
-                                <Pagination
-                                    numberOfItems={ rules.count }
-                                    onPerPageSelect={ this.setPerPage }
-                                    page={ page }
-                                    onSetPage={ this.setPage }
-                                    itemsPerPage={ pageSize }
-                                />
-                            </TableToolbar>
-                        </StackItem>
-                    </Stack>
-                </Main>
+                <RulesTable impacting={ impacting } urlFilters={ urlFilters }/>
             </React.Fragment>
         );
     }
 }
 
 ViewActions.propTypes = {
-    fetchRules: PropTypes.func,
-    match: PropTypes.any,
-    rulesFetchStatus: PropTypes.string,
-    rules: PropTypes.object,
-    filters: PropTypes.object
+    match: PropTypes.any
 };
 
-const mapStateToProps = (state, ownProps) => ({
-    rules: state.AdvisorStore.rules,
-    rulesFetchStatus: state.AdvisorStore.rulesFetchStatus,
-    filters: state.AdvisorStore.filters,
-    ...ownProps
-});
-
-const mapDispatchToProps = dispatch => ({ fetchRules: (url) => dispatch(AppActions.fetchRules(url)) });
-
-export default routerParams(connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(ViewActions));
+export default ViewActions;

--- a/src/SmartComponents/Actions/_actions.scss
+++ b/src/SmartComponents/Actions/_actions.scss
@@ -1,24 +1,5 @@
-@import '~@red-hat-insights/insights-frontend-components/Utilities/_variables';
-@import '~@red-hat-insights/insights-frontend-components/Utilities/_mixins';
-
 .page__actions {
-    .actions__view--title { text-transform: capitalize; }
-    .actions__view {
-        table.rules-table {
-            th:first-child { width: 50%; }
-            td {
-                padding: $ins-padding;
-                &:not(:first-of-type) { text-align: center; }
-            }
-            tfoot tr td:first-child { padding: 0; }
-        }
-    }
-}
-
-.actions__description { margin: $ins-margin 0; }
-
-@media only screen and (min-width: 768px) {
-    .ins-l-icon-group__vertical > *:not(:first-child) {
-        @include rem('margin-top', 5px);
-    }
+  .actions__view--title {
+    text-transform: capitalize;
+  }
 }

--- a/src/SmartComponents/Rules/ListRules.js
+++ b/src/SmartComponents/Rules/ListRules.js
@@ -1,152 +1,31 @@
-/* eslint camelcase: 0 */
 import React, { Component } from 'react';
-import { Main, Pagination, routerParams, TableToolbar } from '@red-hat-insights/insights-frontend-components';
+import { routerParams } from '@red-hat-insights/insights-frontend-components';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { Checkbox, Stack, StackItem } from '@patternfly/react-core';
-import debounce from 'lodash/debounce';
 
 import * as AppActions from '../../AppActions';
-import { SYSTEM_TYPES } from '../../AppConstants';
-import Filters from '../../PresentationalComponents/Filters/Filters';
-import Loading from '../../PresentationalComponents/Loading/Loading';
-import rulesCardSkeleton from '../../PresentationalComponents/Skeletons/RulesCard/RulesCardSkeleton.js';
-
-const RulesCard = rulesCardSkeleton(() => import('../../PresentationalComponents/Cards/RulesCard.js'));
+import RulesTable from '../../PresentationalComponents/RulesTable/RulesTable';
 
 class ListRules extends Component {
-    state = {
-        summary: '',
-        pageSize: 10,
-        page: 1,
-        cards: [],
-        impacting: true
-    };
-
     async componentDidMount () {
         await insights.chrome.auth.getUser();
         this.props.setBreadcrumbs([{ title: 'Rules', navigate: '/rules' }]);
-        this.props.fetchRules({ page: this.state.page, page_size: this.state.pageSize, impacting: this.state.impacting });
     }
 
-    componentDidUpdate (prevProps) {
-        if (this.props.rules !== prevProps.rules) {
-            const rules = this.props.rules.results;
-            const cards = rules.map((value, key) => {
-                const resolution_risk = value.resolution_set.find(resolution => resolution.system_type === SYSTEM_TYPES.rhel);
-                return <RulesCard
-                    key={ key }
-                    widget-id={ value }
-                    ruleID={ value.rule_id }
-                    category={ value.category.name }
-                    description={ value.description }
-                    summary={ value.summary }
-                    impact={ value.impact.impact }
-                    likelihood={ value.likelihood }
-                    totalRisk={ value.total_risk }
-                    riskOfChange={ resolution_risk ? resolution_risk.resolution_risk.risk : 0 }
-                    ansible={ value.has_playbook }
-                    hitCount={ value.impacted_systems_count }
-                />;
-            });
-            this.setState({ cards });
-        }
-    }
-
-    toggleRulesWithHits = (showRulesWithHits) => {
-        this.setState({ impacting: showRulesWithHits });
-        this.props.fetchRules({
-            ...this.props.filters,
-            page_size: this.state.pageSize,
-            impacting: showRulesWithHits
-        });
-    };
-
-    setPage = (newPage, textInput) => {
-        if (textInput) {
-            this.setState(
-                () => ({ page: newPage }),
-                debounce(() => this.setPage(newPage), 800)
-            );
-        } else {
-            this.setState({ page: newPage });
-            this.props.fetchRules({ ...this.props.filters, page: newPage, page_size: this.state.pageSize, impacting: this.state.impacting });
-        }
-    };
-
-    setPerPage = (pageSize) => {
-        this.setState({ pageSize });
-        this.props.fetchRules({ ...this.props.filters, page: 1, page_size: pageSize, impacting: this.state.impacting });
-    };
-
-    render () {
-        const { rulesFetchStatus, rules } = this.props;
-        const { pageSize, page, impacting } = this.state;
-        return (
-            <Main>
-                <Stack gutter='md'>
-                    <StackItem className='advisor-l-actions__filters'>
-                        <Filters
-                            fetchAction={ (filters) => this.props.fetchRules({ ...filters, pageSize, page, impacting }) }
-                            searchPlaceholder='Find a Rule'
-                            resultsCount={ rules.count }
-                        >
-                            <Checkbox
-                                label="Show Rules With Hits"
-                                isChecked={ impacting }
-                                onChange={ this.toggleRulesWithHits }
-                                aria-label="InsightsRulesHideHits"
-                                id="InsightsRulesHideHits"
-                            />
-                        </Filters>
-                    </StackItem>
-                    <StackItem>
-                        { rulesFetchStatus === 'fulfilled' &&
-                        <>
-                            { this.state.cards }
-                            <TableToolbar>
-                                <Pagination
-                                    useNext
-                                    numberOfItems={ rules.count }
-                                    onPerPageSelect={ this.setPerPage }
-                                    onSetPage={ this.setPage }
-                                    page={ page }
-                                    itemsPerPage={ pageSize }
-                                />
-                            </TableToolbar>
-                        </>
-                        }
-                        { rulesFetchStatus === 'pending' && (<Loading/>) }
-                    </StackItem>
-                </Stack>
-            </Main>
-        );
-    };
+    render = () => <RulesTable/>;
 }
 
 ListRules.displayName = 'list-rules';
-
 ListRules.propTypes = {
-    breadcrumbs: PropTypes.array,
-    fetchRules: PropTypes.func,
-    match: PropTypes.object,
-    rulesFetchStatus: PropTypes.string,
-    rules: PropTypes.object,
-    setBreadcrumbs: PropTypes.func,
-    filters: PropTypes.object
+    setBreadcrumbs: PropTypes.func
 };
 
 const mapStateToProps = (state, ownProps) => ({
-    breadcrumbs: state.AdvisorStore.breadcrumbs,
-    filters: state.AdvisorStore.filters,
-    rules: state.AdvisorStore.rules,
-    rulesFetchStatus: state.AdvisorStore.rulesFetchStatus,
     ...ownProps
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({
-    fetchRules: (url) => AppActions.fetchRules(url),
     setBreadcrumbs: (obj) => AppActions.setBreadcrumbs(obj)
 }, dispatch);
 


### PR DESCRIPTION
tl;dr - "Rules" tab now navigates to a unfiltered rule table!  yay. and this dry's out a bunch of stuff, more to folllllloooooowwwww

Fixes https://projects.engineering.redhat.com/browse/RHIADVISOR-450

SO this pr begets another, one where we do a crap tonne of cleanup, removing unused components n such, also right now, `ListRules` and `ViewActions` do the same thing (act as a 🏠 for rulestable) and should be named the same, thinking of renaming `ViewActions to `ListActions` and renaming `ListActions to... something that makes sense... cuz its the component for viewing a single rule

### what rules now looks like
<img width="1222" alt="screen shot 2019-03-04 at 10 50 32 am" src="https://user-images.githubusercontent.com/6640236/53744622-5e897400-3e6b-11e9-928c-187451d9cb33.png">
