### PR TITLE
Fixes misplaced empty donut style, rendering unnecessary 0, and severity chart hit misreporting

### DIFF
--- a/src/PresentationalComponents/Charts/SummaryChart/SummaryChart.js
+++ b/src/PresentationalComponents/Charts/SummaryChart/SummaryChart.js
@@ -10,7 +10,7 @@ const SummaryChartItem = asyncComponent(() => import('./SummaryChartItem'));
 
 const SummaryChart = (props) => {
     const noHits = [];
-    const hitsBuilder = (totalRisk, totalIssues) => Object.entries(totalRisk).map(([ key, value ]) => {
+    const hitsBuilder = (rulesTotalRisk, totalIssues) => Object.entries(rulesTotalRisk).map(([ key, value ]) => {
         const riskName = invert(SEVERITY_MAP)[key];
         const normalizedRiskName = capitalize(riskName.split('-')[0]);
         if (value) {
@@ -19,12 +19,12 @@ const SummaryChart = (props) => {
                 riskName={ riskName }
                 name={ normalizedRiskName }
                 numIssues={ value }
-                affectedSystems={ totalIssues }/>;
+                affectedSystems={ totalIssues[key] }/>;
         } else {
             noHits.push(`No ${normalizedRiskName.toLocaleLowerCase()} hits.`);
         }
     });
-    const rulesWithHits = hitsBuilder(props.totalRisk, props.totalIssues).reverse();
+    const rulesWithHits = hitsBuilder(props.rulesTotalRisk, props.reportsTotalRisk).reverse();
 
     return <Stack
         style={ { marginTop: 18 } }
@@ -44,8 +44,8 @@ const SummaryChart = (props) => {
 };
 
 SummaryChart.propTypes = {
-    totalRisk: PropTypes.object,
-    totalIssues: PropTypes.number
+    rulesTotalRisk: PropTypes.object,
+    reportsTotalRisk: PropTypes.object
 };
 
 export default SummaryChart;

--- a/src/PresentationalComponents/Charts/SummaryChart/SummaryChart.js
+++ b/src/PresentationalComponents/Charts/SummaryChart/SummaryChart.js
@@ -32,7 +32,7 @@ const SummaryChart = (props) => {
         { rulesWithHits.filter(Boolean).length > 0 ?
             <>
                 { rulesWithHits }
-                { noHits.length &&
+                { noHits.length > 0 &&
                 <StackItem className="disabled border-top">
                     <p>{ noHits }</p>
                 </StackItem>

--- a/src/SmartComponents/Actions/ActionsOverview.js
+++ b/src/SmartComponents/Actions/ActionsOverview.js
@@ -14,7 +14,8 @@ const ActionsOverviewDonut = asyncComponent(() => import('../../PresentationalCo
 
 class ActionsOverview extends Component {
     state = {
-        totalRisk: {},
+        rulesTotalRisk: {},
+        reportsTotalRisk: {},
         total: 0,
         category: []
     };
@@ -28,7 +29,7 @@ class ActionsOverview extends Component {
     componentDidUpdate (prevProps) {
         if (this.props.stats !== prevProps.stats) {
             const rules = this.props.stats.rules;
-            this.setState({ totalRisk: rules.total_risk });
+            this.setState({ rulesTotalRisk: rules.total_risk, reportsTotalRisk: this.props.stats.reports.total_risk });
             this.setState({
                 category: [ rules.category.Availability, rules.category.Stability, rules.category.Performance, rules.category.Security ]
             });
@@ -40,9 +41,7 @@ class ActionsOverview extends Component {
         const {
             statsFetchStatus
         } = this.props;
-
-        const { totalRisk, category, total } = this.state;
-
+        const { rulesTotalRisk, reportsTotalRisk, category } = this.state;
         return <>
             <PageHeader>
                 <PageHeaderTitle title='Overview'/>
@@ -52,7 +51,7 @@ class ActionsOverview extends Component {
                     <GalleryItem>
                         <Title size='lg' headingLevel='h3'>Rule hits by severity</Title>
                         { statsFetchStatus === 'fulfilled' && (
-                            <SummaryChart totalRisk={ totalRisk } totalIssues={ total }/>
+                            <SummaryChart rulesTotalRisk={ rulesTotalRisk } reportsTotalRisk={ reportsTotalRisk }/>
                         ) }
                         { statsFetchStatus === 'pending' && (<Loading/>) }
                     </GalleryItem>


### PR DESCRIPTION
<img width="1230" alt="Screen Shot 2019-04-03 at 3 23 56 PM" src="https://user-images.githubusercontent.com/6640236/55507406-9a0f8d80-5625-11e9-9275-975fbdb2006d.png">

<img width="1108" alt="Screen Shot 2019-04-03 at 3 40 34 PM" src="https://user-images.githubusercontent.com/6640236/55507949-d8f21300-5626-11e9-939b-389d4b1f4de9.png">


<img width="1037" alt="Screen Shot 2019-04-03 at 4 37 05 PM" src="https://user-images.githubusercontent.com/6640236/55511753-5752b300-562f-11e9-9472-decd2d17c498.png">

