### PR TITLE
0 - 0 of 0 items is the correct value to display when results are absent

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -270,7 +270,7 @@ const RulesTable = (props) => {
                             id="InsightsRulesHideHits"
                         />
                         <Pagination
-                            itemCount={ results || 10 }
+                            itemCount={ results }
                             onPerPageSelect={ onPerPageSelect }
                             onSetPage={ onSetPage }
                             page={ (offset / limit + 1) }
@@ -289,7 +289,7 @@ const RulesTable = (props) => {
                 { rulesFetchStatus === 'failed' && (<Failed message={ `There was an error fetching rules list.` }/>) }
                 <TableToolbar className='pf-c-pagination'>
                     <Pagination
-                        itemCount={ results || 10 }
+                        itemCount={ results }
                         onPerPageSelect={ onPerPageSelect }
                         onSetPage={ onSetPage }
                         page={ (offset / limit + 1) }


### PR DESCRIPTION
This doesn't address the invalid form event bubbling up n making the input red though

### accurate display, but still throwing that invalid input error
<img width="1569" alt="Screen Shot 2019-07-08 at 1 02 20 AM" src="https://user-images.githubusercontent.com/6640236/60784258-37de9100-a11c-11e9-93d5-bfaed54dfbe6.png">

### but this is a pf issue, so not gonna spend too much time on it atm
<img width="1158" alt="Screen Shot 2019-07-08 at 1 10 09 AM" src="https://user-images.githubusercontent.com/6640236/60784524-45e0e180-a11d-11e9-8df4-afda257d6839.png">
