### PR TITLE
Refactor severity chart to rely on props rather than local state

### DIFF
--- a/src/SmartComponents/Overview/Dashboard.js
+++ b/src/SmartComponents/Overview/Dashboard.js
@@ -14,8 +14,6 @@ const OverviewDonut = asyncComponent(() => import('../../PresentationalComponent
 
 class OverviewDashboard extends Component {
     state = {
-        rulesTotalRisk: {},
-        reportsTotalRisk: {},
         total: 0,
         category: []
     };
@@ -35,17 +33,13 @@ class OverviewDashboard extends Component {
             });
             this.setState({ total: rules.total });
         }
-
-        if (this.props.statsSystems !== prevProps.statsSystems) {
-            this.setState({ rulesTotalRisk: this.props.statsRules.total_risk, reportsTotalRisk: this.props.statsSystems.total_risk });
-        }
     }
 
     render () {
         const {
-            statsRulesFetchStatus, statsSystemsFetchStatus
+            statsRulesFetchStatus, statsSystemsFetchStatus, statsRules, statsSystems
         } = this.props;
-        const { rulesTotalRisk, reportsTotalRisk, category } = this.state;
+        const { category } = this.state;
         return <>
             <PageHeader>
                 <PageHeaderTitle title='Overview'/>
@@ -55,7 +49,7 @@ class OverviewDashboard extends Component {
                     <GalleryItem>
                         <Title size='lg' headingLevel='h3'>Rule hits by severity</Title>
                         { statsRulesFetchStatus === 'fulfilled' && statsSystemsFetchStatus === 'fulfilled' ? (
-                            <SummaryChart rulesTotalRisk={ rulesTotalRisk } reportsTotalRisk={ reportsTotalRisk }/>
+                            <SummaryChart rulesTotalRisk={ statsRules.total_risk } reportsTotalRisk={ statsSystems.total_risk }/>
                         )
                             : (<Loading/>)
                         }


### PR DESCRIPTION
works!  our issue ended up being local state wasn't updated in the didupdate, but the props indicating resources were loaded were updated

#### yah
<img width="1578" alt="Screen Shot 2019-04-11 at 11 19 07 AM" src="https://user-images.githubusercontent.com/6640236/55969443-cb9edf00-5c4b-11e9-87f3-24d80fc78506.png">
