### PR TITLE
Ends up we don't need itemsStart for pagination component

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -299,7 +299,6 @@ class RulesTable extends Component {
                             onPerPageSelect={ this.onPerPageSelect }
                             onSetPage={ this.onSetPage }
                             page={ page }
-                            itemsStart={ offset }
                             perPage={ limit }
                         />
                     </TableToolbar>


### PR DESCRIPTION
Has no impact on api calls

### now we start at 1 rather than 0
<img width="1401" alt="Screen Shot 2019-04-24 at 1 32 36 PM" src="https://user-images.githubusercontent.com/6640236/56680916-37df0100-6696-11e9-9507-445ca0cfe226.png">
