### PR TITLE
Adds expandable table to rules table

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -61,9 +61,9 @@ export const FILTER_CATEGORIES = [
     }
 ];
 export const RISK_OF_CHANGE_DESC = {
-    1: 'The change takes very little time to implement and there is minimal impact to system operations. These are typically configuration changes that do not impact a running kernel or service. These changes can be made by modifying a line or file; the change that is taken is immediate and does not impact the system itself.',
-    2: 'Typically, these changes do not require that a system be taken offline. They are safe to make and even if executed incorrectly, will still leave the systemin a usable state.',
-    3: 'These will likely require an outage window. If these changes are executed incorrectly, they can leave the system in a severely degraded state.',
+    1: 'The change takes very little time to implement and there is minimal impact to system operations.',
+    2: 'Typically, these changes do not require that a system be taken offline.',
+    3: 'These will likely require an outage window.',
     4: 'The change takes a significant amount of time and planning to execute, and will impact the system and business operations of the host due to downtime.'
 };
 export const IMPACT_LABEL = { 1: 'Low', 2: 'Medium', 3: 'High', 4: 'Critcal' };

--- a/src/PresentationalComponents/RuleDetails/RuleDetails.js
+++ b/src/PresentationalComponents/RuleDetails/RuleDetails.js
@@ -1,6 +1,6 @@
 /* eslint max-len: 0 */
 import React, { Component } from 'react';
-import { Battery, Shield, routerParams } from '@red-hat-insights/insights-frontend-components';
+import { Battery, Shield } from '@red-hat-insights/insights-frontend-components';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
@@ -8,9 +8,7 @@ import { Grid, GridItem } from '@patternfly/react-core';
 import { addNotification } from '@red-hat-insights/insights-frontend-components/components/Notifications';
 import ReactMarkdown from 'react-markdown/with-html';
 
-import * as AppActions from '../../AppActions';
 import * as AppConstants from '../../AppConstants';
-import Loading from '../../PresentationalComponents/Loading/Loading';
 import API from '../../Utilities/Api';
 import './_RuleDetails.scss';
 
@@ -18,18 +16,16 @@ class RuleDetails extends Component {
     state = {
         kbaDetails: {},
         kbaDetailsLoading: false
-    }
+    };
 
-    componentDidUpdate () {
-        if (this.props.ruleFetchStatus === 'fulfilled' && !this.state.kbaDetailsLoading) {
-            this.setState({ kbaDetailsLoading: true });
-            this.fetchKbaDetails();
-        }
+    componentDidMount () {
+        this.fetchKbaDetails();
     }
 
     async fetchKbaDetails () {
         try {
-            const kbaDetails = (await API.get(`/rs/search?q=id:${this.props.rule.node_id }`)).data.response.docs[0];
+            this.setState({ kbaDetailsLoading: true });
+            const kbaDetails = (await API.get(`/rs/search?q=id:${this.props.rule.node_id}`)).data.response.docs[0];
             this.setState({ kbaDetails });
         } catch (error) {
             this.props.addNotification({
@@ -41,146 +37,107 @@ class RuleDetails extends Component {
         }
     }
 
-    getSelectedItems = () => {
-        if (!this.props.entities || !this.props.entities.loaded) {
-            return [];
-        }
-
-        return this.props.entities.rows.filter(entity => entity.selected).map(entity => entity.id);
-    }
-
-    remediationDataProvider = () => {
-        return {
-            issues: [{
-                id: `advisor:${this.props.rule.rule_id}`,
-                description: this.props.rule.description
-            }],
-            systems: this.getSelectedItems()
-        };
-    }
-
     ruleResolutionRisk = (rule) => {
         return (rule.resolution_set.find(resolution => resolution.system_type === AppConstants.SYSTEM_TYPES.rhel).resolution_risk.risk);
     };
 
-    ruleRebootRequired = (rule) => {
-        return rule.resolution_set.find(resolution => resolution.system_type === AppConstants.SYSTEM_TYPES.rhel).resolution_risk.reboot_required;
-    };
-
     render () {
-        const { children, className, ruleFetchStatus, rule } = this.props;
+        const { children, className, rule } = this.props;
         const { kbaDetails } = this.state;
         return (
-            <>
-                { ruleFetchStatus === 'pending' && (<Loading/>) }
-                { ruleFetchStatus === 'fulfilled' && (
-                    <Grid gutter='md' className={ className }>
-                        <GridItem md={ 8 } sm={ 12 }>
-                            <Grid>
-                                <GridItem className='pf-u-pb-md'>
-                                    {
-                                        typeof rule.summary === 'string' &&
-                                        Boolean(rule.summary) &&
-                                        <ReactMarkdown source={ rule.summary } escapeHtml={ false }/>
-                                    }
-                                </GridItem>
-                                { kbaDetails.view_uri && (
-                                    <GridItem className='pf-u-pb-md'>
-                                        <a href={ kbaDetails.view_uri }>
-                                            Knowledgebase Article
-                                        </a>
-                                    </GridItem>
-                                ) }
-                                { rule.tags && (
-                                    <GridItem>
-                                        Find Other Rules Related To:<br />
-                                        { rule.tags.replace(/ /g, ', ') }
-                                    </GridItem>
-                                ) }
-                            </Grid>
+            <Grid gutter='md' className={ className }>
+                <GridItem md={ 8 } sm={ 12 }>
+                    <Grid>
+                        <GridItem className='pf-u-pb-md'>
+                            {
+                                typeof rule.summary === 'string' &&
+                                Boolean(rule.summary) &&
+                                <ReactMarkdown source={ rule.summary } escapeHtml={ false }/>
+                            }
                         </GridItem>
-                        <GridItem md={ 4 } sm={ 12 }>
-                            <Grid gutter='sm'>
-                                { children && (
-                                    <GridItem>
-                                        { children }
-                                    </GridItem>
-                                ) }
-                                <GridItem className='pf-u-pb-md' sm={ 8 } md={ 12 }>
-                                    <div>Total Risk</div>
-                                    <div className='pf-u-display-inline-flex pf-m-align-center pf-u-pb-sm pf-u-pt-sm'>
-                                        <div className='pf-u-display-inline-flex'>
-                                            <Battery
-                                                label=''
-                                                severity={ rule.total_risk }
-                                            />
-                                        </div>
-                                        <div className='pf-u-display-inline-flex'>
-                                            <span className={ `label pf-u-pl-sm ins-sev-clr-${rule.total_risk}` }>
-                                                { AppConstants.TOTAL_RISK_LABEL[rule.total_risk] || 'Undefined' }
-                                            </span>
-                                        </div>
-                                    </div>
-                                    <p>
-                                        { `The likelihood that this will be a problem is ${AppConstants.LIKELIHOOD_LABEL[rule.likelihood] || 'Undefined'}. ` }
-                                        { `The impact of the problem would be ${AppConstants.IMPACT_LABEL[rule.impact.impact] || 'Undefined'} if it occurred.` }
-                                    </p>
-                                </GridItem>
-                                <GridItem sm={ 4 } md={ 12 } className='pf-l-flex'>
-                                    <div>Risk of Change</div>
-                                    <div className='pf-u-display-inline-flex pf-m-align-center pf-u-pb-sm pf-u-pt-sm'>
-                                        <div className='pf-u-display-inline-flex'>
-                                            <Shield
-                                                hasTooltip={ false }
-                                                impact={ this.ruleResolutionRisk(rule) }
-                                                size={ 'md' }
-                                                title={ AppConstants.RISK_OF_CHANGE_LABEL[this.ruleResolutionRisk(rule)] || 'Undefined' }
-                                            />
-                                        </div>
-                                        <div className='pf-u-display-inline-flex'>
-                                            <span className={ `label pf-u-pl-sm ins-sev-clr-${this.ruleResolutionRisk(rule)}` }>
-                                                { AppConstants.RISK_OF_CHANGE_LABEL[this.ruleResolutionRisk(rule)] || 'Undefined' }
-                                            </span>
-                                        </div>
-                                    </div>
-                                    <p>{ AppConstants.RISK_OF_CHANGE_DESC[this.ruleResolutionRisk(rule)] }</p>
-                                </GridItem>
-                                { this.ruleRebootRequired && (<GridItem>
-                                    <span className='ins-sev-clr-4'>Restart Required</span>
-                                </GridItem>) }
-                            </Grid>
-                        </GridItem>
+                        { kbaDetails.view_uri && (
+                            <GridItem className='pf-u-pb-md'>
+                                <a href={ kbaDetails.view_uri }>
+                                    Knowledgebase Article
+                                </a>
+                            </GridItem>
+                        ) }
+                        { rule.tags && (
+                            <GridItem>
+                                Find Other Rules Related To:<br/>
+                                { rule.tags.replace(/ /g, ', ') }
+                            </GridItem>
+                        ) }
                     </Grid>
-                ) }
-            </>
+                </GridItem>
+                <GridItem md={ 4 } sm={ 12 }>
+                    <Grid gutter='sm'>
+                        { children && (
+                            <GridItem>
+                                { children }
+                            </GridItem>
+                        ) }
+                        <GridItem className='pf-u-pb-md' sm={ 8 } md={ 12 }>
+                            <div>Total Risk</div>
+                            <div className='pf-u-display-inline-flex pf-m-align-center pf-u-pb-sm pf-u-pt-sm'>
+                                <div className='pf-u-display-inline-flex'>
+                                    <Battery
+                                        label=''
+                                        severity={ rule.total_risk }
+                                    />
+                                </div>
+                                <div className='pf-u-display-inline-flex'>
+                                    <span className={ `label pf-u-pl-sm ins-sev-clr-${rule.total_risk}` }>
+                                        { AppConstants.TOTAL_RISK_LABEL[rule.total_risk] || 'Undefined' }
+                                    </span>
+                                </div>
+                            </div>
+                            <p>
+                                { `The likelihood that this will be a problem is ${AppConstants.LIKELIHOOD_LABEL[rule.likelihood] || 'Undefined'}. ` }
+                                { `The impact of the problem would be ${AppConstants.IMPACT_LABEL[rule.impact.impact] || 'Undefined'} if it occurred.` }
+                            </p>
+                        </GridItem>
+                        <GridItem sm={ 4 } md={ 12 } className='pf-l-flex'>
+                            <div>Risk of Change</div>
+                            <div className='pf-u-display-inline-flex pf-m-align-center pf-u-pb-sm pf-u-pt-sm'>
+                                <div className='pf-u-display-inline-flex'>
+                                    <Shield
+                                        hasTooltip={ false }
+                                        impact={ this.ruleResolutionRisk(rule) }
+                                        size={ 'md' }
+                                        title={ AppConstants.RISK_OF_CHANGE_LABEL[this.ruleResolutionRisk(rule)] || 'Undefined' }
+                                    />
+                                </div>
+                                <div className='pf-u-display-inline-flex'>
+                                    <span className={ `label pf-u-pl-sm ins-sev-clr-${this.ruleResolutionRisk(rule)}` }>
+                                        { AppConstants.RISK_OF_CHANGE_LABEL[this.ruleResolutionRisk(rule)] || 'Undefined' }
+                                    </span>
+                                </div>
+                            </div>
+                            <p>{ AppConstants.RISK_OF_CHANGE_DESC[this.ruleResolutionRisk(rule)] }</p>
+                        </GridItem>
+                        { rule.reboot_required && (<GridItem>
+                            <span className='ins-sev-clr-4'>Restart Required</span>
+                        </GridItem>) }
+                    </Grid>
+                </GridItem>
+            </Grid>
         );
     }
 }
 
 RuleDetails.propTypes = {
-    addNotification: PropTypes.func.isRequired,
+    addNotification: PropTypes.func,
     children: PropTypes.any,
     className: PropTypes.string,
-    entities: PropTypes.any,
-    fetchRule: PropTypes.func,
-    fetchSystem: PropTypes.func,
-    rule: PropTypes.object,
-    ruleFetchStatus: PropTypes.string
+    rule: PropTypes.object
 };
 
-const mapStateToProps = (state, ownProps) => ({
-    entities: state.entities,
-    ruleFetchStatus: state.AdvisorStore.ruleFetchStatus,
-    ...state,
-    ...ownProps
-});
-
 const mapDispatchToProps = dispatch => bindActionCreators({
-    addNotification: data => addNotification(data),
-    fetchSystem: (url) => AppActions.fetchSystem(url)
+    addNotification: data => addNotification(data)
 }, dispatch);
 
-export default routerParams(connect(
-    mapStateToProps,
+export default connect(
+    null,
     mapDispatchToProps
-)(RuleDetails));
+)(RuleDetails);

--- a/src/PresentationalComponents/RuleDetails/RuleDetails.js
+++ b/src/PresentationalComponents/RuleDetails/RuleDetails.js
@@ -1,6 +1,6 @@
 /* eslint max-len: 0 */
 import React, { Component } from 'react';
-import { Battery, Shield } from '@red-hat-insights/insights-frontend-components';
+import { Battery, Shield, Reboot } from '@red-hat-insights/insights-frontend-components';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
@@ -116,9 +116,7 @@ class RuleDetails extends Component {
                             </div>
                             <p>{ AppConstants.RISK_OF_CHANGE_DESC[this.ruleResolutionRisk(rule)] }</p>
                         </GridItem>
-                        { rule.reboot_required && (<GridItem>
-                            <span className='ins-sev-clr-4'>Restart Required</span>
-                        </GridItem>) }
+                        { rule.reboot_required && <Reboot red/> }
                     </Grid>
                 </GridItem>
             </Grid>

--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -31,7 +31,7 @@ class ListActions extends Component {
         }
 
         return this.props.entities.rows.filter(entity => entity.selected).map(entity => entity.id);
-    }
+    };
 
     remediationDataProvider = () => {
         return {
@@ -41,11 +41,11 @@ class ListActions extends Component {
             }],
             systems: this.getSelectedItems()
         };
-    }
+    };
 
     onRemediationCreated = result => {
         this.props.addNotification(result.getNotification());
-    }
+    };
 
     render () {
         const { match, ruleFetchStatus, rule, systemFetchStatus, system } = this.props;
@@ -53,26 +53,26 @@ class ListActions extends Component {
             <React.Fragment>
                 { ruleFetchStatus === 'fulfilled' && (
                     <>
-                    <PageHeader>
-                        <Breadcrumbs
-                            current={ rule.description || '' }
-                            match={ match }
-                        />
-                        <PageHeaderTitle title={ rule.description || '' }/>
-                        <p>Publish Date: { `${(new Date(rule.publish_date)).toLocaleDateString()}` }</p>
-                    </PageHeader>
-                    <Main className='pf-m-light pf-u-pt-sm'>
-                        <RuleDetails rule={ rule }>
-                            { rule.has_playbook && (
-                                <RemediationButton
-                                    isDisabled={ this.getSelectedItems().length === 0 }
-                                    dataProvider={ this.remediationDataProvider }
-                                    onRemediationCreated={ this.onRemediationCreated }
-                                />
-                            ) }
-                        </RuleDetails>
-                    </Main>
-                </>
+                        <PageHeader>
+                            <Breadcrumbs
+                                current={ rule.description || '' }
+                                match={ match }
+                            />
+                            <PageHeaderTitle title={ rule.description || '' }/>
+                            <p>Publish Date: { `${(new Date(rule.publish_date)).toLocaleDateString()}` }</p>
+                        </PageHeader>
+                        <Main className='pf-m-light pf-u-pt-sm'>
+                            <RuleDetails rule={ rule }>
+                                { rule.playbook_count && (
+                                    <RemediationButton
+                                        isDisabled={ this.getSelectedItems().length === 0 }
+                                        dataProvider={ this.remediationDataProvider }
+                                        onRemediationCreated={ this.onRemediationCreated }
+                                    />
+                                ) }
+                            </RuleDetails>
+                        </Main>
+                    </>
                 ) }
                 { ruleFetchStatus === 'pending' && (<Loading/>) }
                 <Main>


### PR DESCRIPTION
### look paw, no hands
<img width="1437" alt="screen shot 2019-03-08 at 7 26 44 am" src="https://user-images.githubusercontent.com/6640236/54029718-6735bf00-4177-11e9-9c7e-f38582b59735.png">
<img width="1436" alt="screen shot 2019-03-08 at 7 26 23 am" src="https://user-images.githubusercontent.com/6640236/54029719-6735bf00-4177-11e9-8e0b-dc31a60b7887.png">


don't worry about the ansible icon being black (or the change from `has_playbook` to `playbook_count` this is a change already present on ci)