### PR TITLE
Add pagination function to affected systems

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -37,15 +37,36 @@ class Inventory extends React.Component {
 
         this.setState({
             Inventory: inventoryConnector().InventoryTable,
-            items
+            items: [ ...items.slice(0, 50) ],
+            page: 1,
+            total: items.length,
+            pageSize: 50
+        });
+    }
+
+    onRefresh = ({ page, per_page: perPage })  => {
+        const { items } = this.props;
+
+        this.setState({
+            page,
+            perPage,
+            items: [ ...items.slice(page - 1 * perPage, page * perPage) ]
         });
     }
 
     render () {
-        const { Inventory, items } = this.state;
+        const { Inventory, items, page, total, pageSize } = this.state;
 
         return (
-            <Inventory items={ items }>{ this.props.children }</Inventory>
+            <Inventory
+                items={ items }
+                onRefresh={ this.onRefresh }
+                page={ page }
+                total={ total }
+                perPage={ pageSize }
+            >
+                { this.props.children }
+            </Inventory>
         );
     }
 }


### PR DESCRIPTION
There's been a change to how inventory is fetching next pages, it used to handle pagination for ourselves, but it has changed in more robust way and now we have to paginate on our side.

In memory as of for now, we should call get current page on each `onRefresh` call so we get newest data.