### PR TITLE
Adds header to kba request, avoids throwing an xml parsing error in ff

### DIFF
--- a/src/PresentationalComponents/RuleDetails/RuleDetails.js
+++ b/src/PresentationalComponents/RuleDetails/RuleDetails.js
@@ -25,7 +25,8 @@ class RuleDetails extends Component {
     async fetchKbaDetails () {
         try {
             this.setState({ kbaDetailsLoading: true });
-            const kbaDetails = (await API.get(`/rs/search?q=id:${this.props.rule.node_id}`)).data.response.docs[0];
+            const kbaDetails = (await API.get(`/rs/search?q=id:${this.props.rule.node_id}`,
+                { Accept: 'application/vnd.redhat.solr+json' })).data.response.docs[0];
             this.setState({ kbaDetails });
         } catch (error) {
             this.props.addNotification({


### PR DESCRIPTION
Response headers
```
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
access-control-allow-methods: POST, GET, OPTIONS, DELETE, PUT
access-control-allow-headers: Content-Type, X-PINGOTHER, X-Omit, Authorization
access-control-allow-credentials: true
server: Apache-Coyote/1.1
cache-control: private
expires: Thu, 01 Jan 1970 00:00:00 UTC
access-control-max-age: 1728000
access-control-expose-headers: Content-Length, Location, View-Uri, view_uri, Uri
content-type: application/vnd.redhat.solr+json
content-encoding: gzip
vary: Accept-Encoding
date: Fri, 08 Mar 2019 16:23:32 GMT
connection: close
set-cookie: strata_auth_type=JWT_AUTH
3af49a4941ac0b71696b53a498d081ee=90ef3f4add2beecdc2bfa6b22d128542; path=/; HttpOnly
transfer-encoding: chunked
```

###and no error in ff!
<img width="1920" alt="screen shot 2019-03-08 at 11 30 58 am" src="https://user-images.githubusercontent.com/6640236/54041419-ad9a1680-4195-11e9-8b4f-e265a447e7a3.png">
