### PR TITLE
Resolves routing issues for `/insights`, `/insights/` and `/insights/actions`

### DIFF
--- a/src/PresentationalComponents/Charts/ActionsOverviewDonut.js
+++ b/src/PresentationalComponents/Charts/ActionsOverviewDonut.js
@@ -87,7 +87,7 @@ class AdvisorOverviewDonut extends React.Component {
 
     render () {
         const { className, category } = this.props;
-        const totalHits = category.reduce((sum, curr) => sum + curr);
+        const totalHits = category.length ? category.reduce((sum, curr) => sum + curr) : 0;
         const label = <svg className="chart-label" height={ 1 }>
             <ChartLabel
                 style={ { fontSize: 20 } }

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,8 +1,7 @@
-import { matchPath, Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import React from 'react';
 import asyncComponent from './Utilities/asyncComponent';
-import some from 'lodash/some';
 
 /**
  * Aysnc imports of components
@@ -31,18 +30,13 @@ const InsightsRoute = ({ component: Component, rootClass, ...rest }) => {
     root.classList.add(`page__${rootClass}`, 'pf-c-page__main');
     root.setAttribute('role', 'main');
 
-    return <Route { ...rest } component={ Component }/>;
+    return (<Route { ...rest } component={ Component } />);
 };
 
 InsightsRoute.propTypes = {
     component: PropTypes.func,
     rootClass: PropTypes.string
 };
-
-function checkPaths (routes, app) {
-    return some(Object
-    .values(routes), route => matchPath(location.href, { path: `${document.baseURI}${app}${route}` }));
-}
 
 /**
  * the Switch component changes routes depending on the path.
@@ -52,30 +46,11 @@ function checkPaths (routes, app) {
  *      path - https://prod.foo.redhat.com:1337/insights/advisor/rules
  *      component - component to be rendered when a route has been chosen.
  */
-export const Routes = ({ childProps: { history }}) => {
-    const pathName = window.location.pathname.split('/');
-    pathName.shift();
+export const Routes = () =>
+    <Switch>
+        <InsightsRoute path={ paths.actions } component={ Actions } rootClass='actions/'/>
+        <InsightsRoute path={ paths.rules } component={ Rules } rootClass='rules'/>
 
-    if (pathName[0] === 'beta') {
-        pathName.shift();
-    }
-
-    if (!checkPaths(paths, pathName[0])) {
-        history.push(paths.actions);
-    }
-
-    return (
-        <Switch>
-            <InsightsRoute path={ paths.actions } component={ Actions } rootClass='actions'/>
-            <InsightsRoute path={ paths.rules } component={ Rules } rootClass='rules'/>
-        </Switch>
-    );
-};
-
-Routes.propTypes = {
-    childProps: PropTypes.shape({
-        history: PropTypes.shape({
-            push: PropTypes.func
-        })
-    })
-};
+        { /* Finally, catch all unmatched routes */ }
+        <Redirect path='*' to={ `${paths.actions}` } push/>
+    </Switch> ;

--- a/src/Utilities/getBaseName.js
+++ b/src/Utilities/getBaseName.js
@@ -9,7 +9,9 @@ function getBaseName(pathname) {
         release = `/beta/`;
     }
 
-    return `${release}${pathName[0]}/${pathName[1]}`;
+    // Most apps need this to be the first *two* elements
+    // Insights needs only one
+    return `${release}${pathName[0]}`;
 }
 
 export default getBaseName;


### PR DESCRIPTION
kinda fixes https://projects.engineering.redhat.com/browse/RHCLOUD-652

~This isn't a perfect fix, still does the following things:~
* ~redirects you to `/insights/undefined/actions` when `/insights` is the base url~
* ~redirects you to `/insights/actions/actions` when `/insights/actions/actions` is the base url~

[this lil nugget fixes the above issues ☝️ ](https://github.com/RedHatInsights/insights-advisor-frontend/pull/274/files#diff-b4e6341a734a41d9f7a2517ea5faaaaaR14) @iphands is 🍕 

but both of these are edge cases, fixes death by spinner, will make the app infantile more pleasant to use... followup work is to fix both of the above issues...