### PR TITLE
Adds host ack capability to inv-table, updates messaging to reflect 🦚

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -14,7 +14,11 @@
     "ruleIsDisabled": "Rule is disabled",
     "ruleIsDisabledBody": "This rule has been disabled and has no results.",
     "ruleIsDisabledJustification": "This rule has been disabled for all systems for the following reason: ",
-    "justificatonNote": "Justification note",
+    "ruleIsDisabledForSystems": "Rule is disabled for some systems",
+    "ruleIsDisabledForSystemsBody": "Rule is disabled for {systems, plural, one {# system.} other {# systems.}}",
+    "enableRuleForSystems": "Enable this rule for all systems",
+    "viewSystems": "View Systems",
+    "justificationNote": "Justification note",
     "enableRule": "Enable rule",
     "rulestable.norulehits.title": "No rule hits",
     "rulestable.norulehits.enabledrulesbody": "None of your connected systems are affected by enabled rules.",
@@ -103,6 +107,11 @@
     "description": "Description",
     "save": "Save",
     "cancel": "Cancel",
-    "none": "None"
+    "none": "None",
+    "dateDisabled": "Date Disabled",
+    "hostAckModalTitle": "Rule has been disabled for:",
+    "systemName": "System name",
+    "enable": "Enable",
+    "error": "Error"
   }
 }

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -13,7 +13,11 @@
   "ruleIsDisabled": "Rule is disabled",
   "ruleIsDisabledBody": "This rule has been disabled and has no results.",
   "ruleIsDisabledJustification": "This rule has been disabled for all systems for the following reason: ",
-  "justificatonNote": "Justification note",
+  "ruleIsDisabledForSystems": "Rule is disabled for some systems",
+  "ruleIsDisabledForSystemsBody": "Rule is disabled for {systems, plural, one {# system.} other {# systems.}}",
+  "enableRuleForSystems": "Enable this rule for all systems",
+  "viewSystems": "View Systems",
+  "justificationNote": "Justification note",
   "enableRule": "Enable rule",
   "rulestable.norulehits.title": "No rule hits",
   "rulestable.norulehits.enabledrulesbody": "None of your connected systems are affected by enabled rules.",
@@ -102,5 +106,10 @@
   "description": "Description",
   "save": "Save",
   "cancel": "Cancel",
-  "none": "None"
+  "none": "None",
+  "dateDisabled": "Date Disabled",
+  "hostAckModalTitle": "Rule has been disabled for:",
+  "systemName": "System name",
+  "enable": "Enable",
+  "error": "Error"
 }

--- a/src/AppActions.js
+++ b/src/AppActions.js
@@ -52,10 +52,13 @@ export const fetchSystems = (options) => ({
 });
 export const fetchRuleAck = (options) => ({
     type: ActionTypes.RULE_ACK_FETCH,
-    payload: fetchData(`${ActionTypes.RULE_ACK_FETCH_URL}${options.rule_id}/`)
+    payload: fetchData(`${ActionTypes.RULE_ACK_URL}${options.rule_id}/`)
 });
-export const setRuleAck = (options) => ({
-    type: ActionTypes.RULE_ACK_FETCH,
-    payload: setData(ActionTypes.RULE_ACK_FETCH_URL, {}, options)
+export const setAck = (options) => ({
+    type: ActionTypes[`${options.type}_ACK_SET`],
+    payload: setData(ActionTypes[`${options.type}_ACK_URL`], {}, options.options)
 });
-
+export const fetchHostAcks = (options) => ({
+    type: ActionTypes.HOST_ACK_FETCH,
+    payload: fetchData(`${ActionTypes.HOST_ACK_URL}`, {}, options)
+});

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -25,6 +25,8 @@ export const TOPICS_FETCH = 'TOPICS_FETCH';
 export const SYSTEMS_FETCH = 'SYSTEMS_FETCH';
 export const RULE_ACK_FETCH = 'RULE_ACK_FETCH';
 export const RULE_ACK_SET = 'RULE_ACK_SET';
+export const HOST_ACK_FETCH = 'HOST_ACK_FETCH';
+export const HOST_ACK_SET = 'HOST_ACK_SET';
 
 export const BASE_URL = '/api/insights/v1';
 export const RULES_FETCH_URL = `${BASE_URL}/rule/`;
@@ -32,7 +34,8 @@ export const STATS_RULES_FETCH_URL = `${BASE_URL}/stats/rules/`;
 export const STATS_SYSTEMS_FETCH_URL = `${BASE_URL}/stats/systems/`;
 export const TOPICS_FETCH_URL = `${BASE_URL}/topic/`;
 export const SYSTEMS_FETCH_URL = `${BASE_URL}/system/`;
-export const RULE_ACK_FETCH_URL = `${BASE_URL}/ack/`;
+export const RULE_ACK_URL = `${BASE_URL}/ack/`;
+export const HOST_ACK_URL = `${BASE_URL}/hostack/`;
 
 export const SYSTEM_TYPES = { rhel: 105, ocp: 325 };
 export const RULE_CATEGORIES = {

--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -27,7 +27,9 @@ const initialState = Immutable({
     systems: {},
     systemsFetchStatus: '',
     ruleAck: {},
-    ruleAckFetchStatus: ''
+    ruleAckFetchStatus: '',
+    hostAcks: {},
+    hostAcksFetchStatus: ''
 });
 
 export const AdvisorStore = (state = initialState, action) => {
@@ -141,6 +143,16 @@ export const AdvisorStore = (state = initialState, action) => {
             return Immutable.merge(state, {
                 ruleAck: action.payload
             });
+
+        case `${ActionTypes.HOST_ACK_FETCH}_PENDING`:
+            return state.set('hostAcksFetchStatus', 'pending');
+        case `${ActionTypes.HOST_ACK_FETCH}_FULFILLED`:
+            return Immutable.merge(state, {
+                hostAcks: action.payload,
+                hostAcksFetchStatus: 'fulfilled'
+            });
+        case `${ActionTypes.HOST_ACK_FETCH}_REJECTED`:
+            return state.set('hostAcksFetchStatus', 'rejected');
 
         default:
             return state;

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -72,8 +72,28 @@ export default defineMessages({
         description: 'Explaining that the rule is disabled with following justification',
         defaultMessage: 'This rule has been disabled for all systems for the following reason: '
     },
-    justificatonNote: {
-        id: 'justificatonNote',
+    ruleIsDisabledForSystems: {
+        id: 'ruleIsDisabledForSystems',
+        description: 'Exclaiming that the rule is disabled for systems',
+        defaultMessage: 'Rule is disabled for some systems'
+    },
+    ruleIsDisabledForSystemsBody: {
+        id: 'ruleIsDisabledForSystemsBody',
+        description: 'Exclaiming that the rule is disabled for systems (system count)',
+        defaultMessage: 'Rule is disabled for {systems, plural, one {# system.} other {# systems.}}'
+    },
+    enableRuleForSystems: {
+        id: 'enableRuleForSystems',
+        description: 'Enable this rule for all systems',
+        defaultMessage: 'Enable this rule for all systems'
+    },
+    viewSystems: {
+        id: 'viewSystems',
+        description: 'View systems',
+        defaultMessage: 'View Systems'
+    },
+    justificationNote: {
+        id: 'justificationNote',
         description: 'Justification note',
         defaultMessage: 'Justification note'
     },
@@ -530,5 +550,30 @@ export default defineMessages({
         id: 'none',
         description: 'None',
         defaultMessage: `None`
+    },
+    dateDisabled: {
+        id: 'dateDisabled',
+        description: 'Date disabled',
+        defaultMessage: 'Date Disabled'
+    },
+    hostAckModalTitle: {
+        id: 'hostAckModalTitle',
+        description: 'Title for host ack table modal',
+        defaultMessage: 'Rule has been disabled for:'
+    },
+    systemName: {
+        id: 'systemName',
+        description: 'System name',
+        defaultMessage: 'System name'
+    },
+    enable: {
+        id: 'enable',
+        description: 'Enable',
+        defaultMessage: 'Enable'
+    },
+    error: {
+        id: 'error',
+        description: 'Error',
+        defaultMessage: 'Error'
     }
 });

--- a/src/PresentationalComponents/Modals/DisableRule.js
+++ b/src/PresentationalComponents/Modals/DisableRule.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { Button, Checkbox, Form, FormGroup, Modal, TextInput } from '@patternfly/react-core';
 import React, { useState } from 'react';
 
@@ -5,18 +6,21 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import messages from '../../Messages';
-import { setRuleAck } from '../../AppActions';
+import { setAck } from '../../AppActions';
 
-const DisableRule = ({ handleModalToggle, intl, isModalOpen, displaySingleSystemCheckbox, rule, afterDisableFn, setRuleAck }) => {
+const DisableRule = ({ handleModalToggle, intl, isModalOpen, host, rule, afterFn, setAck }) => {
     const [justification, setJustificaton] = useState('');
     const [singleSystem, setSingleSystem] = useState(false);
 
     const disableRule = () => {
         if (rule.reports_shown) {
-            // eslint-disable-next-line camelcase
-            setRuleAck({ rule_id: rule.rule_id, justification });
-            afterDisableFn();
+            const options = singleSystem
+                ? { type: 'HOST', options: { rule_id: rule.rule_id, system_uuid: host.id, ...(justification && { justification }) } }
+                : { type: 'RULE', options: { rule_id: rule.rule_id, ...(justification && { justification }) } };
+            setAck(options);
+            afterFn();
             setJustificaton('');
+            setSingleSystem(false);
             handleModalToggle(false);
         }
     };
@@ -39,7 +43,7 @@ const DisableRule = ({ handleModalToggle, intl, isModalOpen, displaySingleSystem
         {intl.formatMessage(messages.disableRuleBody)}
         <Form>
             <FormGroup fieldId='blank-form' />
-            {displaySingleSystemCheckbox && <FormGroup fieldId='disable-rule-one-system'>
+            {host !== undefined && <FormGroup fieldId='disable-rule-one-system'>
                 <Checkbox
                     isChecked={singleSystem}
                     onChange={() => { setSingleSystem(!singleSystem); }}
@@ -48,7 +52,7 @@ const DisableRule = ({ handleModalToggle, intl, isModalOpen, displaySingleSystem
                     name="disable-rule-one-system" />
             </FormGroup>}
             <FormGroup
-                label={intl.formatMessage(messages.justificatonNote)}
+                label={intl.formatMessage(messages.justificationNote)}
                 fieldId="disable-rule-justification">
                 <TextInput
                     type="text"
@@ -65,27 +69,24 @@ const DisableRule = ({ handleModalToggle, intl, isModalOpen, displaySingleSystem
 
 DisableRule.propTypes = {
     isModalOpen: PropTypes.bool,
-    displaySingleSystemCheckbox: PropTypes.bool,
+    host: PropTypes.object,
     handleModalToggle: PropTypes.func,
     intl: PropTypes.any,
     rule: PropTypes.object,
-    afterDisableFn: PropTypes.func,
-    setRuleAck: PropTypes.func
+    afterFn: PropTypes.func,
+    setAck: PropTypes.func
 };
 
 DisableRule.defaultProps = {
     isModalOpen: false,
     handleModalToggle: () => undefined,
-    displaySingleSystemCheckbox: false,
+    system: undefined,
     rule: {},
-    afterDisableFn: () => undefined
+    afterFn: () => undefined
 };
 
 const mapDispatchToProps = dispatch => ({
-    setRuleAck: data => dispatch(setRuleAck(data))
+    setAck: data => dispatch(setAck(data))
 });
 
-export default injectIntl(connect(
-    null,
-    mapDispatchToProps
-)(DisableRule));
+export default injectIntl(connect(null, mapDispatchToProps)(DisableRule));

--- a/src/PresentationalComponents/Modals/ViewHostAcks.js
+++ b/src/PresentationalComponents/Modals/ViewHostAcks.js
@@ -1,0 +1,110 @@
+/* eslint-disable camelcase */
+import { Button, Modal } from '@patternfly/react-core';
+import React, { useEffect, useState } from 'react';
+import { Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { fetchHostAcks, setAck } from '../../AppActions';
+
+import API from '../../Utilities/Api';
+import { BASE_URL } from '../../AppConstants';
+import { OutlinedBellIcon } from '@patternfly/react-icons';
+import PropTypes from 'prop-types';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
+import { connect } from 'react-redux';
+import { injectIntl } from 'react-intl';
+import messages from '../../Messages';
+
+const ViewHostAcks = ({ fetchHostAcks, handleModalToggle, intl, isModalOpen, hostAcks, rule, afterFn }) => {
+    const columns = [
+        intl.formatMessage(messages.systemName),
+        intl.formatMessage(messages.justificationNote),
+        intl.formatMessage(messages.dateDisabled),
+        ''
+    ];
+    const [rows, setRows] = useState([]);
+
+    const deleteAck = async (host) => {
+        try {
+            await API.delete(`${BASE_URL}/hostack/${host.id}/`);
+            fetchHostAcks({ limit: 100000 });
+        } catch (error) {
+            handleModalToggle(false);
+            addNotification({
+                variant: 'danger',
+                dismissable: true,
+                title: intl.formatMessage(messages.error),
+                description: `${error}`
+            });
+        }
+    };
+
+    useEffect(() => {
+        if (hostAcks.data) {
+            const rows = hostAcks.data.filter(item => item.rule === rule.rule_id).map(item => ({
+                cells: [
+                    item.system_uuid,
+                    item.justification || intl.formatMessage(messages.none),
+                    (new Date(item.updated_at)).toLocaleDateString(),
+                    {
+                        title: <Button key={item.system_uuid} isInline variant='link' onClick={() => deleteAck(item)}>
+                            <OutlinedBellIcon size='sm' /> &nbsp; {intl.formatMessage(messages.enable)}
+                        </Button >
+                    }
+                ]
+            })).asMutable();
+
+            if (!rows.length) { afterFn(); handleModalToggle(false); }
+
+            setRows(rows);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [hostAcks]);
+
+    return <Modal
+        width={'50%'}
+        title={intl.formatMessage(messages.hostAckModalTitle)}
+        isOpen={isModalOpen}
+        onClose={() => { afterFn(); handleModalToggle(false); }}
+        isFooterLeftAligned
+    >
+        <Table aria-label="host-ack-table" rows={rows} cells={columns}>
+            <TableHeader />
+            <TableBody />
+        </Table>
+    </Modal>;
+};
+
+ViewHostAcks.propTypes = {
+    isModalOpen: PropTypes.bool,
+    handleModalToggle: PropTypes.func,
+    intl: PropTypes.any,
+    rule: PropTypes.object,
+    fetchHostAcks: PropTypes.func,
+    hostAcks: PropTypes.object,
+    addNotification: PropTypes.func,
+    afterFn: PropTypes.func
+
+};
+
+ViewHostAcks.defaultProps = {
+    isModalOpen: false,
+    handleModalToggle: () => undefined,
+    rule: {},
+    afterFn: () => undefined
+};
+
+const mapStateToProps = (state, ownProps) => ({
+    hostAcks: state.AdvisorStore.hostAcks,
+    ...ownProps
+});
+
+const mapDispatchToProps = dispatch => ({
+    setAck: data => dispatch(setAck(data)),
+    fetchHostAcks: data => dispatch(fetchHostAcks(data)),
+    addNotification: data => dispatch(addNotification(data))
+
+});
+
+export default injectIntl(connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(ViewHostAcks));

--- a/src/SmartComponents/Rules/Details.js
+++ b/src/SmartComponents/Rules/Details.js
@@ -20,7 +20,7 @@ import {
     ToolbarItem
 } from '@patternfly/react-core';
 import { BulkSelect, Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
-import React, { Component } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import API from '../../Utilities/Api';
 import { BASE_URL } from '../../AppConstants';
@@ -33,6 +33,7 @@ import MessageState from '../../PresentationalComponents/MessageState/MessageSta
 import PropTypes from 'prop-types';
 import RemediationButton from '@redhat-cloud-services/frontend-components-remediations/RemediationButton';
 import RuleDetails from '../../PresentationalComponents/RuleDetails/RuleDetails';
+import ViewHostAcks from '../../PresentationalComponents/Modals/ViewHostAcks';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import { connect } from 'react-redux';
 import { global_BackgroundColor_100 } from '@patternfly/react-tokens';
@@ -40,217 +41,248 @@ import { injectIntl } from 'react-intl';
 import messages from '../../Messages';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
 
-class OverviewDetails extends Component {
-    state = {
-        kbaDetails: {},
-        kbaDetailsLoading: false,
-        selected: false,
-        selectedEntities: 0,
-        actionsDropdownOpen: false,
-        disableRuleModalOpen: false
+const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchRule, ruleFetchStatus, rule, systemFetchStatus, system, intl, entities,
+    topics, ruleAck, hostAcks, fetchHostAcks, selectEntity }) => {
+    const [selected, setSelected] = useState(false);
+    const [selectedEntities, setSelectedEntities] = useState(0);
+    const [actionsDropdownOpen, setActionsDropdownOpen] = useState(false);
+    const [disableRuleModalOpen, setDisableRuleModalOpen] = useState(false);
+    const [host, setHost] = useState(undefined);
+    const [ruleHostAcks, setRuleHostAcks] = useState([]);
+    const [viewSystemsModalOpen, setviewSystemsModalOpen] = useState(false);
+
+    const getSelectedItems = useCallback(() => {
+        return entities && entities.loaded ?
+            selectedEntities === system.host_ids.length ? system.host_ids
+                : entities.rows.filter(entity => entity.selected === true).map(entity => entity.id)
+            : [];
+    }, [entities, selectedEntities, system.host_ids]);
+
+    const remediationDataProvider = () => ({
+        issues: [{
+            id: `advisor:${rule.rule_id}`,
+            description: rule.description
+        }],
+        systems: getSelectedItems()
+    });
+
+    const onRemediationCreated = result => (addNotification(result.getNotification()));
+
+    const bulkOnClick = (selected, selectedEntities) => {
+        setSelectedEntities(selectedEntities);
+        setSelected(selected);
+        selectEntity({ selected });
     };
 
-    async componentDidMount() {
-        const { fetchRule, fetchRuleAck, fetchSystem, fetchTopics, match } = this.props;
-        await fetchRule({ rule_id: match.params.id });
-        fetchSystem({ rule_id: match.params.id });
-        fetchTopics();
-        this.setState({ selectedEntities: this.getSelectedItems().length });
-        if (!this.props.rule.reports_shown && this.props.rule.rule_id) {
-            fetchRuleAck({ rule_id: this.props.rule.rule_id });
-        }
-    }
-    componentDidUpdate(prevProps) {
-        if (this.props !== prevProps) {
-            this.setState({ selectedEntities: this.getSelectedItems().length });
-        }
-    }
-
-    getSelectedItems = () => {
-        const { entities, system } = this.props;
-        if (!entities || !entities.loaded) {
-            return [];
-        }
-
-        return (this.state.selectedEntities === system.host_ids.length) && this.state.selectedEntities > 1 ? system.host_ids
-            : entities.rows.filter(entity => entity.selected === true).map(entity => entity.id);
+    const handleModalToggle = (disableRuleModalOpen, host = undefined) => {
+        setDisableRuleModalOpen(disableRuleModalOpen);
+        setHost(host);
     };
 
-    remediationDataProvider = () => {
-        return {
-            issues: [{
-                id: `advisor:${this.props.rule.rule_id}`,
-                description: this.props.rule.description
-            }],
-            systems: this.getSelectedItems()
-        };
-    };
-
-    onRemediationCreated = result => {
-        this.props.addNotification(result.getNotification());
-    };
-
-    bulkOnClick = (selected, selectedEntities) => {
-        this.setState({ selected, selectedEntities });
-        this.props.selectEntity({ selected });
-    }
-
-    handleModalToggle = (disableRuleModalOpen) => {
-        this.setState({ disableRuleModalOpen });
-    }
-
-    enableRule = async (rule) => {
+    const enableRule = async (rule) => {
         try {
             await API.delete(`${BASE_URL}/ack/${rule.rule_id}/`);
-            this.props.fetchRule({ rule_id: this.props.match.params.id });
+            fetchSystem({ rule_id: match.params.id });
+            fetchRule({ rule_id: match.params.id });
         } catch (error) {
-            this.handleModalToggle(false);
+            handleModalToggle(false);
             addNotification({
                 variant: 'danger',
                 dismissable: true,
-                title: this.props.intl.formatMessage(messages.rulesTableHideReportsErrorDisabled),
+                title: intl.formatMessage(messages.rulesTableHideReportsErrorDisabled),
                 description: `${error}`
             });
         }
-    }
+    };
 
-    render() {
-        const { match, ruleFetchStatus, rule, systemFetchStatus, system, intl, entities, topics, ruleAck } = this.props;
-        const { selected, selectedEntities, disableRuleModalOpen, actionsDropdownOpen } = this.state;
-        const bulkSelectMenuItems = [{
-            title: intl.formatMessage(messages.selectNone),
-            onClick: () => this.bulkOnClick(false, 0)
-        },
-        {
-            title: intl.formatMessage(messages.selectPage, { items: entities && entities.count || 0 }),
-            onClick: () => this.bulkOnClick(true, entities && entities.count || 0)
-        },
-        {
-            title: intl.formatMessage(messages.selectAll, { items: system && system.host_ids && system.host_ids.length || 0 }),
-            onClick: () => this.bulkOnClick(true, system && system.host_ids && system.host_ids.length || 0)
-        }];
+    const bulkSelectMenuItems = [{
+        title: intl.formatMessage(messages.selectNone),
+        onClick: () => bulkOnClick(false, 0)
+    },
+    {
+        title: intl.formatMessage(messages.selectPage, { items: entities && entities.count || 0 }),
+        onClick: () => bulkOnClick(true, entities && entities.count || 0)
+    },
+    {
+        title: intl.formatMessage(messages.selectAll, { items: system && system.host_ids && system.host_ids.length || 0 }),
+        onClick: () => bulkOnClick(true, system && system.host_ids && system.host_ids.length || 0)
+    }];
 
-        return (
+    const afterViewSystemsFn = () => {
+        fetchSystem({ rule_id: match.params.id });
+    };
+
+    const afterDisableFn = () => {
+        setHost(undefined);
+        fetchRule({ rule_id: match.params.id });
+    };
+
+    const actionResolver = () => ([{
+        title: 'Disable rule for system',
+        onClick: (event, rowIndex, item) => (handleModalToggle(true, item))
+    }]);
+
+    useEffect(() => {
+        if (host === undefined) {
+            fetchSystem({ rule_id: match.params.id });
+            fetchHostAcks({ limit: 100000 });
+        }
+    }, [fetchHostAcks, fetchSystem, host, match.params.id]);
+
+    useEffect(() => {
+        fetchRule({ rule_id: match.params.id });
+        fetchHostAcks({ limit: 100000 });
+        fetchSystem({ rule_id: match.params.id });
+        fetchTopics();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+        if (!rule.reports_shown && rule.rule_id) {
+            fetchRuleAck({ rule_id: rule.rule_id });
+        }
+    }, [fetchRuleAck, rule.reports_shown, rule.rule_id]);
+
+    useEffect(() => {
+        setSelectedEntities(getSelectedItems().length);
+    }, [getSelectedItems]);
+
+    useEffect(() => {
+        if (hostAcks && hostAcks.data) {
+            setRuleHostAcks(hostAcks.data.filter(item => item.rule === rule.rule_id));
+        }
+    }, [hostAcks, rule.rule_id]);
+
+    return <React.Fragment>
+        {viewSystemsModalOpen && <ViewHostAcks
+            handleModalToggle={(toggleModal) => setviewSystemsModalOpen(toggleModal)}
+            isModalOpen={viewSystemsModalOpen}
+            afterFn={afterViewSystemsFn}
+            rule={rule}
+        />}
+        {disableRuleModalOpen && <DisableRule
+            handleModalToggle={handleModalToggle}
+            isModalOpen={disableRuleModalOpen}
+            rule={rule}
+            afterFn={afterDisableFn}
+            host={host} />
+        }
+        {ruleFetchStatus === 'fulfilled' &&
             <React.Fragment>
-                <DisableRule
-                    handleModalToggle={this.handleModalToggle}
-                    isModalOpen={disableRuleModalOpen}
-                    rule={rule}
-                    afterDisableFn={() => this.props.fetchRule({ rule_id: this.props.match.params.id })}
-                />
-                {ruleFetchStatus === 'fulfilled' && (
+                <PageHeader className='pageHeaderOverride'>
+                    <Breadcrumbs
+                        current={rule.description || ''}
+                        match={match} />
+                </PageHeader>
+                <Main className='pf-m-light pf-u-pt-sm'>
+                    <RuleDetails rule={rule} topics={topics} header={
+                        <React.Fragment>
+                            <PageHeaderTitle title={<span>
+                                {!rule.reports_shown && <Badge isRead>
+                                    <BellSlashIcon size='md' />&nbsp;
+                                    {intl.formatMessage(messages.disabled)}
+                                </Badge>}
+                                {rule.description}
+                            </span>} />
+                            <p>{intl.formatMessage(
+                                messages.rulesDetailsPubishdate, { date: (new Date(rule.publish_date)).toLocaleDateString() }
+                            )}</p>
+                        </React.Fragment>}>
+                        <Flex>
+                            <FlexItem breakpointMods={[{ modifier: 'align-right' }]}>
+                                <Dropdown
+                                    onSelect={() => setActionsDropdownOpen(!actionsDropdownOpen)}
+                                    toggle={<DropdownToggle
+                                        onToggle={(actionsDropdownOpen) => setActionsDropdownOpen(actionsDropdownOpen)}
+                                        iconComponent={CaretDownIcon}>Actions
+                                    </DropdownToggle>}
+                                    isOpen={actionsDropdownOpen}
+                                    dropdownItems={rule && rule.reports_shown ?
+                                        [<DropdownItem key='link'
+                                            onClick={() => { handleModalToggle(true); }}>
+                                            {intl.formatMessage(messages.disableRule)}</DropdownItem>]
+                                        : [<DropdownItem key='link'
+                                            onClick={() => { enableRule(rule); }}>
+                                            {intl.formatMessage(messages.enableRule)}</DropdownItem>]} />
+                            </FlexItem>
+                        </Flex>
+                    </RuleDetails>
+                </Main>
+            </React.Fragment>}
+        {ruleFetchStatus === 'pending' && (<Loading />)}
+        <Main>
+            <React.Fragment>
+                {ruleFetchStatus === 'fulfilled' &&
                     <React.Fragment>
-                        <PageHeader className='pageHeaderOverride'>
-                            <Breadcrumbs
-                                current={rule.description || ''}
-                                match={match}
-                            />
-                        </PageHeader>
-                        <Main className='pf-m-light pf-u-pt-sm'>
-                            <RuleDetails rule={rule} topics={topics} header={
-                                <React.Fragment>
-                                    <PageHeaderTitle title={<span>
-                                        {!rule.reports_shown && <Badge isRead>
-                                            <BellSlashIcon size='md' />&nbsp;
-                                            {intl.formatMessage(messages.disabled)}
-                                        </Badge>}
-                                        {rule.description}
-                                    </span>} />
-                                    <p>{intl.formatMessage(
-                                        messages.rulesDetailsPubishdate, { date: (new Date(rule.publish_date)).toLocaleDateString() }
-                                    )}</p>
-                                </React.Fragment>
-                            }>
-                                <Flex>
-                                    <FlexItem breakpointMods={[{ modifier: 'align-right' }]}>
-                                        <Dropdown
-                                            onSelect={() => { this.setState({ actionsDropdownOpen: !actionsDropdownOpen }); }}
-                                            toggle={<DropdownToggle
-                                                onToggle={(actionsDropdownOpen) => { this.setState({ actionsDropdownOpen }); }}
-                                                iconComponent={CaretDownIcon}>Actions
-                                            </DropdownToggle>}
-                                            isOpen={actionsDropdownOpen}
-                                            dropdownItems={rule && rule.reports_shown ?
-                                                [<DropdownItem key="link"
-                                                    onClick={() => { this.handleModalToggle(true); }}>
-                                                    {intl.formatMessage(messages.disableRule)}</DropdownItem>]
-                                                : [<DropdownItem key="link"
-                                                    onClick={() => { this.enableRule(rule); }}>
-                                                    {intl.formatMessage(messages.enableRule)}</DropdownItem>]
-                                            }
-                                        />
-                                    </FlexItem>
-                                </Flex>
-                            </RuleDetails>
-                        </Main>
-                    </React.Fragment>
-                )}
-                {ruleFetchStatus === 'pending' && (<Loading />)}
-                <Main>
-                    <React.Fragment>
-                        {ruleFetchStatus === 'fulfilled' && rule.reports_shown ?
-                            <React.Fragment>
-                                <Title headingLevel="h3" size="2xl" className='titlePaddingOverride'>
-                                    {intl.formatMessage(messages.affectedSystems)}
-                                </Title>
-                                {systemFetchStatus === 'fulfilled' && (
-                                    <Inventory tableProps={{ canSelectAll: false }} items={system.host_ids}>
-                                        {rule.playbook_count > 0 &&
-                                            <ToolbarGroup>
-                                                <ToolbarItem className='pf-u-mr-sm'>
-                                                    <BulkSelect count={selectedEntities}
-                                                        items={bulkSelectMenuItems}
-                                                        checked={selected}
-                                                        onChange={() => {
-                                                            this.bulkOnClick(!selected, !selected ?
-                                                                system && system.host_ids && system.host_ids.length : 0);
-                                                        }} />
-                                                </ToolbarItem>
-                                                <ToolbarItem>
-                                                    <RemediationButton
-                                                        isDisabled={selectedEntities === 0}
-                                                        dataProvider={this.remediationDataProvider}
-                                                        onRemediationCreated={this.onRemediationCreated}
-                                                    >
-                                                        <AnsibeTowerIcon size='sm' color={global_BackgroundColor_100.value} />
-                                                        &nbsp;{intl.formatMessage(messages.remediate)}
-                                                    </RemediationButton>
-                                                </ToolbarItem>
-                                            </ToolbarGroup>
-                                        }
-                                    </Inventory>
-                                )}
-                                {systemFetchStatus === 'pending' && (<Loading />)}
-                            </React.Fragment>
-                            : <React.Fragment>
-                                <Card className='cardBorderOverride'>
-                                    <CardHead>
-                                        <BellSlashIcon size='sm' />&nbsp;{intl.formatMessage(messages.ruleIsDisabled)}</CardHead>
-                                    <CardBody>
-                                        <p>
+                        {(ruleHostAcks.length > 0 || !rule.reports_shown) && <Card className='cardBorderOverride'>
+                            <CardHead>
+                                <BellSlashIcon size='sm' />&nbsp;{intl.formatMessage(ruleHostAcks.length > 0 && rule.reports_shown ?
+                                    messages.ruleIsDisabledForSystems : messages.ruleIsDisabled)}</CardHead>
+                            <CardBody>
+                                <p>
+                                    {ruleHostAcks.length > 0 && rule.reports_shown ?
+                                        <React.Fragment>
+                                            {intl.formatMessage(messages.ruleIsDisabledForSystemsBody, { systems: ruleHostAcks.length })}
+                                            &nbsp;
+                                            <Button isInline variant='link' onClick={() => setviewSystemsModalOpen(true)}>
+                                                {intl.formatMessage(messages.viewSystems)}
+                                            </Button>
+                                        </React.Fragment>
+                                        : <React.Fragment>
                                             {intl.formatMessage(messages.ruleIsDisabledJustification)}
                                             <i>{ruleAck.justification || intl.formatMessage(messages.none)}</i>
                                             {ruleAck.updated_at && <span>&nbsp;({new Date(ruleAck.updated_at).toLocaleDateString()})</span>}
-                                        </p>
-                                        <Button isInline variant='link'
-                                            onClick={() => { this.enableRule(rule); }}>
-                                            {intl.formatMessage(messages.enableRule)}
-                                        </Button>
-                                    </CardBody>
-                                </Card>
-                                <MessageState icon={BellSlashIcon} size='sm'
-                                    title={intl.formatMessage(messages.ruleIsDisabled)}
-                                    text={intl.formatMessage(messages.ruleIsDisabledBody)} />
-                            </React.Fragment>
-                        }
-                        {ruleFetchStatus === 'pending' && (<Loading />)}
-                        {ruleFetchStatus === 'failed' && (<Failed message={intl.formatMessage(messages.rulesTableFetchRulesError)} />)}
-                    </React.Fragment>
-                </Main>
+                                        </React.Fragment>}
+                                </p>
+                                {ruleHostAcks.length > 0 && rule.reports_shown ?
+                                    // to be enabled with bulk actions
+                                    // <Button isInline variant='link' onClick={() => enableRuleForSystems()}>
+                                    //     {intl.formatMessage(messages.enableRuleForSystems)}
+                                    // </Button>
+                                    <React.Fragment></React.Fragment>
+                                    : <Button isInline variant='link' onClick={() => enableRule(rule)}>
+                                        {intl.formatMessage(messages.enableRule)}
+                                    </Button>}
+                            </CardBody>
+                        </Card>}
+                        {rule.reports_shown && <React.Fragment>
+                            <Title headingLevel='h3' size='2xl'>
+                                {intl.formatMessage(messages.affectedSystems)}
+                            </Title>
+                            {systemFetchStatus === 'fulfilled' &&
+                                <Inventory tableProps={{ canSelectAll: false, actionResolver }} items={system.host_ids}>
+                                    {rule.playbook_count > 0 &&
+                                        <ToolbarGroup>
+                                            <ToolbarItem className='pf-u-mr-sm'>
+                                                <BulkSelect count={selectedEntities}
+                                                    items={bulkSelectMenuItems}
+                                                    checked={selected && selectedEntities === system.host_ids.length}
+                                                    onChange={() => bulkOnClick(!selected, !selected ?
+                                                        system && system.host_ids && system.host_ids.length : 0)} />
+                                            </ToolbarItem>
+                                            <ToolbarItem>
+                                                <RemediationButton
+                                                    isDisabled={selectedEntities === 0}
+                                                    dataProvider={remediationDataProvider}
+                                                    onRemediationCreated={onRemediationCreated}>
+                                                    <AnsibeTowerIcon size='sm' color={global_BackgroundColor_100.value} />
+                                                    &nbsp;{intl.formatMessage(messages.remediate)}
+                                                </RemediationButton>
+                                            </ToolbarItem>
+                                        </ToolbarGroup>}
+                                </Inventory>}
+                            {systemFetchStatus === 'pending' && (<Loading />)}
+                        </React.Fragment>}
+                        {systemFetchStatus === 'fulfilled' && !rule.reports_shown && <MessageState icon={BellSlashIcon} size='sm'
+                            title={intl.formatMessage(messages.ruleIsDisabled)}
+                            text={intl.formatMessage(messages.ruleIsDisabledBody)} />}
+                    </React.Fragment>}
+                {ruleFetchStatus === 'pending' && (<Loading />)}
+                {ruleFetchStatus === 'failed' && (<Failed message={intl.formatMessage(messages.rulesTableFetchRulesError)} />)}
             </React.Fragment>
-        );
-    }
-}
+        </Main>
+    </React.Fragment>;
+};
 
 OverviewDetails.propTypes = {
     match: PropTypes.any,
@@ -261,13 +293,16 @@ OverviewDetails.propTypes = {
     systemFetchStatus: PropTypes.string,
     system: PropTypes.object,
     entities: PropTypes.any,
-    addNotification: PropTypes.func.isRequired,
+    addNotification: PropTypes.func,
     intl: PropTypes.any,
     selectEntity: PropTypes.func,
     fetchTopics: PropTypes.func,
     topics: PropTypes.array,
     ruleAck: PropTypes.object,
-    fetchRuleAck: PropTypes.func
+    fetchRuleAck: PropTypes.func,
+    fetchHostAcks: PropTypes.func,
+    hostAcks: PropTypes.object
+
 };
 
 const mapStateToProps = (state, ownProps) => ({
@@ -278,6 +313,7 @@ const mapStateToProps = (state, ownProps) => ({
     entities: state.entities,
     topics: state.AdvisorStore.topics,
     ruleAck: state.AdvisorStore.ruleAck,
+    hostAcks: state.AdvisorStore.hostAcks,
     ...ownProps
 });
 
@@ -287,7 +323,9 @@ const mapDispatchToProps = dispatch => ({
     addNotification: data => dispatch(addNotification(data)),
     selectEntity: (payload) => dispatch({ type: 'SELECT_ENTITY', payload }),
     fetchTopics: () => dispatch(AppActions.fetchTopics()),
-    fetchRuleAck: data => dispatch(AppActions.fetchRuleAck(data))
+    fetchRuleAck: data => dispatch(AppActions.fetchRuleAck(data)),
+    fetchHostAcks: data => dispatch(AppActions.fetchHostAcks(data))
+
 });
 
 export default injectIntl(routerParams(connect(

--- a/src/SmartComponents/Rules/Details.scss
+++ b/src/SmartComponents/Rules/Details.scss
@@ -1,15 +1,16 @@
-.titlePaddingOverride{
-  padding-bottom: var(--pf-global--spacer--sm);
-}
-
-.pageHeaderOverride{
+.pageHeaderOverride {
   padding-bottom: 0px;
 }
 
-.cardBorderOverride{
+.cardBorderOverride {
   border-left: var(--pf-global--BorderWidth--lg) solid var(--pf-global--info-color--200);
-  
+  margin-bottom: var(--pf-global--spacer--md);
   .pf-c-card__head {
     color: var(--pf-global--info-color--200);
+    padding-top: var(--pf-global--spacer--md);
   }
+}
+
+.pf-c-card__body {
+  padding-bottom: var(--pf-global--spacer--md);
 }


### PR DESCRIPTION
sorry, its a biggie 😭 

almost fixes https://projects.engineering.redhat.com/browse/RHCLOUD-2986
but really just: 
* https://projects.engineering.redhat.com/browse/RHCLOUD-2985
* https://projects.engineering.redhat.com/browse/RHCLOUD-2986

this work is blocked by (but not really, we'll still merge)
* https://projects.engineering.redhat.com/browse/RHCLOUD-3424

**this has one quirk** (that already existed), relating to bulk select, if you select all, then deselect items from the table, unless select none is used (or another bulk action) the table deselect is not reflected (this is because when bulk select was added, inventory didn't support it, so we rolled our own, this has since changed, and updating to inventory bulk select will fix this bug

#### quick, where did we have those 25 systems acked!
<img width="1920" alt="Screen Shot 2019-11-20 at 3 41 00 PM" src="https://user-images.githubusercontent.com/6640236/69276290-3209b980-0bac-11ea-976a-70ab45de354e.png">

#### i did a lotta acking
<img width="1309" alt="Screen Shot 2019-11-21 at 11 59 43 AM" src="https://user-images.githubusercontent.com/6640236/69359360-6fc31c80-0c56-11ea-8725-f9040b0e4c94.png">

#### checkbox does work
<img width="951" alt="Screen Shot 2019-11-18 at 3 22 25 PM" src="https://user-images.githubusercontent.com/6640236/69090989-6009c500-0a17-11ea-8d48-851a5b0136b9.png">
