### PR TITLE
Fix topics admin protected route - set a pattern for app route rbac

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4170,9 +4170,9 @@
       "integrity": "sha512-HVa1fe7H4NRRv6lmezpvW2TfIDF7bSbKvhMmCVqBk80Fd3wfLcPhacnWdt6PLWq7WX4dVx7dF7+v4sFh8RczSg=="
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-0.0.45.tgz",
-      "integrity": "sha512-ODrty0SYYJprrWGX79nT/wnKVIs3moN5+bAXwLEegF6wU4yBTjpJYytS3XoApdqERGydkGjjffOqDat3mfd2Kw==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-0.0.47.tgz",
+      "integrity": "sha512-t1LCOasK+8X/6e3Dgc4KuQgl4qi5JLesKQLAhAVfxuU4hHb6pBSpXOv3UasXRxjZupQc2mcUjiQcvdols0S6Wg==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": ">=0.0.7"
       }
@@ -5164,9 +5164,9 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -11167,9 +11167,9 @@
       "dev": true
     },
     "globule": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.0.tgz",
+      "integrity": "sha512-YlD4kdMqRCQHrhVdonet4TdRtv1/sZKepvoxNT4Nrhrp5HI8XFfc8kFlGlBn2myBo80aGp8Eft259mbcUJhgSg==",
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
@@ -15473,9 +15473,9 @@
       }
     },
     "node-sass": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
-      "integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -19132,9 +19132,9 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@patternfly/react-icons": "3.14.33",
     "@patternfly/react-table": "2.24.64",
     "@patternfly/react-tokens": "2.7.14",
-    "@redhat-cloud-services/frontend-components": "0.0.45",
+    "@redhat-cloud-services/frontend-components": "0.0.47",
     "@redhat-cloud-services/frontend-components-inventory-insights": "0.4.2",
     "@redhat-cloud-services/frontend-components-notifications": "0.0.7",
     "@redhat-cloud-services/frontend-components-remediations": "0.0.4",

--- a/src/SmartComponents/Topics/Topics.js
+++ b/src/SmartComponents/Topics/Topics.js
@@ -1,25 +1,31 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useReducer } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
+import PropTypes from 'prop-types';
 import asyncComponent from '../../Utilities/asyncComponent';
 
 const List = asyncComponent(() => import(/* webpackChunkName: "TopicsList" */ './List'));
 const Details = asyncComponent(() => import(/* webpackChunkName: "TopicDetails" */ './Details'));
 const Admin = asyncComponent(() => import(/* webpackChunkName: "TopicAdmin" */ '../../PresentationalComponents/TopicsAdminTable/TopicsAdminTable'));
 
-const Topics = () => {
-    const [isInternal, setIsInternal] = useState(false);
-    useEffect(() => { insights.chrome.auth.getUser().then((data) => setIsInternal(data.identity.user.is_internal)); }, []);
+const reducer = (state, { type, payload }) => ({ setLoaded: { ...state, loaded: true, isInternal: payload } }[type]);
 
-    return <React.Fragment>
-        <Switch>
-            {isInternal && <Route exact path='/topics/admin/manage' component={Admin} />}
-            <Route exact path='/topics' component={List} />
-            <Route exact path='/topics/:id' component={Details} />
+const ProtectedRoute = ({ component: Component, ...props }) => {
+    const [state, dispatch] = useReducer(reducer, { isInternal: false, loaded: false });
 
-            <Redirect path='*' to='/topics' push />
-        </Switch>
-    </React.Fragment>;
+    useEffect(() => { insights.chrome.auth.getUser().then((data) => dispatch({ type: 'setLoaded', payload: data.identity.user.is_internal })); }, []);
+
+    return <Route {...props} render={props => state.loaded && (state.isInternal ? <Component {...props} /> : <Redirect to='/topics' />)} />;
 };
+
+const Topics = () => <Switch>
+    <Route exact path='/topics' component={List} />
+    <Route exact path='/topics/:id' component={Details} />
+    <ProtectedRoute exact path='/topics/admin/manage' component={Admin} />
+
+    <Redirect path='*' to='/topics' push />
+</Switch>;
+
+ProtectedRoute.propTypes = { component: PropTypes.any };
 
 export default Topics;


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-4129

so now, if yah have the user flag `is_internal` yah can go to the topics admin table, else redirect to topic.. important part of this work is, we only ever check if you try to go to /admin/manage/ (opposed to of every time topics route is loaded)