### PR TITLE
Switch from flakey class to hardcoded style 

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -273,7 +273,7 @@ class RulesTable extends Component {
                     <p>{ this.state.summary }</p>
                 </StackItem>
                 <StackItem>
-                    <TableToolbar className='pf-u-justify-content-space-between'>
+                    <TableToolbar style={ { justifyContent: 'space-between' } }>
                         <Filters
                             fetchAction={ this.fetchAction }
                             searchPlaceholder='Find a rule...'


### PR DESCRIPTION
### what it looks like now, used to look like before
<img width="1285" alt="Screen Shot 2019-05-21 at 12 40 06 PM" src="https://user-images.githubusercontent.com/6640236/58115986-4226e900-7bc9-11e9-892d-e2436099163a.png">



the pf class we were using, `pf-u-justify-content-space-between` decided to disappear, so giving up on that, gonna hardcode the style as much as it pains me. 