### PR TITLE
Replaces badge (incident/disabled) with label component

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -13,6 +13,7 @@
     "disableRuleBody": "Disabling a rule means that hits for this rule across all systems will not be shown in reports and dashboards.",
     "disableRuleSingleSystem": "Disable only for this system",
     "ruleIsDisabled": "Rule is disabled",
+    "ruleIsDisabledTooltip": "Indicates hits for this rule across all systems will not be shown in reports and dashboards.",
     "ruleIsDisabledBody": "This rule has been disabled and has no results.",
     "ruleIsDisabledJustification": "This rule has been disabled for all systems for the following reason: ",
     "ruleIsDisabledForSystems": "Rule is disabled for some systems",
@@ -135,6 +136,10 @@
     "viewAffectedSystems": "View {systems, plural, one {the affected system.} other {# affected systems.}}",
     "ruleHelpful": "Is this rule helpful?",
     "feedbackThankyou": "Thank you for your feedback!",
-    "all": "All"
+    "all": "All",
+    "incidentRules": "Incident rules",
+    "nonIncidentRules": "Non-incident rules",
+    "incident": "Incident",
+    "incidentTooltip": "Indicates configurations that are currently affecting your systems."
   }
 }

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -12,6 +12,7 @@
   "disableRuleBody": "Disabling a rule means that hits for this rule across all systems will not be shown in reports and dashboards.",
   "disableRuleSingleSystem": "Disable only for this system",
   "ruleIsDisabled": "Rule is disabled",
+  "ruleIsDisabledTooltip": "Indicates hits for this rule across all systems will not be shown in reports and dashboards.",
   "ruleIsDisabledBody": "This rule has been disabled and has no results.",
   "ruleIsDisabledJustification": "This rule has been disabled for all systems for the following reason: ",
   "ruleIsDisabledForSystems": "Rule is disabled for some systems",
@@ -134,5 +135,9 @@
   "viewAffectedSystems": "View {systems, plural, one {the affected system.} other {# affected systems.}}",
   "ruleHelpful": "Is this rule helpful?",
   "feedbackThankyou": "Thank you for your feedback!",
-  "all": "All"
+  "all": "All",
+  "incidentRules": "Incident rules",
+  "nonIncidentRules": "Non-incident rules",
+  "incident": "Incident",
+  "incidentTooltip": "Indicates configurations that are currently affecting your systems."
 }

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -124,6 +124,12 @@ export const FILTER_CATEGORIES = {
             { label: intlHelper(intl.formatMessage(messages.security), intlSettings), value: `${RULE_CATEGORIES.security}` }
         ]
     },
+    incident: {
+        type: 'checkbox', title: 'Incident rules', urlParam: 'incident', values: [
+            { label: intlHelper(intl.formatMessage(messages.incidentRules), intlSettings), value: 'true' },
+            { label: intlHelper(intl.formatMessage(messages.nonIncidentRules), intlSettings), value: 'false' }
+        ]
+    },
     reports_shown: {
         type: 'radio', title: 'Rule status', urlParam: 'reports_shown', values: [
             { label: intlHelper(intl.formatMessage(messages.all), intlSettings), value: 'undefined' },

--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -19,7 +19,7 @@ const initialState = Immutable({
     systemFetchStatus: '',
     systemtype: {},
     systemtypeFetchStatus: '',
-    filters: { impacting: true, reports_shown: 'true', sort: '-publish_date' },
+    filters: { impacting: true, reports_shown: 'true', sort: '-publish_date', incident: ['true'] },
     topic: {},
     topicFetchStatus: '',
     topics: [],

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -67,6 +67,11 @@ export default defineMessages({
         description: 'Exclaiming that the rule is disabled',
         defaultMessage: 'Rule is disabled'
     },
+    ruleIsDisabledTooltip: {
+        id: 'ruleIsDisabledTooltip',
+        description: 'Disabled badge tooltip explaining the meaning of a disabled rule',
+        defaultMessage: 'Indicates hits for this rule across all systems will not be shown in reports and dashboards.'
+    },
     ruleIsDisabledBody: {
         id: 'ruleIsDisabledBody',
         description: 'Explaining that the rule is disabled',
@@ -690,5 +695,25 @@ export default defineMessages({
         id: 'all',
         description: 'All',
         defaultMessage: 'All'
+    },
+    incidentRules: {
+        id: 'incidentRules',
+        description: 'Rules with incidents',
+        defaultMessage: 'Incident rules'
+    },
+    nonIncidentRules: {
+        id: 'nonIncidentRules',
+        description: 'Rules with no incidents',
+        defaultMessage: 'Non-incident rules'
+    },
+    incident: {
+        id: 'incident',
+        description: 'Incident',
+        defaultMessage: 'Incident'
+    },
+    incidentTooltip: {
+        id: 'incidentTooltip',
+        description: 'Incident badge tooltip text',
+        defaultMessage: 'Indicates configurations that are currently affecting your systems.'
     }
 });

--- a/src/PresentationalComponents/RuleLabels/RuleLabels.js
+++ b/src/PresentationalComponents/RuleLabels/RuleLabels.js
@@ -1,0 +1,25 @@
+import './_RuleLabels.scss';
+
+import { Label, Tooltip, TooltipPosition } from '@patternfly/react-core';
+
+import { BellSlashIcon } from '@patternfly/react-icons';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { injectIntl } from 'react-intl';
+import messages from '../../Messages';
+
+const RuleLabels = ({ intl, rule }) => <React.Fragment >
+    {rule.tags.search('incident') !== -1 && <Tooltip content={intl.formatMessage(messages.incidentTooltip)} position={TooltipPosition.right}>
+        <Label isCompact className='incidentLabel'>{intl.formatMessage(messages.incident)}</Label>
+    </Tooltip>}
+    {!rule.reports_shown && <Tooltip content={intl.formatMessage(messages.ruleIsDisabledTooltip)} position={TooltipPosition.right}>
+        <Label isCompact className='disabledLabel'><BellSlashIcon size='sm' />&nbsp;{intl.formatMessage(messages.disabled)}</Label>
+    </Tooltip>}
+</React.Fragment>;
+
+RuleLabels.propTypes = {
+    intl: PropTypes.any,
+    rule: PropTypes.object
+};
+
+export default injectIntl(RuleLabels);

--- a/src/PresentationalComponents/RuleLabels/_RuleLabels.scss
+++ b/src/PresentationalComponents/RuleLabels/_RuleLabels.scss
@@ -1,0 +1,11 @@
+.incidentLabel {
+  background-color: var(--pf-global--danger-color--100);
+}
+
+.disabledLabel {
+  background-color: var(--pf-global--Color--200);
+}
+
+.pf-c-label {
+  margin-right: var(--pf-global--spacer--xs);
+}

--- a/src/SmartComponents/Rules/Details.js
+++ b/src/SmartComponents/Rules/Details.js
@@ -3,8 +3,8 @@ import './Details.scss';
 
 import * as AppActions from '../../AppActions';
 
+import { BellSlashIcon, CaretDownIcon } from '@patternfly/react-icons';
 import {
-    Badge,
     Button,
     Card,
     CardBody,
@@ -17,7 +17,6 @@ import {
     FlexItem,
     Title
 } from '@patternfly/react-core';
-import { BellSlashIcon, CaretDownIcon } from '@patternfly/react-icons';
 import { DateFormat, Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
 import React, { useEffect, useState } from 'react';
 
@@ -31,6 +30,7 @@ import Loading from '../../PresentationalComponents/Loading/Loading';
 import MessageState from '../../PresentationalComponents/MessageState/MessageState';
 import PropTypes from 'prop-types';
 import RuleDetails from '../../PresentationalComponents/RuleDetails/RuleDetails';
+import RuleLabels from '../../PresentationalComponents/RuleLabels/RuleLabels';
 import ViewHostAcks from '../../PresentationalComponents/Modals/ViewHostAcks';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import { connect } from 'react-redux';
@@ -132,13 +132,7 @@ const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchR
                 <Main className='pf-m-light pf-u-pt-sm'>
                     <RuleDetails isDetailsPage rule={rule} topics={topics} header={
                         <React.Fragment>
-                            <PageHeaderTitle title={<span>
-                                {!rule.reports_shown && <Badge isRead>
-                                    <BellSlashIcon size='md' />&nbsp;
-                                    {intl.formatMessage(messages.disabled)}
-                                </Badge>}
-                                {rule.description}
-                            </span>} />
+                            <PageHeaderTitle title={<React.Fragment><RuleLabels rule={rule} />{rule.description}</React.Fragment>} />
                             <p>{intl.formatMessage(
                                 messages.rulesDetailsPubishdate, { date: <DateFormat date={new Date(rule.publish_date)} type="onlyDate" /> }
                             )}</p>


### PR DESCRIPTION
So this work adds the incident badge and encapsulates all rule badges in one component. It adds an `incident` filter that is by default, always set to true (kinda like how we have enabled rules set to true by default). It also adds a tooltip for disabled rule badge.  (mocks here https://marvelapp.com/i4441ie/screen/63574982)

fixes https://projects.engineering.redhat.com/browse/RHCLOUD-3648 https://projects.engineering.redhat.com/browse/RHCLOUD-3649 https://projects.engineering.redhat.com/browse/RHCLOUD-3650 https://projects.engineering.redhat.com/browse/RHCLOUD-3651

#### Looks kinda like...
<img width="1309" alt="Screen Shot 2020-01-28 at 11 04 07 AM" src="https://user-images.githubusercontent.com/6640236/73281395-ef70e880-41bd-11ea-9528-16dcd5823970.png">
<img width="1310" alt="Screen Shot 2020-01-28 at 11 09 23 AM" src="https://user-images.githubusercontent.com/6640236/73281905-ae2d0880-41be-11ea-85ae-0936f9b3567c.png">

<img width="1310" alt="Screen Shot 2020-01-27 at 1 04 46 PM" src="https://user-images.githubusercontent.com/6640236/73201001-fa684200-4105-11ea-8e54-81ee0c42ce1c.png">
<img width="1310" alt="Screen Shot 2020-01-27 at 1 04 56 PM" src="https://user-images.githubusercontent.com/6640236/73201002-fb00d880-4105-11ea-9960-e1d81de6398d.png">
<img width="1306" alt="Screen Shot 2020-01-27 at 1 05 13 PM" src="https://user-images.githubusercontent.com/6640236/73201003-fb00d880-4105-11ea-857b-519652cf1fef.png">
<img width="1311" alt="Screen Shot 2020-01-27 at 1 05 31 PM" src="https://user-images.githubusercontent.com/6640236/73201004-fb00d880-4105-11ea-8d40-65513e0e3b2f.png">
