### PR TITLE
Changes dashboard link url

### DIFF
--- a/src/SmartComponents/Overview/Dashboard.js
+++ b/src/SmartComponents/Overview/Dashboard.js
@@ -113,7 +113,7 @@ class OverviewDashboard extends Component {
                                                 href="https://galaxy.ansible.com/redhatinsights/insights-client">Ansible</a> <br/> or
                                             <a rel="noopener noreferrer" target="_blank"
                                                 href="https://forge.puppetlabs.com/lphiri/access_insights_client"> Puppet</a></span> }>
-                                        <Button component="a" href="https://access.redhat.com/insights/getting-started/"
+                                        <Button component="a" href="https://galaxy.ansible.com/redhatinsights/insights-client"
                                             target="_blank" variant="secondary">
                                             Download Ansible Playbook
                                         </Button>


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-1214

just gotta point out, the ansible link and the button redirect to the same place 

### here we see the button url pop up on hover
<img width="734" alt="Screen Shot 2019-05-15 at 6 19 59 AM" src="https://user-images.githubusercontent.com/6640236/57768451-a7667000-76d9-11e9-9dc6-d5f71dbb0d34.png">
