### PR TITLE
Ensure setBreadcrumbs action is dispatched upon visiting /topics

### DIFF
--- a/src/SmartComponents/Topics/List.js
+++ b/src/SmartComponents/Topics/List.js
@@ -71,7 +71,7 @@ const mapStateToProps = (state, ownProps) => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-    setBreadcrumbs: (obj) => AppActions.setBreadcrumbs(obj),
+    setBreadcrumbs: (obj) => dispatch(AppActions.setBreadcrumbs(obj)),
     fetchTopics: () => dispatch(AppActions.fetchTopics())
 });
 


### PR DESCRIPTION
### n now its not broken when you navigate around the app
<img width="1224" alt="Screen Shot 2019-09-18 at 11 56 10 AM" src="https://user-images.githubusercontent.com/6640236/65164668-5958d480-da0b-11e9-8b1a-b528a727538c.png">
