### PR TITLE
Incorrectly displaying 0 for remediation button when playbook_count === 0

### DIFF
--- a/src/SmartComponents/Actions/ViewActions.js
+++ b/src/SmartComponents/Actions/ViewActions.js
@@ -63,7 +63,7 @@ class ListActions extends Component {
                         </PageHeader>
                         <Main className='pf-m-light pf-u-pt-sm'>
                             <RuleDetails rule={ rule }>
-                                { rule.playbook_count && (
+                                { rule.playbook_count.length && (
                                     <RemediationButton
                                         isDisabled={ this.getSelectedItems().length === 0 }
                                         dataProvider={ this.remediationDataProvider }


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-552

### after
<img width="1051" alt="Screen Shot 2019-03-25 at 11 40 03 AM" src="https://user-images.githubusercontent.com/6640236/54934521-076c4180-4ef5-11e9-94bb-d74a232ecf9f.png">

### before
<img width="1052" alt="Screen Shot 2019-03-25 at 11 39 43 AM" src="https://user-images.githubusercontent.com/6640236/54934524-0804d800-4ef5-11e9-8acb-3fc3e5a315cf.png">
