### PR TITLE
Unifies date format across ack work

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -108,7 +108,7 @@
     "save": "Save",
     "cancel": "Cancel",
     "none": "None",
-    "dateDisabled": "Date Disabled",
+    "dateDisabled": "Date disabled",
     "hostAckModalTitle": "Rule has been disabled for:",
     "systemName": "System name",
     "enable": "Enable",

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -107,7 +107,7 @@
   "save": "Save",
   "cancel": "Cancel",
   "none": "None",
-  "dateDisabled": "Date Disabled",
+  "dateDisabled": "Date disabled",
   "hostAckModalTitle": "Rule has been disabled for:",
   "systemName": "System name",
   "enable": "Enable",

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -554,7 +554,7 @@ export default defineMessages({
     dateDisabled: {
         id: 'dateDisabled',
         description: 'Date disabled',
-        defaultMessage: 'Date Disabled'
+        defaultMessage: 'Date disabled'
     },
     hostAckModalTitle: {
         id: 'hostAckModalTitle',

--- a/src/PresentationalComponents/Modals/ViewHostAcks.js
+++ b/src/PresentationalComponents/Modals/ViewHostAcks.js
@@ -6,6 +6,7 @@ import { fetchHostAcks, setAck } from '../../AppActions';
 
 import API from '../../Utilities/Api';
 import { BASE_URL } from '../../AppConstants';
+import { DateFormat } from '@redhat-cloud-services/frontend-components';
 import { OutlinedBellIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
@@ -43,7 +44,7 @@ const ViewHostAcks = ({ fetchHostAcks, handleModalToggle, intl, isModalOpen, hos
                 cells: [
                     item.system_uuid,
                     item.justification || intl.formatMessage(messages.none),
-                    (new Date(item.updated_at)).toLocaleDateString(),
+                    { title: <DateFormat date={new Date(item.updated_at)} type="onlyDate" /> },
                     {
                         title: <Button key={item.system_uuid} isInline variant='link' onClick={() => deleteAck(item)}>
                             <OutlinedBellIcon size='sm' /> &nbsp; {intl.formatMessage(messages.enable)}

--- a/src/SmartComponents/Rules/Details.js
+++ b/src/SmartComponents/Rules/Details.js
@@ -20,7 +20,7 @@ import {
     ToolbarGroup,
     ToolbarItem
 } from '@patternfly/react-core';
-import { BulkSelect, Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
+import { BulkSelect, DateFormat, Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import API from '../../Utilities/Api';
@@ -186,7 +186,7 @@ const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchR
                                 {rule.description}
                             </span>} />
                             <p>{intl.formatMessage(
-                                messages.rulesDetailsPubishdate, { date: (new Date(rule.publish_date)).toLocaleDateString() }
+                                messages.rulesDetailsPubishdate, { date: <DateFormat date={new Date(rule.publish_date)} type="onlyDate" /> }
                             )}</p>
                         </React.Fragment>}>
                         <Flex>
@@ -232,7 +232,7 @@ const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchR
                                     : <React.Fragment>
                                         {intl.formatMessage(messages.ruleIsDisabledJustification)}
                                         <i>{ruleAck.justification || intl.formatMessage(messages.none)}</i>
-                                        {ruleAck.updated_at && <span>&nbsp;({new Date(ruleAck.updated_at).toLocaleDateString()})</span>}
+                                        {ruleAck.updated_at && <span>&nbsp;<DateFormat date={new Date(ruleAck.updated_at)} type="onlyDate" /></span>}
                                     </React.Fragment>}
                             </CardBody>
                             <CardFooter>


### PR DESCRIPTION
#### you'll notice everywhere we mention a date, it looks kinda similar
<img width="1311" alt="Screen Shot 2019-11-26 at 9 37 29 AM" src="https://user-images.githubusercontent.com/6640236/69643069-c2268380-1030-11ea-8562-f2cea7f0582c.png">
<img width="1314" alt="Screen Shot 2019-11-26 at 9 37 11 AM" src="https://user-images.githubusercontent.com/6640236/69643070-c2268380-1030-11ea-94d8-3168d3655d7a.png">
