### PR TITLE
Inv-table preserves page number after host ack

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -18,10 +18,11 @@ import { injectIntl } from 'react-intl';
 import messages from '../../Messages';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
 
+let page = 1;
+let rule_id = '';
 const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification, items, afterDisableFn }) => {
     const inventory = useRef(null);
     const [InventoryTable, setInventoryTable] = useState();
-    const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(50);
     const [selected, setSelected] = useState([]);
     const [disableRuleModalOpen, setDisableRuleModalOpen] = useState(false);
@@ -48,9 +49,12 @@ const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification
     };
 
     const onRefresh = (options) => {
-        setPage(options.page);
         setPageSize(options.per_page);
+        rule_id !== rule.rule_id && (page = 1);
+
         if (inventory && inventory.current) {
+            page = options.page;
+            rule_id = rule.rule_id;
             inventory.current.onRefreshData(options);
         }
     };


### PR DESCRIPTION
Plays well with bulk actions, page redirect, n edge cases of acking the last page

fixes https://projects.engineering.redhat.com/browse/RHCLOUD-3918

##### existing behavior 
acking a host, if yah were on page 10, would send you back to page 1

##### new behavior
* acking a host, if yah were on page 10, will keep you on page 10
* checking host details will not change inv-table page
* navigating away from page and back to will not change inv-table page ~(BUT THIS HAS ONE GOTCHA (that imma fix real quick) navigating between rules won't reset page value)~ but going to away from page and to a different rule *will* reset the page to 1
