### PR TITLE
Separates /stats into /stats/rules and /stats/systems

### DIFF
--- a/src/AppActions.js
+++ b/src/AppActions.js
@@ -3,9 +3,13 @@ import API from './Utilities/Api';
 
 const fetchData = async (url, headers, options) => (await API.get(url, headers, options)).data;
 
-export const fetchStats = () => ({
-    type: ActionTypes.STATS_FETCH,
-    payload: fetchData(ActionTypes.STATS_FETCH_URL)
+export const fetchStatsRules = () => ({
+    type: ActionTypes.STATS_RULES_FETCH,
+    payload: fetchData(ActionTypes.STATS_RULES_FETCH_URL)
+});
+export const fetchStatsSystems = () => ({
+    type: ActionTypes.STATS_SYSTEMS_FETCH,
+    payload: fetchData(ActionTypes.STATS_SYSTEMS_FETCH_URL)
 });
 export const fetchRules = (options) => ({
     type: ActionTypes.RULES_FETCH,

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -3,15 +3,15 @@ export const RULE_FETCH = 'RULE_FETCH';
 export const RULES_FETCH = 'RULES_FETCH';
 export const SYSTEM_FETCH = 'SYSTEM_FETCH';
 export const SYSTEMTYPE_FETCH = 'SYSTEMTYPE_FETCH';
-export const STATS_FETCH = 'STATS_FETCH';
+export const STATS_RULES_FETCH = 'STATS_RULES_FETCH';
+export const STATS_SYSTEMS_FETCH = 'STATS_SYSTEMS_FETCH';
 export const BREADCRUMBS_SET = 'BREADCRUMBS_SET';
-export const LOAD_ENTITY = 'LOAD_ENTITY';
 export const FILTERS_SET = 'FILTERS_SET';
 
 export const BASE_URL = '/api/insights/v1';
 export const RULES_FETCH_URL = `${BASE_URL}/rule/`;
-export const STATS_FETCH_URL = `${BASE_URL}/stats/`;
-export const SYSTEM_FETCH_URL = `${BASE_URL}/system/`;
+export const STATS_RULES_FETCH_URL = `${BASE_URL}/stats/rules/`;
+export const STATS_SYSTEMS_FETCH_URL = `${BASE_URL}/stats/systems/`;
 
 export const SYSTEM_TYPES = { rhel: 105, ocp: 325 };
 export const RULE_CATEGORIES = {

--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -9,8 +9,10 @@ const initialState = Immutable({
     ruleFetchStatus: '',
     rules: {},
     rulesFetchStatus: '',
-    stats: {},
-    statsFetchStatus: '',
+    statsRules: {},
+    statsRulesFetchStatus: '',
+    statsSystems: {},
+    statsSystemsFetchStatus: '',
     system: {},
     systemFetchStatus: '',
     systemtype: {},
@@ -41,15 +43,25 @@ export const AdvisorStore = (state = initialState, action) => {
         case `${ActionTypes.RULES_FETCH}_REJECTED`:
             return state.set('rulesFetchStatus', 'rejected');
 
-        case `${ActionTypes.STATS_FETCH}_PENDING`:
-            return state.set('statsFetchStatus', 'pending');
-        case `${ActionTypes.STATS_FETCH}_FULFILLED`:
+        case `${ActionTypes.STATS_RULES_FETCH}_PENDING`:
+            return state.set('statsRulesFetchStatus', 'pending');
+        case `${ActionTypes.STATS_RULES_FETCH}_FULFILLED`:
             return Immutable.merge(state, {
-                stats: action.payload,
-                statsFetchStatus: 'fulfilled'
+                statsRules: action.payload,
+                statsRulesFetchStatus: 'fulfilled'
             });
-        case `${ActionTypes.STATS_FETCH}_REJECTED`:
-            return state.set('statsFetchStatus', 'rejected');
+        case `${ActionTypes.STATS_RULES_FETCH}_REJECTED`:
+            return state.set('statsRulesFetchStatus', 'rejected');
+
+        case `${ActionTypes.STATS_SYSTEMS_FETCH}_PENDING`:
+            return state.set('statsSystemsFetchStatus', 'pending');
+        case `${ActionTypes.STATS_SYSTEMS_FETCH}_FULFILLED`:
+            return Immutable.merge(state, {
+                statsSystems: action.payload,
+                statsSystemsFetchStatus: 'fulfilled'
+            });
+        case `${ActionTypes.STATS_SYSTEMS_FETCH}_REJECTED`:
+            return state.set('statsSystemsFetchStatus', 'rejected');
 
         case `${ActionTypes.SYSTEM_FETCH}_PENDING`:
             return state.set('systemFetchStatus', 'pending');

--- a/src/SmartComponents/Overview/Dashboard.js
+++ b/src/SmartComponents/Overview/Dashboard.js
@@ -22,24 +22,28 @@ class OverviewDashboard extends Component {
 
     async componentDidMount () {
         await insights.chrome.auth.getUser();
-        this.props.fetchStats();
+        this.props.fetchStatsRules();
+        this.props.fetchStatsSystems();
         this.props.setBreadcrumbs([{ title: 'Overview', navigate: '/overview' }]);
     }
 
     componentDidUpdate (prevProps) {
-        if (this.props.stats !== prevProps.stats) {
-            const rules = this.props.stats.rules;
-            this.setState({ rulesTotalRisk: rules.total_risk, reportsTotalRisk: this.props.stats.reports.total_risk });
+        if (this.props.statsRules !== prevProps.statsRules) {
+            const rules = this.props.statsRules;
             this.setState({
                 category: [ rules.category.Availability, rules.category.Stability, rules.category.Performance, rules.category.Security ]
             });
             this.setState({ total: rules.total });
         }
+
+        if (this.props.statsSystems !== prevProps.statsSystems) {
+            this.setState({ rulesTotalRisk: this.props.statsRules.total_risk, reportsTotalRisk: this.props.statsSystems.total_risk });
+        }
     }
 
     render () {
         const {
-            statsFetchStatus
+            statsRulesFetchStatus, statsSystemsFetchStatus
         } = this.props;
         const { rulesTotalRisk, reportsTotalRisk, category } = this.state;
         return <>
@@ -50,17 +54,18 @@ class OverviewDashboard extends Component {
                 <Gallery gutter="lg">
                     <GalleryItem>
                         <Title size='lg' headingLevel='h3'>Rule hits by severity</Title>
-                        { statsFetchStatus === 'fulfilled' && (
+                        { statsRulesFetchStatus === 'fulfilled' && statsSystemsFetchStatus === 'fulfilled' ? (
                             <SummaryChart rulesTotalRisk={ rulesTotalRisk } reportsTotalRisk={ reportsTotalRisk }/>
-                        ) }
-                        { statsFetchStatus === 'pending' && (<Loading/>) }
+                        )
+                            : (<Loading/>)
+                        }
                     </GalleryItem>
                     <GalleryItem>
                         <Title size='lg' headingLevel='h3'>Rule hits by category</Title>
-                        { statsFetchStatus === 'fulfilled' && (
+                        { statsRulesFetchStatus === 'fulfilled' ? (
                             <OverviewDonut category={ category } className='pf-u-mt-md'/>
-                        ) }
-                        { statsFetchStatus === 'pending' && (<Loading/>) }
+                        )
+                            : (<Loading/>) }
                     </GalleryItem>
                 </Gallery>
             </Main>
@@ -72,21 +77,28 @@ class OverviewDashboard extends Component {
 OverviewDashboard.propTypes = {
     match: PropTypes.object,
     breadcrumbs: PropTypes.array,
-    fetchStats: PropTypes.func,
     setBreadcrumbs: PropTypes.func,
-    statsFetchStatus: PropTypes.string,
-    stats: PropTypes.object
+    statsRulesFetchStatus: PropTypes.string,
+    statsRules: PropTypes.object,
+    fetchStatsRules: PropTypes.func,
+    statsSystemsFetchStatus: PropTypes.string,
+    statsSystems: PropTypes.object,
+    fetchStatsSystems: PropTypes.func
+
 };
 
 const mapStateToProps = (state, ownProps) => ({
     breadcrumbs: state.AdvisorStore.breadcrumbs,
-    stats: state.AdvisorStore.stats,
-    statsFetchStatus: state.AdvisorStore.statsFetchStatus,
+    statsRules: state.AdvisorStore.statsRules,
+    statsRulesFetchStatus: state.AdvisorStore.statsRulesFetchStatus,
+    statsSystems: state.AdvisorStore.statsSystems,
+    statsSystemsFetchStatus: state.AdvisorStore.statsSystemsFetchStatus,
     ...ownProps
 });
 
 const mapDispatchToProps = dispatch => ({
-    fetchStats: (url) => dispatch(AppActions.fetchStats(url)),
+    fetchStatsRules: (url) => dispatch(AppActions.fetchStatsRules(url)),
+    fetchStatsSystems: (url) => dispatch(AppActions.fetchStatsSystems(url)),
     setBreadcrumbs: (obj) => dispatch(AppActions.setBreadcrumbs(obj))
 });
 


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-702

### 's like nothing even changed, cept things load faster, AND separate (donut only needs rules, doesn't wait for systems)
<img width="1169" alt="Screen Shot 2019-04-10 at 11 48 31 AM" src="https://user-images.githubusercontent.com/6640236/55894700-9aa9a600-5b88-11e9-9812-edfeccfe1018.png">
