### PR TITLE
Adds disable rule justification modal and action to rule detail page

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -9,6 +9,9 @@
     "rulestable.hidereports.errordisabling": "Disabling reports failed",
     "rulestable.hidereports.errorenabling": "Enabling reports failed",
     "disableRule": "Disable rule",
+    "disableRuleBody": "Disabling a rule means that hits for this rule across all systems will not be shown in reports and dashboards.",
+    "disableRuleSingleSystem": "Disable only for this system",
+    "justificatonNote": "Justification note",
     "enableRule": "Enable rule",
     "rulestable.norulehits.title": "No rule hits",
     "rulestable.norulehits.enabledrulesbody": "None of your connected systems are affected by enabled rules.",
@@ -94,6 +97,8 @@
     "riskOfChangeTextThree": "These will likely require an outage window.",
     "riskOfChangeTextFour": "The change takes a significant amount of time and planning to execute, and will impact the system and business operations of the host due to downtime.",
     "no": "No",
-    "description": "Description"
+    "description": "Description",
+    "save": "Save",
+    "cancel": "Cancel"
   }
 }

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -8,6 +8,9 @@
   "rulestable.hidereports.errordisabling": "Disabling reports failed",
   "rulestable.hidereports.errorenabling": "Enabling reports failed",
   "disableRule": "Disable rule",
+  "disableRuleBody": "Disabling a rule means that hits for this rule across all systems will not be shown in reports and dashboards.",
+  "disableRuleSingleSystem": "Disable only for this system",
+  "justificatonNote": "Justification note",
   "enableRule": "Enable rule",
   "rulestable.norulehits.title": "No rule hits",
   "rulestable.norulehits.enabledrulesbody": "None of your connected systems are affected by enabled rules.",
@@ -93,5 +96,7 @@
   "riskOfChangeTextThree": "These will likely require an outage window.",
   "riskOfChangeTextFour": "The change takes a significant amount of time and planning to execute, and will impact the system and business operations of the host due to downtime.",
   "no": "No",
-  "description": "Description"
+  "description": "Description",
+  "save": "Save",
+  "cancel": "Cancel"
 }

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -47,6 +47,21 @@ export default defineMessages({
         description: 'Rule table, action text for disabling reporting of a rule',
         defaultMessage: 'Disable rule'
     },
+    disableRuleBody: {
+        id: 'disableRuleBody',
+        description: 'Explaining the action of disabling a rule',
+        defaultMessage: `Disabling a rule means that hits for this rule across all systems will not be shown in reports and dashboards.`
+    },
+    disableRuleSingleSystem: {
+        id: 'disableRuleSingleSystem',
+        description: 'Explaining the action of disabling a rule for a single system',
+        defaultMessage: 'Disable only for this system'
+    },
+    justificatonNote: {
+        id: 'justificatonNote',
+        description: 'Justification note',
+        defaultMessage: 'Justification note'
+    },
     enableRule: {
         id: 'enableRule',
         description: 'Rule table, action text for enabling reporting of a rule',
@@ -485,5 +500,15 @@ export default defineMessages({
         id: 'description',
         description: 'Description',
         defaultMessage: `Description`
+    },
+    save: {
+        id: 'save',
+        description: 'Save',
+        defaultMessage: `Save`
+    },
+    cancel: {
+        id: 'cancel',
+        description: 'Cancel',
+        defaultMessage: `Cancel`
     }
 });

--- a/src/PresentationalComponents/Modals/DisableRule.js
+++ b/src/PresentationalComponents/Modals/DisableRule.js
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Modal, Button, Form, FormGroup, TextInput, Checkbox } from '@patternfly/react-core';
+import { injectIntl } from 'react-intl';
+import { connect } from 'react-redux';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
+
+import API from '../../Utilities/Api';
+import { BASE_URL } from '../../AppConstants';
+import messages from '../../Messages';
+
+const DisableRule = ({ handleModalToggle, intl, isModalOpen, displaySingleSystemCheckbox, rule, afterDisableFn, addNotification }) => {
+    const [justification, setJustificaton] = useState('');
+    const [singleSystem, setSingleSystem] = useState(false);
+
+    const disableRule = async () => {
+        try {
+            if (rule.reports_shown) {
+                // eslint-disable-next-line camelcase
+                await API.post(`${BASE_URL}/ack/`, { rule_id: rule.rule_id, justification });
+                afterDisableFn();
+                handleModalToggle(false);
+            }
+        } catch (error) {
+            handleModalToggle(false);
+            addNotification({
+                variant: 'danger',
+                dismissable: true,
+                title: intl.formatMessage(messages.rulesTableHideReportsErrorDisabled),
+                description: `${error}`
+            });
+        }
+
+        setJustificaton('');
+    };
+
+    return <Modal
+        isSmall
+        title={intl.formatMessage(messages.disableRule)}
+        isOpen={isModalOpen}
+        onClose={() => { handleModalToggle(false); setJustificaton('');  }}
+        actions={[
+            <Button key="confirm" variant="primary" onClick={disableRule}>
+                {intl.formatMessage(messages.save)}
+            </Button>,
+            <Button key="cancel" variant="link" onClick={() => { handleModalToggle(false); setJustificaton(''); }}>
+                {intl.formatMessage(messages.cancel)}
+            </Button>
+        ]}
+        isFooterLeftAligned
+    >
+        {intl.formatMessage(messages.disableRuleBody)}
+        <Form>
+            <FormGroup />
+            {displaySingleSystemCheckbox && <FormGroup>
+                <Checkbox
+                    isChecked={singleSystem}
+                    onChange={() => { setSingleSystem(!singleSystem); }}
+                    label={intl.formatMessage(messages.disableRuleSingleSystem)}
+                    id="disable-rule-one-system"
+                    name="disable-rule-one-system" />
+            </FormGroup>}
+            <FormGroup
+                label={intl.formatMessage(messages.justificatonNote)}
+                fieldId="disable-rule-justification">
+                <TextInput
+                    type="text"
+                    id="disable-rule-justification"
+                    name="disable-rule-justification"
+                    aria-describedby="disable-rule-justification"
+                    value={justification}
+                    onChange={(text) => { setJustificaton(text); }}
+                />
+            </FormGroup>
+        </Form>
+    </Modal>;
+};
+
+DisableRule.propTypes = {
+    isModalOpen: PropTypes.bool,
+    displaySingleSystemCheckbox: PropTypes.bool,
+    handleModalToggle: PropTypes.func,
+    intl: PropTypes.any,
+    rule: PropTypes.object,
+    afterDisableFn: PropTypes.func,
+    addNotification: PropTypes.func
+
+};
+
+DisableRule.defaultProps = {
+    isModalOpen: false,
+    handleModalToggle: () => undefined,
+    displaySingleSystemCheckbox: false,
+    rule: {},
+    afterDisableFn: () => undefined
+};
+
+const mapDispatchToProps = dispatch => ({
+    addNotification: data => dispatch(addNotification(data))
+});
+
+export default injectIntl(connect(
+    null,
+    mapDispatchToProps
+)(DisableRule));

--- a/src/PresentationalComponents/RuleDetails/RuleDetails.js
+++ b/src/PresentationalComponents/RuleDetails/RuleDetails.js
@@ -14,7 +14,7 @@ import './_RuleDetails.scss';
 import messages from '../../Messages';
 import barDividedList from '../../Utilities/BarDividedList';
 
-const RuleDetails = ({ children, className, rule, intl, topics }) => {
+const RuleDetails = ({ children, className, rule, intl, topics, header }) => {
     const ruleResolutionRisk = (rule) => {
         const resolution = rule.resolution_set.find(resolution => resolution.system_type ===
             AppConstants.SYSTEM_TYPES.rhel ||
@@ -36,6 +36,9 @@ const RuleDetails = ({ children, className, rule, intl, topics }) => {
     return <Grid gutter='md' className={className}>
         <GridItem md={8} sm={12}>
             <Grid>
+                {header && <GridItem className='pf-u-pb-md'>
+                    {header}
+                </GridItem>}
                 <GridItem className='pf-u-pb-md'>
                     {
                         typeof rule.summary === 'string' &&
@@ -127,7 +130,8 @@ RuleDetails.propTypes = {
     className: PropTypes.string,
     rule: PropTypes.object,
     intl: PropTypes.any,
-    topics: PropTypes.array
+    topics: PropTypes.array,
+    header: PropTypes.any
 };
 
 export default injectIntl(RuleDetails);

--- a/src/SmartComponents/Rules/Details.scss
+++ b/src/SmartComponents/Rules/Details.scss
@@ -1,5 +1,7 @@
-@import '~@redhat-cloud-services/frontend-components-utilities/files/Utilities/_variables';
-
 .titlePaddingOverride{
   padding-bottom: var(--pf-global--spacer--sm);
+}
+
+.pageHeaderOverride{
+  padding-bottom: 0px;
 }


### PR DESCRIPTION
**TODO:**
* ~api call n such for single system and justification~ https://projects.engineering.redhat.com/browse/RHCLOUD-2986 is where this will be done, but we laid the groundwork here
* ~possibly rolling https://projects.engineering.redhat.com/browse/RHCLOUD-2982  into this one (cuz it would be kinda ah jerk move to allow disabling on rule details without showing it)~ given api toggle is available (enable disable) this can remain separate  

### as per ux guidance, details page now looks like this, i didn't want to updated the gif
<img width="1311" alt="Screen Shot 2019-11-13 at 4 04 06 PM" src="https://user-images.githubusercontent.com/6640236/68854104-5a278300-06a9-11ea-9acb-7419cd000e5c.png">



### Just in case you have some 🍿 lying around
![disable](https://user-images.githubusercontent.com/6640236/68796949-adee8980-0621-11ea-8e48-c479d70c3302.gif)




fixes https://projects.engineering.redhat.com/browse/RHCLOUD-2979