### PR TITLE
Copy api static files to build output

### DIFF
--- a/config/base.webpack.plugins.js
+++ b/config/base.webpack.plugins.js
@@ -79,7 +79,9 @@ plugins.push(ExtractCssWebpackPlugin);
  * Copies files from the specified locations to the corresponding destinations.
  */
 const CopyFilesWebpackPlugin = new (require('copy-webpack-plugin'))([
-    { from: path.resolve(__dirname, '../static/images'), to: 'images' }
+    { from: path.resolve(__dirname, '../static/images'), to: 'images' },
+    { from: path.resolve(__dirname, '../static/drf-yasg'), to: 'drf-yasg' },
+    { from: path.resolve(__dirname, '../static/rest_framework'), to: 'rest_framework' }
 ]);
 plugins.push(CopyFilesWebpackPlugin);
 


### PR DESCRIPTION
So it turns out simply adding files to the static directory does not get them copied to the build output.  The API static files will now be properly copied to the output when built.