### PR TITLE
Swaps dashboard gallery for level

### DIFF
--- a/src/SmartComponents/Overview/Dashboard.js
+++ b/src/SmartComponents/Overview/Dashboard.js
@@ -13,6 +13,7 @@ import Loading from '../../PresentationalComponents/Loading/Loading';
 import '../../App.scss';
 import MessageState from '../../PresentationalComponents/MessageState/MessageState';
 import { ANSIBLE_MARK_ICON, GLOBAL_ECONSYSTEM_ICON, SERVER_STACK_ICON } from '../../AppSvgs';
+import './Dashboard.scss';
 
 const SummaryChart = asyncComponent(() => import('../../PresentationalComponents/Charts/SummaryChart/SummaryChart'));
 const OverviewDonut = asyncComponent(() => import('../../PresentationalComponents/Charts/OverviewDonut'));
@@ -51,8 +52,8 @@ class OverviewDashboard extends Component {
             </PageHeader>
             { total !== 0 ?
                 <>
-                    <Main className='pf-m-light'>
-                        <Level>
+                    <Main className='pf-m-light mainPaddingOverride'>
+                        <Level className='levelItemAlignOverride'>
                             <LevelItem>
                                 <Title size='lg' headingLevel='h3'>Rule hits by severity</Title>
                                 { statsRulesFetchStatus === 'fulfilled' && statsSystemsFetchStatus === 'fulfilled' ? (

--- a/src/SmartComponents/Overview/Dashboard.js
+++ b/src/SmartComponents/Overview/Dashboard.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import asyncComponent from '../../Utilities/asyncComponent';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Button, Gallery, GalleryItem, Level, LevelItem, Title } from '@patternfly/react-core';
+import { Button, Level, LevelItem, Title } from '@patternfly/react-core';
 import { Main, PageHeader, PageHeaderTitle, routerParams } from '@red-hat-insights/insights-frontend-components';
 import { global_Color_100, global_primary_color_100 } from '@patternfly/react-tokens';
 import { ChartSpikeIcon } from '@patternfly/react-icons';
@@ -52,23 +52,24 @@ class OverviewDashboard extends Component {
             { total !== 0 ?
                 <>
                     <Main className='pf-m-light'>
-                        <Gallery gutter="lg">
-                            <GalleryItem>
+                        <Level>
+                            <LevelItem>
                                 <Title size='lg' headingLevel='h3'>Rule hits by severity</Title>
                                 { statsRulesFetchStatus === 'fulfilled' && statsSystemsFetchStatus === 'fulfilled' ? (
                                     <SummaryChart rulesTotalRisk={ statsRules.total_risk } reportsTotalRisk={ statsSystems.total_risk }/>
                                 )
                                     : (<Loading/>)
                                 }
-                            </GalleryItem>
-                            <GalleryItem>
+                            </LevelItem>
+                            <LevelItem>
                                 <Title size='lg' headingLevel='h3'>Rule hits by category</Title>
                                 { statsRulesFetchStatus === 'fulfilled' ? (
                                     <OverviewDonut category={ category } className='pf-u-mt-md'/>
                                 )
                                     : (<Loading/>) }
-                            </GalleryItem>
-                        </Gallery>
+                            </LevelItem>
+                            <LevelItem>&nbsp;</LevelItem>
+                        </Level>
                     </Main>
                     <Main>
                         <Main className='pf-m-light'>
@@ -91,7 +92,7 @@ class OverviewDashboard extends Component {
                                 <LevelItem style={ { maxWidth: '400px' } }>
                                     <MessageState
                                         iconStyle={ { color: global_Color_100.value } }
-                                        icon={ () => ANSIBLE_MARK_ICON  }
+                                        icon={ () => ANSIBLE_MARK_ICON }
                                         title='Remediate Insights findings with Ansible'
                                         text={ <span key='1'>Easily generate an Ansible playbook to<br/>
                             quickly and effectively remediate Insights <br/> findings</span> }>

--- a/src/SmartComponents/Overview/Dashboard.scss
+++ b/src/SmartComponents/Overview/Dashboard.scss
@@ -1,0 +1,8 @@
+.levelItemAlignOverride {
+  align-items: start;
+}
+
+.mainPaddingOverride {
+  padding-top: 0;
+  padding-bottom: 0;
+}


### PR DESCRIPTION
### so now we're a lil more balanced, also you'll notice severity chart doesn't get mushed
<img width="1819" alt="Screen Shot 2019-04-25 at 11 41 17 AM" src="https://user-images.githubusercontent.com/6640236/56749254-5a812080-674f-11e9-85e6-2f670c01892a.png">
