### PR TITLE
Update search input align with the styles used elsewhere in insights

### DIFF
--- a/src/PresentationalComponents/Filters/Filters.js
+++ b/src/PresentationalComponents/Filters/Filters.js
@@ -1,6 +1,6 @@
 /* eslint camelcase: 0 */
 import React, { Component } from 'react';
-import { InputGroup, InputGroupText, TextInput, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import { Button, ButtonVariant, InputGroup, TextInput, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import { FilterDropdown } from '@redhat-cloud-services/frontend-components';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
 import { connect } from 'react-redux';
@@ -69,15 +69,13 @@ class Filters extends Component {
                 <ToolbarGroup>
                     <ToolbarItem className='pf-u-mr-xl'>
                         <InputGroup>
-                            <TextInput
-                                aria-label='Search'
-                                onChange={ this.changeSearchValue }
-                                type='search'
-                                value={ undefined }
-                                placeholder={ searchPlaceholder }/>
-                            <InputGroupText style={ { borderLeft: 0 } }>
+                            <TextInput name='search-input' aria-label='Search'
+                                id='insights-search-input' type='search' value={ undefined }
+                                placeholder={ searchPlaceholder } onChange={ this.changeSearchValue }
+                            />
+                            <Button variant={ ButtonVariant.tertiary } aria-label='search button for search input'>
                                 <SearchIcon/>
-                            </InputGroupText>
+                            </Button>
                         </InputGroup>
                     </ToolbarItem>
                     <ToolbarItem className='pf-u-mr-md'>


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-1434

Plus this matches with what pf wants http://patternfly-react.surge.sh/patternfly-4/components/inputgroup/

### New
<img width="1449" alt="Screen Shot 2019-06-03 at 7 31 52 AM" src="https://user-images.githubusercontent.com/6640236/58798984-172d9380-85d2-11e9-8b46-620eb2cb762a.png">

### Old
<img width="1450" alt="Screen Shot 2019-06-03 at 7 34 17 AM" src="https://user-images.githubusercontent.com/6640236/58798968-0e3cc200-85d2-11e9-8922-fa9f5e266ab2.png">
