### PR TITLE
Remove search text from filter chips

### DIFF
--- a/src/PresentationalComponents/Filters/FilterChips.js
+++ b/src/PresentationalComponents/Filters/FilterChips.js
@@ -7,6 +7,7 @@ class FilterChips extends Component {
     render () {
         const { filters } = this.props;
         const localFilters = { ...filters };
+        delete localFilters.text;
         delete localFilters.impacting;
         delete localFilters.reports_shown;
         const prunedFilters = Object.entries(localFilters);


### PR DESCRIPTION
Searching blows up cuz filter chips wants to register the input as a chip, which we _could_ do, but won't/shouldn't