### PR TITLE
Removes external link icon markup from reports, it was breaking prod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1476,9 +1476,9 @@
       "dev": true
     },
     "@patternfly/patternfly": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-2.1.1.tgz",
-      "integrity": "sha512-V3gUgO+hmFcXp7gDi8x3zgwR6Xy4sOmODtgGPFAVAB031IkLD651UuOgz7GB2s2R65HyhTUaV5NH95d6wNlJgg=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-2.3.0.tgz",
+      "integrity": "sha512-B6JQcC9KJSeZCeKj97bQEMYhGEsSbjVSdVMg9FK6LFESD2rQWGjH73SDmmRPe5uBZ1E+S8gFsTJeyFge7Z5KPg=="
     },
     "@patternfly/react-charts": {
       "version": "2.2.3",
@@ -1570,15 +1570,17 @@
       "integrity": "sha512-ni5abWOau8NwsN6oZNj+NX0QzqE1XX0WtOjBuhZSV4wtKCNwLNRlLHNLXdpVeT4nffhcMdKVV/yFxkgipUC7AA=="
     },
     "@red-hat-insights/insights-frontend-components": {
-      "version": "3.41.12",
-      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.41.12.tgz",
-      "integrity": "sha512-vy2qsEqIl86/UctzOZQ/YlZclxIV/FBKfTRQB7RSaS44Jm49b7GJ5Os1XpaLuKz6t0opRH8kHzdA1doZ50VsRA==",
+      "version": "3.41.21",
+      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.41.21.tgz",
+      "integrity": "sha512-ndvmtkOfDe9SBd4rIVzgi7qMNo+cbTz7x58bvUvXO9vNTpB9SGawald5+K8fjUBURLIG93H78kZF6qtExJBm5A==",
       "requires": {
         "@patternfly/react-core": "^2.1.4",
         "@patternfly/react-icons": "^3.0.2",
         "@patternfly/react-table": "^1.0.22",
+        "@redhat-cloud-services/host-inventory-client": "^1.0.1",
         "abortcontroller-polyfill": "^1.2.1",
         "apollo-boost": "^0.1.23",
+        "axios": "^0.18.0",
         "bootstrap-sass": "^3.3.7",
         "c3": "^0.6.7",
         "classnames": "^2.2.5",
@@ -1600,20 +1602,6 @@
         "urijs": "^1.19.1"
       },
       "dependencies": {
-        "react-redux": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
-          "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
-          "requires": {
-            "@babel/runtime": "^7.1.2",
-            "hoist-non-react-statics": "^3.1.0",
-            "invariant": "^2.2.4",
-            "loose-envify": "^1.1.0",
-            "prop-types": "^15.6.1",
-            "react-is": "^16.6.0",
-            "react-lifecycles-compat": "^3.0.0"
-          }
-        },
         "redux": {
           "version": "3.7.2",
           "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
@@ -1630,6 +1618,14 @@
           "resolved": "https://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-5.1.1.tgz",
           "integrity": "sha512-YC1tiheU28Hgmtu5HHMLiuveLgjL1aCJWsSnwquMiZBcj5i/J9qVLt6vgOnb0Gz37y4deJ/rjiNt7l6Dh+Z8lA=="
         }
+      }
+    },
+    "@redhat-cloud-services/host-inventory-client": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.7.tgz",
+      "integrity": "sha512-3Wo8VkLDs6Ki9n0C6pa+CxaB4sfzGr1nkAD9RIlRDw7jTm5c+bGwQG0nSngJwGdPo8QYBpaC39hY28M37pV/tg==",
+      "requires": {
+        "axios": "^0.18.0"
       }
     },
     "@tippy.js/react": {
@@ -2475,9 +2471,9 @@
       },
       "dependencies": {
         "ts-invariant": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.2.tgz",
-          "integrity": "sha512-QsY8BCaRnHiB5T6iE4DPlJMAKEG3gzMiUco9FEt1jUXQf0XP6zi0idT0i0rMTu8A326JqNSDsmlkA9dRSh1TRg==",
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.3.tgz",
+          "integrity": "sha512-UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==",
           "requires": {
             "tslib": "^1.9.3"
           }
@@ -2524,9 +2520,9 @@
       },
       "dependencies": {
         "ts-invariant": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.2.tgz",
-          "integrity": "sha512-QsY8BCaRnHiB5T6iE4DPlJMAKEG3gzMiUco9FEt1jUXQf0XP6zi0idT0i0rMTu8A326JqNSDsmlkA9dRSh1TRg==",
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.3.tgz",
+          "integrity": "sha512-UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==",
           "requires": {
             "tslib": "^1.9.3"
           }
@@ -2871,7 +2867,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
-      "dev": true,
       "requires": {
         "follow-redirects": "^1.3.0",
         "is-buffer": "^1.1.5"
@@ -7183,7 +7178,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
       "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
-      "dev": true,
       "requires": {
         "debug": "^3.2.6"
       },
@@ -7192,7 +7186,6 @@
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -7200,8 +7193,7 @@
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -9063,8 +9055,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.1.4",
@@ -11038,9 +11029,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.1.tgz",
-      "integrity": "sha512-+H0L3ibcWhAZE02SKMqmvYsErLo4EAVJxu5h3bHBBDvvjeWXtl92rGUSBYHL2++5Y+RSNgl8dYOAXcYe7lp1fA=="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz",
+      "integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA=="
     },
     "material-ui": {
       "version": "0.20.2",
@@ -13491,9 +13482,9 @@
       }
     },
     "react-apollo": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.5.3.tgz",
-      "integrity": "sha512-sBh7M3h4xdbck8NFnn1nlUG0mD0hCTeIcvov4A8hagxjOyTVSakoum+DP6rYNaHuAZFDS3oNurNNSbGZmgoU6g==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.5.4.tgz",
+      "integrity": "sha512-olH9zYijOXVfj14hD7bQlZ0POBJchxg2e+mfnxEiEdqZra4+58SfIY0KPhmM9jqbeeusc6J/P4zzWIHt5DdNDg==",
       "requires": {
         "apollo-utilities": "^1.2.1",
         "hoist-non-react-statics": "^3.3.0",
@@ -13504,9 +13495,9 @@
       },
       "dependencies": {
         "ts-invariant": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.2.tgz",
-          "integrity": "sha512-QsY8BCaRnHiB5T6iE4DPlJMAKEG3gzMiUco9FEt1jUXQf0XP6zi0idT0i0rMTu8A326JqNSDsmlkA9dRSh1TRg==",
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.3.tgz",
+          "integrity": "sha512-UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==",
           "requires": {
             "tslib": "^1.9.3"
           }
@@ -13787,7 +13778,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.0.tgz",
       "integrity": "sha512-CRMpEx8+ccpoVxQrQDkG1obExNYpj6dZ1Ni7lUNFB9wcxOhy02tIqpFo4IUXc0kYvCGMu6ABj9A4imEX2VGZJQ==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.1.2",
         "hoist-non-react-statics": "^3.0.0",
@@ -13869,11 +13859,11 @@
       "dev": true
     },
     "react-transition-group": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.8.0.tgz",
-      "integrity": "sha512-So23a1MPn8CGoW5WNU4l0tLiVkOFmeXSS1K4Roe+dxxqqHvI/2XBmj76jx+u96LHnQddWG7LX8QovPAainSmWQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
       "requires": {
-        "dom-helpers": "^3.3.1",
+        "dom-helpers": "^3.4.0",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2",
         "react-lifecycles-compat": "^3.0.4"
@@ -18113,9 +18103,9 @@
       }
     },
     "webpack-bundle-analyzer": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.2.0.tgz",
-      "integrity": "sha512-F6bwrg5TBb9HsHZCltH1L5F091ELQ+/i67MEH7jWkYRvVp53eONNneGaIXSdOQUiXUyd3RnkITWRfWvSVQGnZQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.3.2.tgz",
+      "integrity": "sha512-7qvJLPKB4rRWZGjVp5U1KEjwutbDHSKboAl0IfafnrdXMrgC0tOtZbQD6Rw0u4cmpgRN4O02Fc0t8eAT+FgGzA==",
       "dev": true,
       "requires": {
         "acorn": "^6.0.7",
@@ -18708,9 +18698,9 @@
       }
     },
     "zen-observable": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.13.tgz",
-      "integrity": "sha512-fa+6aDUVvavYsefZw0zaZ/v3ckEtMgCFi30sn91SEZea4y/6jQp05E3omjkX91zV6RVdn15fqnFZ6RKjRGbp2g=="
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.14.tgz",
+      "integrity": "sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g=="
     },
     "zen-observable-ts": {
       "version": "0.8.18",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   },
   "dependencies": {
     "@babel/runtime": "7.4.3",
-    "@patternfly/patternfly": "2.1.1",
+    "@patternfly/patternfly": "2.3.0",
     "@patternfly/react-charts": "2.2.3",
     "@patternfly/react-core": "2.10.9",
     "@patternfly/react-icons": "3.7.1",
     "@patternfly/react-table": "1.4.10",
-    "@red-hat-insights/insights-frontend-components": "3.41.12",
+    "@red-hat-insights/insights-frontend-components": "3.41.21",
     "classnames": "2.2.6",
     "create-react-class": "15.6.3",
     "lodash": "4.17.11"
@@ -107,7 +107,7 @@
     "stylelint-scss": "3.5.4",
     "topojson": "3.0.2",
     "webpack": "4.29.6",
-    "webpack-bundle-analyzer": "3.2.0",
+    "webpack-bundle-analyzer": "3.3.2",
     "webpack-cli": "3.3.0",
     "webpack-dev-server": "3.3.1",
     "webpack-visualizer-plugin": "0.1.11",


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-721
includes https://github.com/RedHatInsights/insights-frontend-components/pull/383


this removes the external icons from links in reports on a system... we'll have to circle back around and find a better way to do that or fix the react dep that breaks when minified 