### PR TITLE
Update overview donut to better align with pf styles (black tooltip)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1487,15 +1487,38 @@
       "integrity": "sha512-x+zxOCEOtxqoLwBQK+I2BB1CGY/uX40uFpE4RMUPv75W8BLegC0jvXHMM+BK5eP3680AMfVZn5xbfQVAVzyT1A=="
     },
     "@patternfly/react-charts": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-3.4.2.tgz",
-      "integrity": "sha512-y8WsRBzYMaCpLgYRWKHnPV7DYPzEe6l1VTw2witeSbtRyHlRxDZFQym+NsxDGhkmqa9yYwiWE2buzfNBm7aaYQ==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-3.6.4.tgz",
+      "integrity": "sha512-HOiYgwgHNW7ZLbMiimoNycFhm927XimNKmS1djiJcMxwDy85qwiT0C5R6UPq+C2Jnqfgm3WXiMB9SwCNP4Tppw==",
       "requires": {
-        "@patternfly/react-styles": "^3.2.0",
-        "@types/victory": "^0.9.19",
-        "hoist-non-react-statics": "^3.1.0",
-        "victory": "^30.1.0",
-        "victory-core": "^31.1.0"
+        "@patternfly/react-styles": "^3.2.3",
+        "@types/victory": "^31.0.18",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.11",
+        "victory": "^32.2.3",
+        "victory-core": "^32.2.3",
+        "victory-legend": "^32.2.3"
+      },
+      "dependencies": {
+        "@patternfly/react-styles": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-3.2.3.tgz",
+          "integrity": "sha512-2CSR+gkLLDKzgW1dLf2xL8wubdexcDwHuUJ+Q2ee9XD6kKD+qJBV86LAGTAQH4wTYTv6gPuSLTSnde3DR3vJag==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0-beta.48",
+            "camel-case": "^3.0.0",
+            "css": "^2.2.3",
+            "cssom": "^0.3.4",
+            "cssstyle": "^0.3.1",
+            "emotion": "^9.2.9",
+            "emotion-server": "^9.2.9",
+            "fbjs-scripts": "^0.8.3",
+            "fs-extra": "^6.0.1",
+            "jsdom": "^11.11.0",
+            "relative": "^3.0.2",
+            "resolve-from": "^4.0.0"
+          }
+        }
       }
     },
     "@patternfly/react-core": {
@@ -1796,9 +1819,9 @@
       }
     },
     "@types/victory": {
-      "version": "0.9.21",
-      "resolved": "https://registry.npmjs.org/@types/victory/-/victory-0.9.21.tgz",
-      "integrity": "sha512-7A2dDRhPk2O5L4nCYw55I53uNX3G/PoLb41b0XclPFi98Bf8eA7Ov/LpmUlneSQY/3o2qbpPqJ2c8TLi3R8oJg==",
+      "version": "31.0.18",
+      "resolved": "https://registry.npmjs.org/@types/victory/-/victory-31.0.18.tgz",
+      "integrity": "sha512-tU4mJSiV3QVcOs6FnB4cWoJnPAt5ZLddThafg8U7oMctEZ83TTttgSa9ndsJcDvdOnEJH8XrwgKZdnjIhFWBSw==",
       "optional": true,
       "requires": {
         "@types/react": "*"
@@ -16384,296 +16407,135 @@
       }
     },
     "victory": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory/-/victory-30.6.1.tgz",
-      "integrity": "sha512-VJAFvZz4s6qT3KhDKLv9qMKtSwLjbRZiuK917KrfomTLYcjMgrA1FckW/8nIn1URwNdkawe4YvgAE0wdtbDO3A==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-32.2.3.tgz",
+      "integrity": "sha512-1jtZHHdQsHLcOJRRszLcKvigcz8KgQ1n8S+gK1QLh8f+TJ5nFtlDA8BXCgAghJq4X6WH9YOh94AO+9gkg+hHqw==",
       "optional": true,
       "requires": {
-        "victory-area": "^30.6.1",
-        "victory-axis": "^30.6.1",
-        "victory-bar": "^30.6.1",
-        "victory-box-plot": "^30.6.1",
-        "victory-brush-container": "^30.6.1",
-        "victory-brush-line": "^30.6.1",
-        "victory-candlestick": "^30.6.1",
-        "victory-chart": "^30.6.1",
-        "victory-core": "^30.6.1",
-        "victory-create-container": "^30.6.1",
-        "victory-cursor-container": "^30.6.1",
-        "victory-errorbar": "^30.6.1",
-        "victory-group": "^30.6.1",
-        "victory-legend": "^30.6.1",
-        "victory-line": "^30.6.1",
-        "victory-pie": "^30.6.1",
-        "victory-polar-axis": "^30.6.1",
-        "victory-scatter": "^30.6.1",
-        "victory-selection-container": "^30.6.1",
-        "victory-shared-events": "^30.6.1",
-        "victory-stack": "^30.6.1",
-        "victory-tooltip": "^30.6.1",
-        "victory-voronoi": "^30.6.1",
-        "victory-voronoi-container": "^30.6.1",
-        "victory-zoom-container": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-area": "^32.2.3",
+        "victory-axis": "^32.2.3",
+        "victory-bar": "^32.2.3",
+        "victory-box-plot": "^32.2.3",
+        "victory-brush-container": "^32.2.3",
+        "victory-brush-line": "^32.2.3",
+        "victory-candlestick": "^32.2.3",
+        "victory-chart": "^32.2.3",
+        "victory-core": "^32.2.3",
+        "victory-create-container": "^32.2.3",
+        "victory-cursor-container": "^32.2.3",
+        "victory-errorbar": "^32.2.3",
+        "victory-group": "^32.2.3",
+        "victory-legend": "^32.2.3",
+        "victory-line": "^32.2.3",
+        "victory-pie": "^32.2.3",
+        "victory-polar-axis": "^32.2.3",
+        "victory-scatter": "^32.2.3",
+        "victory-selection-container": "^32.2.3",
+        "victory-shared-events": "^32.2.3",
+        "victory-stack": "^32.2.3",
+        "victory-tooltip": "^32.2.3",
+        "victory-voronoi": "^32.2.3",
+        "victory-voronoi-container": "^32.2.3",
+        "victory-zoom-container": "^32.2.3"
       }
     },
     "victory-area": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-30.6.1.tgz",
-      "integrity": "sha512-Ksu0dnS2Ssiiuv/OH/1XK/a3M2D7to20JUkzVSyvm3m1HvKyvRCK4fDuBI2mXFWaX5iT2gJmqtVj6R22b+NOtg==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-32.2.3.tgz",
+      "integrity": "sha512-KEFQLqr6c/a4/9ssTNxmJw+Ry+TADMY44IAvTxAuz7rxiDEq0G0TkBWxUKCp1hZ2mNLVQ5JKJ3CAk3pWu1usNw==",
       "optional": true,
       "requires": {
         "d3-shape": "^1.2.0",
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-axis": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-30.6.1.tgz",
-      "integrity": "sha512-SJFdMDYOLG9EfPovskomeXvb4VOJnTF//DvXCIcw6Ysy6sMpkwvWfpJVKgh9JAzELirW8OSU775f5BcwZ+z1xg==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-32.2.3.tgz",
+      "integrity": "sha512-DuxHlwmJzNxQ0I72zRJoe7VWE2us7SKToYmmbQ571ed8S75vJV9627C1zdg7Sb98/8AsQvjXShLK8gfp+fdABA==",
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-bar": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-30.6.1.tgz",
-      "integrity": "sha512-P9v6OAz9w71+cTvRuRm43jtXV9Ag41bGn2RXf7nUgp1M0GFvaFQGujSILdSVsE8zEdyQLmwUxJRSz+s5b6CeSQ==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-32.2.3.tgz",
+      "integrity": "sha512-SgzAsjcrRMBO3kbchbESxKLhjfALi8unjoC3vn4HDtBx9lK9T9xR1TOSgOlf+a9GXOBU+9QQR4QwdpImZkNueg==",
       "optional": true,
       "requires": {
         "d3-shape": "^1.2.0",
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-box-plot": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-30.6.1.tgz",
-      "integrity": "sha512-2UVGOG+E4Nm0LLQyj3q13oAaE8vChAkrOZryTFFtDLZHVw5pUxDzZtWlgysna82tkJQA4vjlcq2h2lbZw9G1Rw==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-32.2.3.tgz",
+      "integrity": "sha512-gzPsDBR0Gmyu695slYeeWHdmyyOrbSMGcJrlqeFG1AgXRrPHk7qBBhey8p2skOSrsNAKzHNnVkH9qnX/ywf8ag==",
       "optional": true,
       "requires": {
         "d3-array": "^1.2.0",
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-brush-container": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-30.6.1.tgz",
-      "integrity": "sha512-V76eHU0Mn92DgOjnYJVHT+4skHkACBn2wQROd0E9ZFNqqyTa76U/ISD+4ihjNSqy0HfGdaHTjxcjL83E/EfONw==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-32.2.3.tgz",
+      "integrity": "sha512-l4c3Nb7gVsGpOGcnLODULO5Yf6521aHe1ZRo9C4ScEUImwNXhoy9g+QoDVFi+SM8WbOTJd4SMGyngStZ87pLGg==",
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-brush-line": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-30.6.1.tgz",
-      "integrity": "sha512-wOeIIPm8BDNqqDJQFfHe6txJ8JPWNKzHeQ6WTiwntw/IN8oLk4cwnbbW5yhQQC6rOniRFZH5iqb5V+zdCLUCWg==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-32.2.3.tgz",
+      "integrity": "sha512-EKcaUddQ9+BFSzjnyFZG4d8VrAK91T63m+TWB9v0Si4S8UnlP8Rsu1EaVd28eGZhgXgJ5nZk1bGsIczOqQnCnQ==",
       "optional": true,
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-candlestick": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-30.6.1.tgz",
-      "integrity": "sha512-cF0/jRU8LY14vBWHugU/5Ei1a+Lcc6u1k4o03m7ujKSsBffvVDnj4CN+nR9jwMMEMUeViBiVpY8HfhzFXVQ5KQ==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-32.2.3.tgz",
+      "integrity": "sha512-0KW7U1304ZYSI/yGuTPftz2qTJgwCljBFyPD6jo7M+y73o2WTJDLhnZb6Svs5taKmldVsvLw1P9/KZr6rfWkTg==",
       "optional": true,
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-chart": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-30.6.1.tgz",
-      "integrity": "sha512-JHP51QSJweuOQqMMqVim5u/vLKnvD3hjANpJdPPzthTrrmm1IPHAMLkUQ0m0tPiKsAf/5E49jDx4mDz7r6IK7w==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-32.2.3.tgz",
+      "integrity": "sha512-ECZrYcTK7Ze1156lyeD5Sjj/PrahtQKy+c++egmdUnmYZuYKYfg4WUaiTFGk6+XoYT0tUAxiyhfqWbzP4gSCSQ==",
       "optional": true,
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-axis": "^30.6.1",
-        "victory-core": "^30.6.1",
-        "victory-polar-axis": "^30.6.1",
-        "victory-shared-events": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-axis": "^32.2.3",
+        "victory-core": "^32.2.3",
+        "victory-polar-axis": "^32.2.3",
+        "victory-shared-events": "^32.2.3"
       }
     },
     "victory-core": {
-      "version": "31.2.0",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-31.2.0.tgz",
-      "integrity": "sha512-fKSJ2vKkvk6jc6ofBQ7/MbC2+r3Do7zeKfUnT7l4Z163kPDOWicA+wUdgMPlRtRv4J70z9tIENq8xMI22FMCpA==",
-      "optional": true,
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-32.2.3.tgz",
+      "integrity": "sha512-JFASPSrVH9lXwD5CdL59fEVc68waa3FDjqhukKhHsHeH7uDHaIr+3QKcWC36fBt5lzrymDWe5bEeWFWLWQeufw==",
       "requires": {
         "d3-ease": "^1.0.0",
         "d3-interpolate": "^1.1.1",
@@ -16686,462 +16548,184 @@
       }
     },
     "victory-create-container": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-30.6.1.tgz",
-      "integrity": "sha512-Bm23Yk9xzdO8uCK99G+IFFclWx/vpDLea2vcW2MyHlTT2Iwa1HHW8UAYFfwr6858LYMaOa/Y9UV/YvP+twctoA==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-32.2.3.tgz",
+      "integrity": "sha512-RoZdlHSK3xl8r2oCPLpxW+GsYz5wfKmtOokBJQ191Lr7LDpuct26SEADhIoiCqJUfzATpJiHWN5xBOyF0d4Eww==",
       "optional": true,
       "requires": {
         "lodash": "^4.17.5",
-        "victory-brush-container": "^30.6.1",
-        "victory-core": "^30.6.1",
-        "victory-cursor-container": "^30.6.1",
-        "victory-selection-container": "^30.6.1",
-        "victory-voronoi-container": "^30.6.1",
-        "victory-zoom-container": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-brush-container": "^32.2.3",
+        "victory-core": "^32.2.3",
+        "victory-cursor-container": "^32.2.3",
+        "victory-selection-container": "^32.2.3",
+        "victory-voronoi-container": "^32.2.3",
+        "victory-zoom-container": "^32.2.3"
       }
     },
     "victory-cursor-container": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-30.6.1.tgz",
-      "integrity": "sha512-XjmLUdQWEiv8F+AwfpVvi3kETJz7OCWlpkypbiIJjLvYM8lUeT84boOftMfyw+HRjUAxPQFh1D7yBUvAqrwKiA==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-32.2.3.tgz",
+      "integrity": "sha512-7qAFSscMm5Ze6C8EoWuPk0VVfMpth0NTpsCFgqZ3BWHVBbCUIrU/6mq395pjDIyiDExFAFZrV5puo2gcadWAcw==",
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-errorbar": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-30.6.1.tgz",
-      "integrity": "sha512-SBowNqH5MBh1GoqA3UF5YVsFB0h0o60IkR5Yjhe/uaGhwyZVAu5X9+BE0CXRq0uDLhOX9GDvqDs59hAe0D3xiw==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-32.2.3.tgz",
+      "integrity": "sha512-ZEDLceGUGbeQYIxHDS6zbHz18bKMA81UCWJ9kxmTHlIywOLuZEXZc1pKDzfV/YX634Wh5zVYrsTnG04WupwjxA==",
       "optional": true,
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-group": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-30.6.1.tgz",
-      "integrity": "sha512-fGt6/+GgsBqFiuzVdzQHRc2joYEDL9Bo2wE8rCH5HAUnj/oI6drKi8euooUpBOIhbOQeycCj7r6BXJvp8H9CfQ==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-32.2.3.tgz",
+      "integrity": "sha512-w/vJnbSedFs8s/yeMOe1DlELKoWNpN5mEnUYjWEJbVq59uuvdKSE6kek/P/0SRvI3OycGP36U1emYVIYMfkfng==",
       "optional": true,
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^32.2.3"
       }
     },
     "victory-legend": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-30.6.1.tgz",
-      "integrity": "sha512-iadVJSaj+mhT9Crx2eYMF39qTyvn03B5p44OjeLqKcvb0MDElVDsXyYHTwsUgnE4i+YPOFz9+buMaw2UWXU0NA==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-32.2.3.tgz",
+      "integrity": "sha512-MA6WTXpT6/b9GLVzZAS0b1vvLjjrHj5iEqYD4OUCrEUctZWKZ0z3z6b0XQ2buewDFavvD6tMlqJBGwCY7byKJA==",
       "optional": true,
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-line": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-30.6.1.tgz",
-      "integrity": "sha512-JmL17SK4bLkhQEelDoj6QK9KLF8o5uW0aNNxdhSqluFxROLtuixUzvffEYlN0weHCkIR6f/o2PqbujLVtoxOOg==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-32.2.3.tgz",
+      "integrity": "sha512-xnuR0nt7kNEGXJzPw3J4v3yfnG4Me0QJ7IHA1RKYOIggYrVl6y+tHPwAQIWrq2F1OJQ5yl4K+ypFKLS5MDtTrQ==",
       "optional": true,
       "requires": {
         "d3-shape": "^1.2.0",
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-pie": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-30.6.1.tgz",
-      "integrity": "sha512-03jIWh/+17j7FX21KSNWSglhb50DqJQ9Jy5+nVAEcTlhIiI3bffuDd9IvoCfXMMwDmoRvaRq1xtXSElq4jZYpw==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-32.2.3.tgz",
+      "integrity": "sha512-JHustLMDwfzSOoNSBzdWNezZIUH9YmF1yWPXqtnGn0bgeDQeNrr8QmwATdJuz1DT+nZTV897uBwAiHVTvoX5Yg==",
       "optional": true,
       "requires": {
         "d3-shape": "^1.0.0",
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-polar-axis": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-30.6.1.tgz",
-      "integrity": "sha512-OQIAKURdTdmOk/rXr+DNeE9xoROEOqmAdanTYXdpeazbYiClSbhcbIypK0Z7qyGziIV8D8W4r4at/mAMA9AkXQ==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-32.2.3.tgz",
+      "integrity": "sha512-jAtB0ic80P3NaM3eaFqRaxT5UVL9SftyYuK+D18s4E2QQQdeED/W8BLmJxh8Sdnun6CZ2iTadrcudA8nVN2QvQ==",
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-scatter": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-30.6.1.tgz",
-      "integrity": "sha512-UsIne7V/LruhkA5r+BqUa4MNuMGSgOgPyklOOyKur1jrYm83kE3t0T7ObiTrFBLsL7SqVnmxARXW66Lv2GWE+g==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-32.2.3.tgz",
+      "integrity": "sha512-LLSHNUHujEuW1eC/PU2zoga6QWEHp7RmvERHdhRcoSD6V448iLIG1ow+ikHmoa+mHay67lximnL+aE/lFamSHQ==",
       "optional": true,
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-selection-container": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-30.6.1.tgz",
-      "integrity": "sha512-ihv1aGOwu3IX/v94IRawMAlWRMlt/BogrU28FXhhVMdqXemPFkq3J9COq0khGhh+wuqtC1tu9Ni7uw4YA3fdZg==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-32.2.3.tgz",
+      "integrity": "sha512-8dXw90iLQc9EZPzmput+9XgmCqUaNLWaG9wYzyXVLs4Y9sSEfUcdTyeQc0vvpN3QMag1r03/yxY2ZCGzpTf1gQ==",
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-shared-events": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-30.6.1.tgz",
-      "integrity": "sha512-4zQ6gfkrQVNtx+bUv+kgNNtVX5Mr6T68Hs2xV4H0f3FrToyFrsXtANGFhAzgmi+00Mk06FVIAIY94tZW3Cej1Q==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-32.2.3.tgz",
+      "integrity": "sha512-bTkaGZhXKPnpA6e7m3gw4wkywpPd5tBoHV7MUjrpbYkupIPnju3ltQBfqfROVghx4Et3NnffGbjHV8nyuDdmsQ==",
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^32.2.3"
       }
     },
     "victory-stack": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-30.6.1.tgz",
-      "integrity": "sha512-WJk9FIe/GuqXaZsB+vZSTbgIyg53I6cwCtyMvh4Jj3iFWHuRmpVaT7vwJ46/I2WOKLvQWyd0EY380kby5PNUVg==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-32.2.3.tgz",
+      "integrity": "sha512-KjD1HvGmHaAvP5IYPVkKtjepLvkXbZkyoKPOwWpATkuQ0wYoKh+fyH00wtFyC4AaGM9jKX/jcm1XCwU7xXdP0Q==",
       "optional": true,
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^32.2.3"
       }
     },
     "victory-tooltip": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-30.6.1.tgz",
-      "integrity": "sha512-Mezqycvoxms6ON6ftBKU8TpB8Ggsiy+1gJREeOt83TfvrIp8DKher33kj83ofD853rPcmRJeMNAz57I1mpXtHA==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-32.2.3.tgz",
+      "integrity": "sha512-pyJr4gs9/X3NhgJn09sllMqQyqCnxMxkk5Dn2rB/YyeHvAmfLxrvF0uVBg4ptHHmkrDdxZKpT2AvuGHtR2yl3Q==",
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-voronoi": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-30.6.1.tgz",
-      "integrity": "sha512-bxzYmGROFYtpP3EmmcKwHMDAvpIVNYK+7LNOuYwu0z/IHBT//K2EplWAV90IYIvTdKVT75lgqiYsFOWY78L2yw==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-32.2.3.tgz",
+      "integrity": "sha512-DUJp/seuhM94ETt/EsP8mEEWkfQvc8P8S/70RTkcW6Xrf5sz6aBP1RdiFS8nEB+0qCgP7deUUvxjeg1VeXnNeQ==",
       "optional": true,
       "requires": {
         "d3-voronoi": "^1.1.2",
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "victory-voronoi-container": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-30.6.1.tgz",
-      "integrity": "sha512-rHT7rgYLuetgi67CFyM8N3AgomzNi1/tjjUKC2SmD2qq8bBysVXlyzTh2Zx4aTLVX59XNNGAaLxPjUjkZWYY2g==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-32.2.3.tgz",
+      "integrity": "sha512-sMrVF2ybES6Ed9YMjzURGOqKh/MLKCuQrzUZCTBRxNbhXdptjBxaX5JUaLPenjSy1b9m83tvFsc9XYKKSuZxKw==",
       "requires": {
         "d3-voronoi": "^1.1.2",
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1",
-        "victory-tooltip": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3",
+        "victory-tooltip": "^32.2.3"
       }
     },
     "victory-zoom-container": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-30.6.1.tgz",
-      "integrity": "sha512-F/b2l6LJjkR1OF+ioU49yGDW0rJJusKqrOFtcSDbnyeSwKkQGkgJ0T+Nv/TN5jSBdC3Wb/kKtwqHRYCrxtt3Zg==",
+      "version": "32.2.3",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-32.2.3.tgz",
+      "integrity": "sha512-mSx6scjnFB4zfNObyQls450pUYi6ZcRz9+ijGlXfa1uZUkEaIqFAxE41Ne0JUoclmWrQEHUNpnH8U9K4XjbZ0Q==",
       "requires": {
         "lodash": "^4.17.5",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^32.2.3"
       }
     },
     "vm-browserify": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@babel/runtime": "7.4.5",
     "@patternfly/patternfly": "2.8.3",
-    "@patternfly/react-charts": "3.4.2",
+    "@patternfly/react-charts": "3.6.4",
     "@patternfly/react-core": "3.16.10",
     "@patternfly/react-icons": "3.9.3",
     "@patternfly/react-table": "2.5.11",

--- a/src/PresentationalComponents/Charts/OverviewDonut.js
+++ b/src/PresentationalComponents/Charts/OverviewDonut.js
@@ -1,81 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
-import { ChartDonut, ChartLabel, ChartLegend, ChartTheme } from '@patternfly/react-charts';
-import { Grid, GridItem } from '@patternfly/react-core';
+import { ChartDonut, ChartLegend, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
 
 import './OverviewDonut.scss';
 
 class AdvisorOverviewDonut extends React.Component {
-    getChart = (theme, typeNames) => <ChartDonut
-        data={ this.props.category.map((value, key) => ({ x: typeNames[key], y: value, label: `${typeNames[key]}: ${value}` })) }
-        theme={ theme }
-        height={ 200 }
-        width={ 200 }
-        events={ [{
-            target: 'data',
-            eventHandlers: {
-                onClick: () => {
-                    return [
-                        {
-                            target: 'data',
-                            mutation: (props) => {
-                                this.props.history.push(`/overview/${props.datum.xName.toLowerCase()}`);
-                            }
-                        }
-                    ];
-                },
-                onMouseOver: () => {
-                    return [{
-                        mutation: (props) => {
-                            return {
-                                style: Object.assign({}, props.style, { fill: 'tomato', cursor: 'pointer' })
-                            };
-                        }
-                    }, {
-                        target: 'labels',
-                        mutation: () => ({ active: true })
-                    }];
-                },
-                onMouseOut: () => {
-                    return [{
-                        mutation: () => {
-                            return null;
-                        }
-                    }, {
-                        target: 'labels',
-                        mutation: () => ({ active: false })
-                    }];
-                }
-            }
-        }] }
-    />;
-
-    getLegend = (theme, typeNames) => <ChartLegend
-        data={ this.props.category.map((value, key) => ({ name: `${typeNames[key]} (${value})` })) }
-        itemsPerRow={ 1 }
-        events={ [
-            {
-                target: 'labels', eventHandlers: {
-                    onClick: this.legendClick,
-                    onMouseOver: () => {
-                        return [{
-                            mutation: (props) => {
-                                return {
-                                    style: Object.assign({}, props.style, { cursor: 'pointer' })
-                                };
-                            }
-                        }];
-                    }
-                }
-            }] }
-        theme={ theme }
-        gutter={ 0 }
-        width={ 60 }
-        height={ 60 }
-        y={ 30 }
-    />;
-
     legendClick = () => {
         return [{
             target: 'labels',
@@ -88,39 +18,60 @@ class AdvisorOverviewDonut extends React.Component {
     render () {
         const { className, category } = this.props;
         const totalHits = category.length ? category.reduce((sum, curr) => sum + curr) : 0;
-        const label = <svg className="chart-label" height={ 1 }>
-            <ChartLabel
-                style={ { fontSize: 20 } }
-                text={ totalHits }
-                textAnchor="middle"
-                verticalAnchor="middle"
-                x={ 88 }
-                y={ 66 }
-            />
-            <ChartLabel
-                style={ { fill: '#bbb' } }
-                text='Total hits'
-                textAnchor='middle'
-                verticalAnchor='middle'
-                x={ 88 }
-                y={ 89 }
-            />
-        </svg>;
         const typeNames = [ 'Availability', 'Stability', 'Performance', 'Security' ];
 
-        return <>{ totalHits ? <div className={ `chart-inline ${className}` }>
-            <Grid>
-                <GridItem span={ 6 }>
-                    <div className="chart-container">
-                        { label }
-                        { this.getChart(ChartTheme.light.multi, typeNames) }
-                    </div>
-                </GridItem>
-                <GridItem aria-label="Chart legend" span={ 6 }>
-                    { this.getLegend(ChartTheme.light.multi, typeNames) }
-                </GridItem>
-            </Grid>
-        </div>
+        return <>{ totalHits ?
+            <div className={ `donut-chart-inline ${className}` }>
+                <div className="donut-chart-container">
+                    <ChartDonut
+                        data={ this.props.category.map((value, key) => ({ x: typeNames[key], y: value, label: `${typeNames[key]}: ${value}` })) }
+                        labels={ datum => `${datum.x}: ${datum.y}` }
+                        events={ [{
+                            target: 'data',
+                            eventHandlers: {
+                                onClick: () => {
+                                    return [
+                                        {
+                                            target: 'data',
+                                            mutation: (props) => {
+                                                this.props.history.push(`/overview/${props.datum.xName.toLowerCase()}`);
+                                            }
+                                        }
+                                    ];
+                                }
+                            }
+                        }] }
+                        title={ `${totalHits}` }
+                        subTitle="Total Hits"
+                        themeColor={ ChartThemeColor.multi }
+                        themeVariant={ ChartThemeVariant.light }
+                    />
+                </div>
+                <ChartLegend
+                    data={ this.props.category.map((value, key) => ({ name: `${typeNames[key]} (${value})` })) }
+                    events={ [
+                        {
+                            target: 'labels', eventHandlers: {
+                                onClick: this.legendClick,
+                                onMouseOver: () => {
+                                    return [{
+                                        mutation: (props) => {
+                                            return {
+                                                style: Object.assign({}, props.style, { cursor: 'pointer' })
+                                            };
+                                        }
+                                    }];
+                                }
+                            }
+                        }] }
+                    orientation="vertical"
+                    height={ 200 }
+                    y={ 40 }
+                    responsive={ false }
+                    themeColor={ ChartThemeColor.multi }
+                    themeVariant={ ChartThemeVariant.light }
+                />;
+            </div>
             : <p style={ { marginTop: 18 } }>{ `Your connected systems have no categorized rule hits.` }</p>
         }</>;
     }

--- a/src/PresentationalComponents/Charts/OverviewDonut.scss
+++ b/src/PresentationalComponents/Charts/OverviewDonut.scss
@@ -1,18 +1,8 @@
-.chart-container{
-  height: 200px !important;
-  .VictoryContainer {
-    left: -12px;
-    top: -36px;
-  }
+.donut-chart-container{
+  height:200px;
+  width: 200px;
 }
 
-.chart-inline {
-  svg:not(:root) {
-    overflow: visible; }
-    .pf-l-grid {
-      width: 400px;
-      .pf-l-grid__item {
-        width: 200px;
-      }
-    }
+.donut-chart-inline{
+  display: inline-flex;
 }


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-1433

[pf friends updated the donut to be better, so we'll update the donut to be better](http://patternfly-react.surge.sh/patternfly-4/charts/chartdonut/)

**Notes**
* all behavior, aside from mouseover slice highlight, is preserved (but that wasn't ever a pf thing to begin with)
* satisfies https://redhat.invisionapp.com/share/V4NY3C6XKRW#/357403104_Donut_Interactions
* uses bunches of less code 🤤 


### What it looks...
<img width="1524" alt="Screen Shot 2019-06-03 at 8 33 14 AM" src="https://user-images.githubusercontent.com/6640236/58803638-f9662b80-85dd-11e9-8259-3dc161308589.png">
<img width="1571" alt="Screen Shot 2019-06-03 at 9 13 09 AM" src="https://user-images.githubusercontent.com/6640236/58804441-e2c0d400-85df-11e9-845e-fc080d6e4f79.png">


### Now when we zoom in, it maintains sanity!! (previously it would freak out)
<img width="1569" alt="Screen Shot 2019-06-03 at 8 33 41 AM" src="https://user-images.githubusercontent.com/6640236/58803637-f9662b80-85dd-11e9-828f-1492534eaed4.png">


