### PR TITLE
Adds total risk tooltip and label to rules table

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -1,7 +1,8 @@
 import * as AppActions from '../../AppActions';
+import * as AppConstants from '../../AppConstants';
 
 import { AnsibeTowerIcon, BellSlashIcon, CheckCircleIcon, CheckIcon } from '@patternfly/react-icons';
-import { Badge, Button, Pagination, PaginationVariant, Stack, StackItem } from '@patternfly/react-core';
+import { Badge, Button, Pagination, PaginationVariant, Stack, StackItem, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { Battery, Main, PrimaryToolbar, TableToolbar } from '@redhat-cloud-services/frontend-components';
 /* eslint camelcase: 0 */
 import React, { useCallback, useEffect, useState } from 'react';
@@ -30,7 +31,7 @@ const RulesTable = ({ rules, filters, rulesFetchStatus, setFilters, fetchRules, 
     const [cols] = useState([
         { title: intl.formatMessage(messages.description), transforms: [sortable] },
         { title: intl.formatMessage(messages.added), transforms: [sortable, cellWidth(15)] },
-        { title: intl.formatMessage(messages.totalRisk), transforms: [sortable] },
+        { title: intl.formatMessage(messages.totalRisk), transforms: [sortable, cellWidth(15)] },
         { title: intl.formatMessage(messages.systems), transforms: [sortable] },
         {
             title: <><AnsibeTowerIcon size='md' /> {intl.formatMessage(messages.ansible)}</>,
@@ -248,12 +249,18 @@ const RulesTable = ({ rules, filters, rulesFetchStatus, setFilters, fetchRules, 
                             {moment(value.publish_date).fromNow()}
                         </div>
                     }, {
-                        title: <div className="pf-m-center" key={key} style={{ verticalAlign: 'top' }}>
-                            <Battery
-                                label={intl.formatMessage(messages.totalRisk)}
-                                labelHidden
-                                severity={value.total_risk}
-                            />
+                        title: <div className="pf-m-center" key={key}>
+                            <Tooltip position={TooltipPosition.bottom} content={intl.formatMessage(messages.rulesDetailsTotalriskBody, {
+                                likelihood: AppConstants.LIKELIHOOD_LABEL[value.likelihood] || intl.formatMessage(messages.undefined),
+                                impact: AppConstants.IMPACT_LABEL[value.impact.impact] || intl.formatMessage(messages.undefined),
+                                strong(str) { return <strong>{str}</strong>; }
+                            })}>
+                                <Battery
+                                    label={AppConstants.TOTAL_RISK_LABEL[value.total_risk] || intl.formatMessage(messages.undefined)}
+                                    RHCLOUD-2752
+                                    severity={value.total_risk}
+                                />
+                            </Tooltip>
                         </div>
                     }, {
                         title: <div key={key}> {value.reports_shown ?


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-2752
aligns with https://marvelapp.com/i4441ie/screen/58398647

#### now we look like 
<img width="1224" alt="Screen Shot 2019-12-10 at 9 09 27 AM" src="https://user-images.githubusercontent.com/6640236/70536644-25361100-1b2d-11ea-8f4b-9fb00aec4032.png">
<img width="1224" alt="Screen Shot 2019-12-10 at 9 09 45 AM" src="https://user-images.githubusercontent.com/6640236/70536645-25361100-1b2d-11ea-83c1-746169c230bf.png">
