### PR TITLE
Complex translation passing isn't workin, revering this constant till 👍🏽

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -115,8 +115,8 @@ export const RISK_OF_CHANGE_LABEL = {
     4: intlHelper(intl.formatMessage(messages.high), intlSettings)
 };
 export const TOTAL_RISK_LABEL = {
-    1: intlHelper(intl.formatMessage(messages.low), intlSettings),
-    2: intlHelper(intl.formatMessage(messages.moderate), intlSettings),
-    3: intlHelper(intl.formatMessage(messages.important), intlSettings),
-    4: intlHelper(intl.formatMessage(messages.critical), intlSettings)
+    1: 'Low',
+    2: 'Moderate',
+    3: 'Important',
+    4: 'Critical'
 };


### PR DESCRIPTION
We're having a lil trouble getting this to show up like it ought to, something about passing a translation as a value to another translation string is off... till its figured out, reverting this constant...

#### see look, all better (kinda)
<img width="462" alt="Screen Shot 2019-10-14 at 4 31 57 PM" src="https://user-images.githubusercontent.com/6640236/66781178-9eecae00-eea0-11e9-920e-ac2351f2db19.png">
