### PR TITLE
As per ux design, going with large table rather than compact

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -95,7 +95,7 @@ class RulesTable extends Component {
                                 <div key={ key }>
                                     { moment(value.created_at).fromNow() }
                                 </div>,
-                                <div className="pf-m-center" key={ key }>
+                                <div className="pf-m-center" key={ key } style={ { verticalAlign: 'top' } }>
                                     <Battery
                                         label='Total Risk'
                                         labelHidden
@@ -192,7 +192,7 @@ class RulesTable extends Component {
     handleOnCollapse = (event, rowId, isOpen) => {
         const rows = [ ...this.state.rows ];
         rows[rowId] = { ...rows[rowId], isOpen };
-        const content = isOpen ? <RuleDetails rule={ rows[rowId].rule }/> : 'Loading...';
+        const content = isOpen ? <Main className='pf-m-light'><RuleDetails rule={ rows[rowId].rule }/></Main> : 'Loading...';
 
         rows[rowId + 1] = {
             ...rows[rowId + 1], cells: [ <div key={ `child-${rowId}` }>

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { debounce, flatten } from 'lodash';
 import { connect } from 'react-redux';
 import { Badge, Button, Checkbox, Pagination, Stack, StackItem } from '@patternfly/react-core';
-import { cellWidth, sortable, Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
+import { cellWidth, sortable, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { addNotification } from '@red-hat-insights/insights-frontend-components/components/Notifications';
 import moment from 'moment';
 import { CheckIcon } from '@patternfly/react-icons';
@@ -285,7 +285,7 @@ class RulesTable extends Component {
                         </Filters>
                     </TableToolbar>
                     { rulesFetchStatus === 'fulfilled' &&
-                    <Table aria-label={ 'rule-table' } variant={ TableVariant.compact }
+                    <Table aria-label={ 'rule-table' }
                         actionResolver={ this.actionResolver } onCollapse={ this.handleOnCollapse } sortBy={ sortBy }
                         onSort={ this.onSort } cells={ cols } rows={ rows }>
                         <TableHeader/>


### PR DESCRIPTION
fixes https://docs.google.com/spreadsheets/d/1xbzvLhRUd0o27CIk1MOQWbpYMpJXktx3HUpI2MAjpk4/edit?ts=5cc0cc87#gid=967324608


### tada, bigger, n supports expanded table nicely
<img width="1231" alt="Screen Shot 2019-04-25 at 12 18 45 PM" src="https://user-images.githubusercontent.com/6640236/56751545-5c011780-6754-11e9-8fca-480f69f507cc.png">
