### PR TITLE
Adds padding between the charts when collapsed

### DIFF
--- a/src/SmartComponents/Overview/Dashboard.js
+++ b/src/SmartComponents/Overview/Dashboard.js
@@ -53,8 +53,8 @@ class OverviewDashboard extends Component {
             { total !== 0 ?
                 <>
                     <Main className='pf-m-light mainPaddingOverride'>
-                        <Level className='levelItemAlignOverride'>
-                            <LevelItem>
+                        <Level className='levelAlignOverride'>
+                            <LevelItem className='levelItemPaddingOverride'>
                                 <Title size='lg' headingLevel='h3'>Rule hits by severity</Title>
                                 { statsRulesFetchStatus === 'fulfilled' && statsSystemsFetchStatus === 'fulfilled' ? (
                                     <SummaryChart rulesTotalRisk={ statsRules.total_risk } reportsTotalRisk={ statsSystems.total_risk }/>

--- a/src/SmartComponents/Overview/Dashboard.scss
+++ b/src/SmartComponents/Overview/Dashboard.scss
@@ -1,8 +1,12 @@
-.levelItemAlignOverride {
+.levelAlignOverride {
   align-items: start;
 }
 
 .mainPaddingOverride {
   padding-top: 0;
   padding-bottom: 0;
+}
+
+.levelItemPaddingOverride {
+  padding-bottom: 32px;
 }


### PR DESCRIPTION
### looks like...
<img width="1603" alt="Screen Shot 2019-04-26 at 7 22 40 AM" src="https://user-images.githubusercontent.com/6640236/56804675-9ae6aa00-67f4-11e9-9e74-bb28fdb57798.png">
<img width="1019" alt="Screen Shot 2019-04-26 at 7 22 29 AM" src="https://user-images.githubusercontent.com/6640236/56804676-9ae6aa00-67f4-11e9-8150-b3079fe353c4.png">
