### PR TITLE
Now all system detail bullets are the same size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2021,9 +2021,9 @@
       "integrity": "sha512-ZykUfWT4yCELXhGGwQxcNqnXwe3sqfSuoL6IlQRV6wtUKk+/et7NkVvrRwvci926+Usemr4IQVc8V9gbHqRN/A=="
     },
     "@red-hat-insights/insights-frontend-components": {
-      "version": "3.41.60",
-      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.41.60.tgz",
-      "integrity": "sha512-7LrH+dbLHopBZsHkiRnx7p07IvgJ5pARNIGxbilKMTnaX/X9heZ/2zod0O4uK0J7cRJ0U1bL97OyVFYElZwiTQ==",
+      "version": "3.41.61",
+      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.41.61.tgz",
+      "integrity": "sha512-o7xZKfbvOi5KhKOyFY5k4DtJkiQ2BO3vmmBX7ZDaWseysIP8rJoTuwq5ylULlkFeT0wBVeFF0EB+jb8nKTnQ7A==",
       "requires": {
         "@babel/core": "^7.4.3",
         "@patternfly/react-core": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@patternfly/react-icons": "3.9.2",
     "@patternfly/react-table": "2.5.11",
     "@patternfly/react-tokens": "2.5.1",
-    "@red-hat-insights/insights-frontend-components": "3.41.60",
+    "@red-hat-insights/insights-frontend-components": "3.41.61",
     "classnames": "2.2.6",
     "create-react-class": "15.6.3",
     "lodash": "4.17.11"


### PR DESCRIPTION

<img width="1064" alt="Screen Shot 2019-05-13 at 8 33 04 AM" src="https://user-images.githubusercontent.com/6640236/57623085-03f05080-755d-11e9-9934-d30cf92c3b64.png">
includes https://github.com/RedHatInsights/insights-frontend-components/pull/434