### PR TITLE
Adds Topics (list/details views) and supporting components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13575,6 +13575,11 @@
         "extend-shallow": "^1.1.2"
       }
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
+    },
     "pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@redhat-cloud-services/frontend-components-remediations": "0.0.3",
     "@redhat-cloud-services/frontend-components-utilities": "0.0.8",
     "classnames": "2.2.6",
+    "pluralize": "8.0.0",
     "react": "16.9.0",
     "react-content-loader": "4.2.2",
     "react-dom": "16.9.0",

--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,8 @@ class App extends Component {
         if (this.props !== prevProps) {
             const baseComponentUrl = location.href.slice(location.href.indexOf('insights/')).split('/')[1];
             const appNavClick = {
-                rules() { insights.chrome.appNavClick({ id: 'rules' }); }
+                topics() { insights.chrome.appNavClick({ id: 'topics' });},
+                rules() { insights.chrome.appNavClick({ id: 'rules' });}
             };
             if (appNavClick[baseComponentUrl]) {
                 appNavClick[baseComponentUrl]();

--- a/src/AppActions.js
+++ b/src/AppActions.js
@@ -35,3 +35,11 @@ export const setFilters = (filters) => ({
     type: ActionTypes.FILTERS_SET,
     payload: filters
 });
+export const fetchTopics = () => ({
+    type: ActionTypes.TOPICS_FETCH,
+    payload: fetchData(ActionTypes.TOPICS_FETCH_URL)
+});
+export const fetchTopic = (options) => ({
+    type: ActionTypes.TOPIC_FETCH,
+    payload: fetchData(`${ActionTypes.TOPICS_FETCH_URL}${options.topic_id}/`)
+});

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -7,11 +7,14 @@ export const STATS_RULES_FETCH = 'STATS_RULES_FETCH';
 export const STATS_SYSTEMS_FETCH = 'STATS_SYSTEMS_FETCH';
 export const BREADCRUMBS_SET = 'BREADCRUMBS_SET';
 export const FILTERS_SET = 'FILTERS_SET';
+export const TOPIC_FETCH = 'TOPIC_FETCH';
+export const TOPICS_FETCH = 'TOPICS_FETCH';
 
 export const BASE_URL = '/api/insights/v1';
 export const RULES_FETCH_URL = `${BASE_URL}/rule/`;
 export const STATS_RULES_FETCH_URL = `${BASE_URL}/stats/rules/`;
 export const STATS_SYSTEMS_FETCH_URL = `${BASE_URL}/stats/systems/`;
+export const TOPICS_FETCH_URL = `${BASE_URL}/topic/`;
 
 export const SYSTEM_TYPES = { rhel: 105, ocp: 325 };
 export const RULE_CATEGORIES = {

--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -19,7 +19,11 @@ const initialState = Immutable({
     systemtype: {},
     systemtypeFetchStatus: '',
     breadcrumbs: [],
-    filters: { impacting: true, reports_shown: true }
+    filters: { impacting: true, reports_shown: true },
+    topic: {},
+    topicFetchStatus: '',
+    topics: [],
+    topicsFetchStatus: ''
 });
 
 export const AdvisorStore = (state = initialState, action) => {
@@ -94,12 +98,32 @@ export const AdvisorStore = (state = initialState, action) => {
                 filters: action.payload
             });
 
+        case `${ActionTypes.TOPIC_FETCH}_PENDING`:
+            return state.set('topicFetchStatus', 'pending');
+        case `${ActionTypes.TOPIC_FETCH}_FULFILLED`:
+            return Immutable.merge(state, {
+                topic: action.payload,
+                topicFetchStatus: 'fulfilled'
+            });
+        case `${ActionTypes.TOPIC_FETCH}_REJECTED`:
+            return state.set('topicFetchStatus', 'rejected');
+
+        case `${ActionTypes.TOPICS_FETCH}_PENDING`:
+            return state.set('topicsFetchStatus', 'pending');
+        case `${ActionTypes.TOPICS_FETCH}_FULFILLED`:
+            return Immutable.merge(state, {
+                topics: action.payload,
+                topicsFetchStatus: 'fulfilled'
+            });
+        case `${ActionTypes.TOPICS_FETCH}_REJECTED`:
+            return state.set('topicsFetchStatus', 'rejected');
+
         default:
             return state;
     }
 };
 
-export function entitiesDetailsReducer (ActionTypes) {
+export function entitiesDetailsReducer(ActionTypes) {
     return applyReducerHash(
         {
             [`${ActionTypes.LOAD_ENTITY}_FULFILLED`]: enableApplications
@@ -108,7 +132,7 @@ export function entitiesDetailsReducer (ActionTypes) {
     );
 }
 
-function enableApplications (state) {
+function enableApplications(state) {
     return {
         ...state,
         loaded: true,

--- a/src/PresentationalComponents/Filters/FilterChips.js
+++ b/src/PresentationalComponents/Filters/FilterChips.js
@@ -9,6 +9,7 @@ const FilterChips = (props) => {
     delete localFilters.text;
     delete localFilters.impacting;
     delete localFilters.reports_shown;
+    delete localFilters.topic;
     const prunedFilters = Object.entries(localFilters);
 
     return prunedFilters.length > 0 && <>

--- a/src/PresentationalComponents/TopicCard/TopicCard.js
+++ b/src/PresentationalComponents/TopicCard/TopicCard.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+    Card, CardHeader, CardBody, Button, Title, Stack, StackItem, GalleryItem, Text, TextContent, TextVariants, Level, LevelItem, Label
+} from '@patternfly/react-core';
+import { StarIcon } from '@patternfly/react-icons';
+import pluralize from 'pluralize';
+import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
+
+import './_TopicCard.scss';
+
+const TopicCard = (props) => {
+    const { topic } = props;
+
+    return <GalleryItem>
+        <Card>
+            <CardHeader>
+                <Title headingLevel="h3" size="lg">{topic.name} </Title>
+            </CardHeader>
+            <CardBody>
+                <Stack gutter="md">
+                    <StackItem className='cardDescription'>
+                        <TextContent>
+                            <Text component={TextVariants.p}>
+                                {topic.description.substring(0, 150)}{topic.description.length > 150 ? '...' : ''}
+                            </Text>
+                        </TextContent>
+                    </StackItem>
+                    <StackItem>
+                        <TextContent>
+                            <Text component={TextVariants.small}>
+                                {pluralize('system', topic.impacted_systems_count, true)} affected
+                            </Text>
+                        </TextContent>
+                    </StackItem>
+                    <StackItem>
+                        <Level className='nowrap'>
+                            <LevelItem>
+                                <Button variant="link" onClick={() => props.history.push(`/topics/${topic.slug}/`)}>
+                                    Learn more
+                                </Button>
+                            </LevelItem>
+                            {topic.featured && <LevelItem>
+                                <Label> <StarIcon /> Recommended</Label>
+                            </LevelItem>}
+                        </Level>
+                    </StackItem>
+                </Stack>
+            </CardBody>
+        </Card>
+
+    </GalleryItem>;
+};
+
+TopicCard.propTypes = {
+    topic: PropTypes.object,
+    history: PropTypes.object
+};
+
+export default routerParams(TopicCard);

--- a/src/PresentationalComponents/TopicCard/_TopicCard.scss
+++ b/src/PresentationalComponents/TopicCard/_TopicCard.scss
@@ -1,0 +1,10 @@
+.pf-c-button.pf-m-link {
+    padding-left: 0px;
+}
+.pf-l-level.nowrap {
+    flex-wrap:nowrap;
+}
+
+.cardDescription {
+    height: 144px;
+}

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -19,9 +19,11 @@ import asyncComponent from './Utilities/asyncComponent';
  */
 const Overview = asyncComponent(() => import(/* webpackChunkName: "Overview" */ './SmartComponents/Overview/Overview'));
 const Rules = asyncComponent(() => import(/* webpackChunkName: "Rules" */ './SmartComponents/Rules/Rules'));
+const Topics = asyncComponent(() => import(/* webpackChunkName: "Topics" */ './SmartComponents/Topics/Topics'));
 const paths = {
     overview: '/overview',
-    rules: '/rules'
+    rules: '/rules',
+    topics: '/topics'
 };
 
 const InsightsRoute = ({ component: Component, rootClass, ...rest }) => {
@@ -50,6 +52,7 @@ export const Routes = () =>
     <Switch>
         <InsightsRoute path={ paths.overview } component={ Overview } rootClass='overview/'/>
         <InsightsRoute path={ paths.rules } component={ Rules } rootClass='rules'/>
+        <InsightsRoute path={ paths.topics } component={ Topics } rootClass='topics'/>
 
         { /* Finally, catch all unmatched routes */ }
         <Redirect path='*' to={ `${paths.overview}` } push/>

--- a/src/SmartComponents/Topics/Details.js
+++ b/src/SmartComponents/Topics/Details.js
@@ -1,0 +1,96 @@
+/* eslint-disable camelcase */
+import React, { useEffect } from 'react';
+import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
+import { Main, PageHeader, Truncate } from '@redhat-cloud-services/frontend-components';
+import {
+    TextContent,
+    Text,
+    TextVariants,
+    Label,
+    Title
+} from '@patternfly/react-core';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { StarIcon, TimesCircleIcon } from '@patternfly/react-icons';
+
+import * as AppActions from '../../AppActions';
+import Breadcrumbs from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
+import RulesTable from '../../PresentationalComponents/RulesTable/RulesTable';
+import Loading from '../../PresentationalComponents/Loading/Loading';
+import MessageState from '../../PresentationalComponents/MessageState/MessageState';
+
+import './_Details.scss';
+
+const Details = (props) => {
+    const { match, fetchTopic, setFilters, topic, topicFetchStatus } = props;
+    useEffect(() => {
+        fetchTopic({ topic_id: props.match.params.id });
+        setFilters({ impacting: true, reports_shown: true, topic: props.match.params.id });
+        return () => setFilters({ impacting: true, reports_shown: true });
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [fetchTopic, topic.slug]);
+
+    return <>
+        <PageHeader>
+            <Breadcrumbs
+                current={topic.name}
+                match={match}
+            />
+            {topicFetchStatus === 'fulfilled' &&
+                <>
+                    <Title size="2xl" className='titleOverride'>
+                        {topic.name}{topic.featured && <Label className='labelOverride'><StarIcon /> Recommended</Label>}
+                    </Title>
+                    <TextContent className='textOverride'>
+                        <Text component={TextVariants.p}>
+                            <Truncate
+                                text={topic.description}
+                                length={600}
+                                expandText='Read more'
+                                collapseText='Read less'
+                                inline
+                            />
+                        </Text>
+                    </TextContent>
+                </>
+            }
+            {topicFetchStatus === '' || topicFetchStatus === 'pending' && <Loading />}
+        </PageHeader>
+        <Main>
+            <>
+                {topicFetchStatus === '' || topicFetchStatus === 'pending' || topicFetchStatus === 'fulfilled' && <>
+                    <Title headingLevel="h3" size="2xl" className='titlePaddingOverride'> Rules</Title>
+                    <RulesTable />
+                </>}
+                {topicFetchStatus === 'failed' || topicFetchStatus === 'rejected' && <MessageState icon={TimesCircleIcon} title='No details for topic'
+                    text={`There exist no further details for this topic.`} />}
+            </>
+        </Main>
+    </>;
+};
+
+Details.propTypes = {
+    match: PropTypes.any,
+    fetchTopic: PropTypes.func,
+    topic: PropTypes.object,
+    topicFetchStatus: PropTypes.string,
+    setFilters: PropTypes.func
+};
+
+const mapStateToProps = (state, ownProps) => ({
+    topic: state.AdvisorStore.topic,
+    topicFetchStatus: state.AdvisorStore.topicFetchStatus,
+    ...state,
+    ...ownProps
+});
+
+const mapDispatchToProps = dispatch => ({
+    fetchTopic: (url) => dispatch(AppActions.fetchTopic(url)),
+    setFilters: (filters) => dispatch(AppActions.setFilters(filters))
+});
+
+export default routerParams(connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(Details));

--- a/src/SmartComponents/Topics/List.js
+++ b/src/SmartComponents/Topics/List.js
@@ -1,0 +1,77 @@
+import React, { useEffect } from 'react';
+import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
+import { Gallery } from '@patternfly/react-core';
+import { Main } from '@redhat-cloud-services/frontend-components';
+import { groupBy, sortBy, reverse } from 'lodash';
+import { TimesCircleIcon } from '@patternfly/react-icons';
+
+import * as AppActions from '../../AppActions';
+import TopicCard from '../../PresentationalComponents/TopicCard/TopicCard';
+import Loading from '../../PresentationalComponents/Loading/Loading';
+import MessageState from '../../PresentationalComponents/MessageState/MessageState';
+
+const List = (props) => {
+    const { topics, topicsFetchStatus, fetchTopics, setBreadcrumbs } = props;
+
+    useEffect(() => {
+        setBreadcrumbs([{ title: 'Topics', navigate: '/topics' }]);
+        fetchTopics();
+    }, [fetchTopics, setBreadcrumbs]);
+
+    const buildTopicList = () => {
+        const groupedTopics = groupBy(topics, 'featured');
+        const sortedTopics = reverse(sortBy(groupedTopics.false, ['impacted_systems_count']));
+        const sortedRecommenedTopics = reverse(sortBy(groupedTopics.true, (topic) => topic.impacted_systems_count));
+        const combinedTopics = [...sortedRecommenedTopics, ...sortedTopics];
+
+        return combinedTopics.map(topic => <TopicCard key={topic.name} topic={topic} />);
+    };
+
+    const renderTopics = () => <>
+        {topicsFetchStatus === '' || topicsFetchStatus === 'pending' && <Loading />}
+        {topicsFetchStatus === 'fulfilled' &&
+            <Gallery gutter="lg">
+                {buildTopicList()}
+            </Gallery>
+        }
+        {topicsFetchStatus === 'failed' || topicsFetchStatus === 'rejected' && <MessageState icon={TimesCircleIcon}
+            title='There was an issue fetching topics' text={`Either no topics presently exist or there is an issue presenting them.`} />
+        }
+    </>;
+
+    return <>
+        <PageHeader>
+            <PageHeaderTitle title='Topics' />
+        </PageHeader>
+        <Main>
+            {renderTopics()}
+        </Main>
+    </>;
+};
+
+List.displayName = 'list-topics';
+List.propTypes = {
+    setBreadcrumbs: PropTypes.func,
+    fetchTopics: PropTypes.func,
+    topicsFetchStatus: PropTypes.string,
+    topics: PropTypes.array
+};
+
+const mapStateToProps = (state, ownProps) => ({
+    topics: state.AdvisorStore.topics,
+    topicsFetchStatus: state.AdvisorStore.topicsFetchStatus,
+    ...ownProps
+});
+
+const mapDispatchToProps = dispatch => ({
+    setBreadcrumbs: (obj) => AppActions.setBreadcrumbs(obj),
+    fetchTopics: () => dispatch(AppActions.fetchTopics())
+});
+
+export default routerParams(connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(List));

--- a/src/SmartComponents/Topics/Topics.js
+++ b/src/SmartComponents/Topics/Topics.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+import asyncComponent from '../../Utilities/asyncComponent';
+
+const List = asyncComponent(() => import(/* webpackChunkName: "TopicsList" */ './List'));
+const Details = asyncComponent(() => import(/* webpackChunkName: "TopicDetails" */ './Details'));
+
+const Topics = () =>
+    <React.Fragment>
+        <Switch>
+            <Route exact path='/topics' component={ List } />
+            <Route exact path='/topics/:id' component={ Details }/>
+        </Switch>
+    </React.Fragment>;
+
+export default Topics;

--- a/src/SmartComponents/Topics/_Details.scss
+++ b/src/SmartComponents/Topics/_Details.scss
@@ -1,0 +1,11 @@
+@import '~@redhat-cloud-services/frontend-components-utilities/files/Utilities/_variables';
+
+
+.pf-c-label.labelOverride {
+    vertical-align: middle;
+    margin-left: 20px;
+}
+
+.textOverride {
+    margin-top: var(--pf-global--spacer--md);
+}

--- a/src/Store/index.js
+++ b/src/Store/index.js
@@ -10,7 +10,10 @@ export function init (...middleware) {
     const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
     registry = getRegistry(
         {},
-        [...middleware, promiseMiddleware, notificationsMiddleware({ errorDescriptionKey: 'response.data' })],
+        [...middleware, promiseMiddleware, notificationsMiddleware({
+            errorTitleKey: ['message'],
+            errorDescriptionKey: ['response.data.detail']
+        })],
         composeEnhancers
     );
     registry.register({ AdvisorStore });


### PR DESCRIPTION
Once we merge this, it'll be hidden from lnav until we merge this https://github.com/RedHatInsights/cloud-services-config/pull/21

also this updates `notificationsMiddleware` to display correct message and response data detail

### what we look like
<img width="1227" alt="Screen Shot 2019-08-01 at 9 59 30 AM" src="https://user-images.githubusercontent.com/6640236/62299537-1d5db600-b443-11e9-8456-3407a3160d37.png">



### the details page (but filtering isn't workin yet cuz.. stuff not merged)
<img width="1226" alt="Screen Shot 2019-08-01 at 9 59 39 AM" src="https://user-images.githubusercontent.com/6640236/62299551-23539700-b443-11e9-83e1-9d651235ece0.png">

<img width="1230" alt="Screen Shot 2019-08-01 at 10 01 09 AM" src="https://user-images.githubusercontent.com/6640236/62299638-5138db80-b443-11e9-8ae7-67b50c4ea749.png">
<img width="1226" alt="Screen Shot 2019-08-01 at 10 01 02 AM" src="https://user-images.githubusercontent.com/6640236/62299639-5138db80-b443-11e9-96eb-85996efb6cf2.png">
