### PR TITLE
Cleanup spandx config to make it easier to connect to a local api

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ The follow six branches are used by IF
 A push or merge to master will automatically release to ci-beta and qa-beta
 The same will happen with action against master-stable, it will automatically release to ci-stable and qa-stable
 The prod-beta and prod-stable environments are updated by a deliberate push, (to each branch)
+
+### Nuggets and Tidbits
+##### Start insights-proxy directly with docker
+If you are running linux and have docker installed, you can skip the installation of the insights-proxy and run it directly with:
+``` shell
+ docker run -v $PWD/config:/config --rm --net='host' -p1337:1337 -e PLATFORM=linux -ti docker.io/redhatinsights/insights-proxy
+```
+#### Running against a local API
+Set `apiHost` in the spandx.config.js to http://127.0.0.1:8000

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -1,13 +1,11 @@
 /* global exports */
-const host = `https://ci.cloud.paas.psi.redhat.com`;
-const localhost = (process.env.PLATFORM === 'linux') ? 'localhost' : 'host.docker.internal';
+const apiHost = `https://ci.cloud.paas.psi.redhat.com`;
+const frontendHost = (process.env.PLATFORM === 'linux') ? 'localhost' : 'host.docker.internal';
+const chromeHost = 'https://ci.cloud.paas.psi.redhat.com';
 
 exports.routes = {
-    '/rule/': { host },
-    '/stats/': { host },
-    '/system/': { host },
-    '/systemtype/': { host },
-    '/apps/chrome': { host },
-    '/apps/insights/': { host: `http://${localhost}:8002` },
-    '/insights': { host: `http://${localhost}:8002` }
+    '/api/insights/v1/': { host: apiHost },
+    '/apps/chrome': { host: chromeHost },
+    '/apps/insights/': { host: `http://${frontendHost}:8002` },
+    '/insights': { host: `http://${frontendHost}:8002` }
 };


### PR DESCRIPTION
This change makes it easy to switch what API you are talking to.  Just change the `apiHost` in the spandx.config.js