### PR TITLE
Update severity chart labels to be consistent with rest of app

### DIFF
--- a/src/PresentationalComponents/Charts/SummaryChart/SummaryChart.js
+++ b/src/PresentationalComponents/Charts/SummaryChart/SummaryChart.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { capitalize, invert } from 'lodash';
+import { invert } from 'lodash';
 import { Stack, StackItem } from '@patternfly/react-core';
-import { SEVERITY_MAP } from '../../../AppConstants';
+import { SEVERITY_MAP, TOTAL_RISK_LABEL } from '../../../AppConstants';
 import asyncComponent from '../../../Utilities/asyncComponent';
 import './SummaryChart.scss';
 
@@ -12,16 +12,16 @@ const SummaryChart = (props) => {
     const noHits = [];
     const hitsBuilder = (rulesTotalRisk, totalIssues) => Object.entries(rulesTotalRisk).map(([key, value]) => {
         const riskName = invert(SEVERITY_MAP)[key];
-        const normalizedRiskName = capitalize(riskName.split('-')[0]);
+        const normalizedRiskName = riskName.split('-')[0];
         if (value) {
             return <SummaryChartItem
                 key={ `${riskName}-value` }
-                riskName={ riskName }
-                name={ normalizedRiskName }
+                riskName={ normalizedRiskName }
+                name={ TOTAL_RISK_LABEL[key] }
                 numIssues={ value }
                 affectedSystems={ totalIssues[key] }/>;
         } else {
-            noHits.push(`No ${normalizedRiskName.toLocaleLowerCase()} hits. `);
+            noHits.push(`No ${TOTAL_RISK_LABEL[key]} hits. `);
         }
     });
     const rulesWithHits = hitsBuilder(props.rulesTotalRisk, props.reportsTotalRisk).reverse();

--- a/src/PresentationalComponents/Charts/SummaryChart/SummaryChartItem.js
+++ b/src/PresentationalComponents/Charts/SummaryChart/SummaryChartItem.js
@@ -22,7 +22,7 @@ const SummaryChartItem = (props) => {
     return <StackItem widget-type='InsightsSummaryChartItem' widget-id={ name }>
         <Split style={ { alignItems: 'flex-end' } }>
             <SplitItem className='pf-u-pr-md'>
-                { returnLink(<Battery label={ riskName } severity={ name.toLowerCase() } labelHidden={ true }/>) }
+                { returnLink(<Battery label={ riskName } severity={ riskName } labelHidden={ true }/>) }
             </SplitItem>
             <SplitItem className='pf-u-text-align-right pf-u-pl-sm'>
                 { returnLink(`${numIssues} ${name} affecting ${props.affectedSystems.toLocaleString()} systems`) }


### PR DESCRIPTION
mock looks like this https://marvelapp.com/i4441ie/screen/58398625

### We now look like this
<img width="1357" alt="Screen Shot 2019-07-15 at 3 19 38 PM" src="https://user-images.githubusercontent.com/6640236/61242631-3c0a4000-a714-11e9-90f0-79f76aab2243.png">
