### PR TITLE
Restores donut outer most div, dashboard doesn't scale well without

### DIFF
--- a/src/PresentationalComponents/Charts/ActionsOverviewDonut.js
+++ b/src/PresentationalComponents/Charts/ActionsOverviewDonut.js
@@ -107,17 +107,19 @@ class AdvisorOverviewDonut extends React.Component {
         </svg>;
         const typeNames = [ 'Availability', 'Stability', 'Performance', 'Security' ];
 
-        return <Grid className={ `chart-inline ${className}` }>
-            <GridItem span={ 6 }>
-                <div className="chart-container">
-                    { label }
-                    { this.getChart(ChartTheme.light.multi, typeNames) }
-                </div>
-            </GridItem>
-            <GridItem aria-label="Chart legend" span={ 6 }>
-                { this.getLegend(ChartTheme.light.multi, typeNames) }
-            </GridItem>
-        </Grid>;
+        return <div className={ `chart-inline ${className}` }>
+            <Grid>
+                <GridItem span={ 6 }>
+                    <div className="chart-container">
+                        { label }
+                        { this.getChart(ChartTheme.light.multi, typeNames) }
+                    </div>
+                </GridItem>
+                <GridItem aria-label="Chart legend" span={ 6 }>
+                    { this.getLegend(ChartTheme.light.multi, typeNames) }
+                </GridItem>
+            </Grid>
+        </div>;
     }
 }
 


### PR DESCRIPTION
slight roll back from #251
fixes #253 

### looks fine for both sizes
<img width="638" alt="Screen Shot 2019-03-26 at 7 10 34 AM" src="https://user-images.githubusercontent.com/6640236/54992692-4a322600-4f96-11e9-9820-83712e527bb4.png">
<img width="1267" alt="Screen Shot 2019-03-26 at 7 10 22 AM" src="https://user-images.githubusercontent.com/6640236/54992693-4a322600-4f96-11e9-966a-0dac378e93a5.png">
