### PR TITLE
Set default rules view to be sorted by newest first

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -34,7 +34,7 @@ class RulesTable extends Component {
         ],
         rows: [],
         sortBy: {},
-        sort: 'rule_id',
+        sort: '-publish_date',
         externalFilters: {},
         impacting: false,
         limit: 10,
@@ -43,10 +43,11 @@ class RulesTable extends Component {
     };
 
     async componentDidMount () {
-        const { offset, limit, reports_shown } = this.state;
+        const { offset, limit, reports_shown, sort } = this.state;
         const impacting = this.props.impacting || this.state.impacting;
         await insights.chrome.auth.getUser();
-        const options = { offset, limit, impacting, reports_shown, ...this.props.externalFilters || {}};
+        const options = { offset, limit, impacting, reports_shown, sort, ...this.props.externalFilters || {}};
+        this.onSort(null, 2, 'desc');
         this.props.fetchRules(options);
         this.setState({ impacting, externalFilters: { ...this.props.externalFilters, reports_shown }});
     }


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-1216

### looks like this
<img width="1373" alt="Screen Shot 2019-05-20 at 3 15 37 PM" src="https://user-images.githubusercontent.com/6640236/58046202-9de26b00-7b12-11e9-8dab-3712f8fbe160.png">

### will apply to all rules table instances by default
<img width="1331" alt="Screen Shot 2019-05-20 at 3 19 22 PM" src="https://user-images.githubusercontent.com/6640236/58046225-b18dd180-7b12-11e9-8b43-25c8868fe99f.png">
