### PR TITLE
Not gonna stop rule detail from loading while we're waiting for topics

### DIFF
--- a/src/SmartComponents/Rules/Details.js
+++ b/src/SmartComponents/Rules/Details.js
@@ -89,7 +89,7 @@ class OverviewDetails extends Component {
 
         return (
             <React.Fragment>
-                {ruleFetchStatus === 'fulfilled' && topicsFetchStatus === 'fulfilled' && (
+                {ruleFetchStatus === 'fulfilled' && (
                     <React.Fragment>
                         <PageHeader>
                             <Breadcrumbs


### PR DESCRIPTION
Its taking too long for topics to load, meaning it visibly delays rule details component, gonna render that as soon as we have the data we need, topics will come afterwards