### PR TITLE
Only fire the appNavClick if its a nav element we store a click for

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,10 +22,11 @@ class App extends Component {
         if (this.props !== prevProps) {
             const baseComponentUrl = location.href.slice(location.href.indexOf('insights/')).split('/')[1];
             const appNavClick = {
-                overview() { insights.chrome.appNavClick({ id: 'overview' });},
-                rules() { insights.chrome.appNavClick({ id: 'rules' });}
+                rules() { insights.chrome.appNavClick({ id: 'rules' }); }
             };
-            appNavClick[baseComponentUrl]();
+            if (appNavClick[baseComponentUrl]) {
+                appNavClick[baseComponentUrl]();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes the issue of overview not showing up as selected by default (because something somewhere else is already selecting it, when we doubly select it, it unhighlights :( ) 