### PR TITLE
Resets page to 1 whenever any filtering is performed, keeps the api 😊

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -227,9 +227,18 @@ class RulesTable extends Component {
             }];
     };
 
+    fetchAction = (filters) => {
+        const { sort, pageSize, impacting } = this.state;
+        this.setState({
+            page: 1
+        });
+        this.props.fetchRules({ ...filters, pageSize, page: 1, impacting, sort });
+
+    };
+
     render () {
         const { rulesFetchStatus, rules } = this.props;
-        const { urlFilters, sort, pageSize, page, impacting, sortBy, cols, rows } = this.state;
+        const { urlFilters, pageSize, page, impacting, sortBy, cols, rows } = this.state;
         return <Main>
             <Stack gutter='md'>
                 <StackItem>
@@ -238,7 +247,7 @@ class RulesTable extends Component {
                 <StackItem>
                     <TableToolbar className='pf-u-justify-content-space-between' results={ rules.count }>
                         <Filters
-                            fetchAction={ (filters) => this.props.fetchRules({ ...filters, pageSize, page, impacting, sort }) }
+                            fetchAction={ this.fetchAction }
                             searchPlaceholder='Find a Rule'
                             externalFilters={ urlFilters }
                         >


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-522

### see we can search for dank without it blowing up
<img width="1052" alt="Screen Shot 2019-03-25 at 11 29 17 AM" src="https://user-images.githubusercontent.com/6640236/54933624-65982500-4ef3-11e9-8efe-94a293592ba2.png">
