### PR TITLE
Persists rule table filters in state, previously reset upon didUnmount

### DIFF
--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -1,3 +1,4 @@
+/* eslint camelcase: 0 */
 import Immutable from 'seamless-immutable';
 import * as ActionTypes from './AppConstants';
 import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
@@ -18,7 +19,7 @@ const initialState = Immutable({
     systemtype: {},
     systemtypeFetchStatus: '',
     breadcrumbs: [],
-    filters: {}
+    filters: { impacting: true, reports_shown: true }
 });
 
 export const AdvisorStore = (state = initialState, action) => {

--- a/src/PresentationalComponents/Charts/OverviewDonut.js
+++ b/src/PresentationalComponents/Charts/OverviewDonut.js
@@ -1,16 +1,27 @@
+/* eslint camelcase: 0 */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
 import { ChartDonut, ChartLegend, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
+import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
+import { connect } from 'react-redux';
 
 import './OverviewDonut.scss';
+import * as AppActions from '../../AppActions';
+import { RULE_CATEGORIES } from '../../AppConstants';
 
-class AdvisorOverviewDonut extends React.Component {
+class OverviewDonut extends React.Component {
+    setFilters = category => {
+        const categoryNum = `${RULE_CATEGORIES[category]}`;
+        this.props.setFilters({ category: categoryNum, reports_shown: true, impacting: true });
+    };
+
     legendClick = () => {
         return [{
             target: 'labels',
             mutation: (props) => {
-                this.props.history.push(`/overview/${props.datum.name.split(' ')[0].toLowerCase()}`);
+                const category = props.datum.name.split(' ')[0].toLowerCase();
+                this.setFilters(category);
+                this.props.history.push(`/overview/${category}`);
             }
         }];
     };
@@ -33,8 +44,10 @@ class AdvisorOverviewDonut extends React.Component {
                                     return [
                                         {
                                             target: 'data',
-                                            mutation: (props) => {
-                                                this.props.history.push(`/overview/${props.datum.xName.toLowerCase()}`);
+                                            mutation: props => {
+                                                const category = props.datum.xName.toLowerCase();
+                                                this.setFilters(category);
+                                                this.props.history.push(`/overview/${category}`);
                                             }
                                         }
                                     ];
@@ -77,15 +90,23 @@ class AdvisorOverviewDonut extends React.Component {
     }
 }
 
-AdvisorOverviewDonut.propTypes = {
+OverviewDonut.propTypes = {
     className: PropTypes.string,
     category: PropTypes.array,
-    history: PropTypes.object
+    history: PropTypes.object,
+    setFilters: PropTypes.func
 
 };
 
-AdvisorOverviewDonut.defaultProps = {
+OverviewDonut.defaultProps = {
     category: []
 };
 
-export default withRouter(AdvisorOverviewDonut);
+const mapDispatchToProps = dispatch => ({
+    setFilters: (filters) => dispatch(AppActions.setFilters(filters))
+});
+
+export default routerParams(connect(
+    null,
+    mapDispatchToProps
+)(OverviewDonut));

--- a/src/PresentationalComponents/Charts/SummaryChart/SummaryChartItem.js
+++ b/src/PresentationalComponents/Charts/SummaryChart/SummaryChartItem.js
@@ -1,32 +1,54 @@
+/* eslint camelcase: 0 */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 import { Battery } from '@redhat-cloud-services/frontend-components';
-import { Split, SplitItem, StackItem } from '@patternfly/react-core';
+import { Button, Split, SplitItem, StackItem } from '@patternfly/react-core';
+import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
+import { connect } from 'react-redux';
 
-const SummaryChartItem = (props) => {
-    const { numIssues, name, riskName } = props;
-    const returnLink = (children) => <Link to={ `/overview/${riskName}` }> { children } </Link>;
+import * as AppActions from '../../../AppActions';
+import { SEVERITY_MAP } from '../../../AppConstants';
 
-    return (
-        <StackItem widget-type='InsightsSummaryChartItem' widget-id={ name }>
-            <Split style={ { alignItems: 'flex-end' } }>
-                <SplitItem className='pf-u-pr-md'>
-                    { returnLink(<Battery label={ riskName } severity={ name.toLowerCase() } labelHidden={ true }/>) }
-                </SplitItem>
-                <SplitItem className='pf-u-text-align-right pf-u-pl-sm' >
-                    { returnLink(`${numIssues} ${name} affecting ${props.affectedSystems.toLocaleString()} systems`) }
-                </SplitItem>
-            </Split>
-        </StackItem>
-    );
-};
+class SummaryChartItem extends React.Component {
+    render() {
+        const { numIssues, name, riskName } = this.props;
+        const setFilters = () => {
+            const totalRisk = `${SEVERITY_MAP[riskName]}`;
+            this.props.setFilters({ total_risk: totalRisk, reports_shown: true, impacting: true });
+            this.props.history.push(`/overview/${riskName}`);
+        };
+
+        const returnLink = (children) => <Button variant="link" onClick={ setFilters }>{ children }</Button>;
+
+        return (
+            <StackItem widget-type='InsightsSummaryChartItem' widget-id={ name }>
+                <Split style={ { alignItems: 'flex-end' } }>
+                    <SplitItem className='pf-u-pr-md'>
+                        { returnLink(<Battery label={ riskName } severity={ name.toLowerCase() } labelHidden={ true }/>) }
+                    </SplitItem>
+                    <SplitItem className='pf-u-text-align-right pf-u-pl-sm'>
+                        { returnLink(`${numIssues} ${name} affecting ${this.props.affectedSystems.toLocaleString()} systems`) }
+                    </SplitItem>
+                </Split>
+            </StackItem>
+        );
+    }
+}
 
 SummaryChartItem.propTypes = {
     affectedSystems: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired,
     numIssues: PropTypes.number.isRequired,
-    riskName: PropTypes.string.isRequired
+    riskName: PropTypes.string.isRequired,
+    history: PropTypes.object,
+    setFilters: PropTypes.func
 };
 
-export default SummaryChartItem;
+const mapDispatchToProps = dispatch => ({
+    setFilters: (filters) => dispatch(AppActions.setFilters(filters))
+});
+
+export default routerParams(connect(
+    null,
+    mapDispatchToProps
+)(SummaryChartItem));

--- a/src/PresentationalComponents/Filters/FilterChips.js
+++ b/src/PresentationalComponents/Filters/FilterChips.js
@@ -6,8 +6,10 @@ import { FILTER_CATEGORIES } from '../../AppConstants';
 class FilterChips extends Component {
     render () {
         const { filters } = this.props;
-        const prunedFilters = Object.entries(filters);
-        prunedFilters.shift();
+        const localFilters = { ...filters };
+        delete localFilters.impacting;
+        delete localFilters.reports_shown;
+        const prunedFilters = Object.entries(localFilters);
 
         return prunedFilters.length > 0 &&
             <>

--- a/src/PresentationalComponents/Filters/Filters.js
+++ b/src/PresentationalComponents/Filters/Filters.js
@@ -13,16 +13,6 @@ import { SearchIcon } from '@patternfly/react-icons';
 import FilterChips from './FilterChips';
 
 class Filters extends Component {
-    componentWillUnmount () {
-        this.props.setFilters({});
-    }
-
-    componentDidUpdate (prevProps) {
-        if (this.props.externalFilters !== prevProps.externalFilters) {
-            this.props.setFilters(this.props.externalFilters);
-        }
-    }
-
     changeSearchValue = debounce(
         value => {
             const filter = { ...this.props.filters };
@@ -64,7 +54,7 @@ class Filters extends Component {
     };
 
     removeAllFilters = () => {
-        const defaultFilters = { reports_shown: true };
+        const defaultFilters = { impacting: true, reports_shown: true };
         this.props.setFilters(defaultFilters);
         this.props.fetchAction(defaultFilters);
     };
@@ -124,7 +114,6 @@ Filters.propTypes = {
     filters: PropTypes.object,
     setFilters: PropTypes.func,
     fetchAction: PropTypes.func,
-    externalFilters: PropTypes.object,
     results: PropTypes.number
 };
 

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -35,18 +35,15 @@ class RulesTable extends Component {
         rows: [],
         sortBy: {},
         sort: '-publish_date',
-        externalFilters: {},
-        impacting: true,
+        impacting: this.props.filters.impacting,
         limit: 10,
         offset: 0,
-        reports_shown: true,
+        reports_shown: this.props.filters.reports_shown,
         isKebabOpen: false
     };
 
     async componentDidMount () {
-        const { reports_shown } = this.state;
         await insights.chrome.auth.getUser();
-        this.setState({ externalFilters: { ...this.props.externalFilters, reports_shown }});
         this.onSort(null, 2, 'desc');
     }
 
@@ -191,14 +188,15 @@ class RulesTable extends Component {
         return parsedTitle.length > 1 ? `${parsedTitle[0]} ${parsedTitle[1]} Actions` : `${parsedTitle}`;
     };
 
-    toggleRulesWithHits = (showRulesWithHits) => {
+    toggleRulesWithHits = (impacting) => {
         const { limit } = this.state;
-        this.setState({ impacting: showRulesWithHits, offset: 0 });
+        this.props.setFilters({ ...this.props.filters, impacting });
+        this.setState({ impacting, offset: 0 });
         this.props.fetchRules({
             ...this.props.filters,
             offset: 0,
             limit,
-            impacting: showRulesWithHits
+            impacting
         });
     };
 
@@ -274,7 +272,7 @@ class RulesTable extends Component {
 
     render () {
         const { rulesFetchStatus, rules } = this.props;
-        const { externalFilters, offset, limit, impacting, sortBy, cols, rows, isKebabOpen } = this.state;
+        const { offset, limit, impacting, sortBy, cols, rows, isKebabOpen } = this.state;
         const page = offset / limit + 1;
         const results = rules.meta ? rules.meta.count : 0;
         return <Main>
@@ -287,7 +285,6 @@ class RulesTable extends Component {
                         <Filters
                             fetchAction={ this.fetchAction }
                             searchPlaceholder='Find a rule...'
-                            externalFilters={ externalFilters }
                             results={ results }
                         >
                             <Dropdown
@@ -350,10 +347,9 @@ RulesTable.propTypes = {
     rulesFetchStatus: PropTypes.string,
     rules: PropTypes.object,
     filters: PropTypes.object,
-    externalFilters: PropTypes.object,
     addNotification: PropTypes.func,
-    setFilters: PropTypes.func
-
+    setFilters: PropTypes.func,
+    history: PropTypes.object
 };
 
 const mapStateToProps = (state, ownProps) => ({

--- a/src/SmartComponents/Overview/List.js
+++ b/src/SmartComponents/Overview/List.js
@@ -5,31 +5,15 @@ import PropTypes from 'prop-types';
 import { capitalize } from '@patternfly/react-core';
 
 import Breadcrumbs from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
-import { RULE_CATEGORIES, SEVERITY_MAP } from '../../AppConstants';
 import RulesTable from '../../PresentationalComponents/RulesTable/RulesTable';
 
 class OverviewList extends Component {
-    state = {
-        urlFilters: {}
-    };
-
-    async componentDidMount () {
-        if (this.props.match.params.type.includes('-risk')) {
-            const totalRisk = SEVERITY_MAP[this.props.match.params.type];
-            this.setState({ urlFilters: { total_risk: `${totalRisk}` }});
-        } else {
-            this.setState({ urlFilters: { category: `${RULE_CATEGORIES[this.props.match.params.type]}` }});
-        }
-    }
-
     parseUrlTitle = (title = '') => {
         const parsedTitle = title.split('-');
         return parsedTitle.length > 1 ? `${capitalize(parsedTitle[0])} ${capitalize(parsedTitle[1])} Actions` : `${capitalize(parsedTitle[0])}`;
     };
 
     render () {
-        const { urlFilters } = this.state;
-
         return (
             <React.Fragment>
                 <PageHeader>
@@ -41,7 +25,7 @@ class OverviewList extends Component {
                         title={ this.parseUrlTitle(this.props.match.params.type) }
                     />
                 </PageHeader>
-                <RulesTable externalFilters={ urlFilters }/>
+                <RulesTable/>
             </React.Fragment>
         );
     }


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-1535

### chart filtering correctly overrides any preset filters
![preserve-filters-chart](https://user-images.githubusercontent.com/6640236/59441989-68563800-8dc7-11e9-8374-3c3ad2ad3b1f.gif)


### we set filters, navigate to rule, filters are the same, set them again, navigate to overview, filters are the same, refresh the page, now they're all cleared! 
![preserve-filters](https://user-images.githubusercontent.com/6640236/59428081-4d28ff80-8daa-11e9-99c4-8e82951bd9e2.gif)
