### PR TITLE
Title.split creates array, address by index, fixes overview chart nav

### DIFF
--- a/src/SmartComponents/Actions/ListActions.js
+++ b/src/SmartComponents/Actions/ListActions.js
@@ -25,7 +25,7 @@ class ViewActions extends Component {
 
     parseUrlTitle = (title = '') => {
         const parsedTitle = title.split('-');
-        return parsedTitle.length > 1 ? `${capitalize(parsedTitle[0])} ${capitalize(parsedTitle[1])} Actions` : `${capitalize(parsedTitle)}`;
+        return parsedTitle.length > 1 ? `${capitalize(parsedTitle[0])} ${capitalize(parsedTitle[1])} Actions` : `${capitalize(parsedTitle[0])}`;
     };
 
     render () {


### PR DESCRIPTION
Fixes what #224 broke

Chart nav from overview to rule table is now fixed