### PR TITLE
Release branches to support master-beta -> master -> master-stable

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -2,33 +2,23 @@
 set -e
 set -x
 
-if [ "${TRAVIS_BRANCH}" = "master" ]; then
-    # for a limited time prod too
-    for env in ci qa prod
-    do
-        echo
+if [ "${TRAVIS_BRANCH}" = "master-beta" ]; then
+    for env in ci qa; do
         echo
         echo "PUSHING ${env}-beta"
-
-        # note to Allen.. remove the temp .git dir
-        # not all of dist O_o
         rm -rf ./dist/.git
         .travis/release.sh "${env}-beta"
     done
-fi
-
-if [ "${TRAVIS_BRANCH}" = "master-stable" ]; then
-    # for a limited time prod too
-    for env in ci qa prod
-    do
+elif [ "${TRAVIS_BRANCH}" = "master" ]; then
+    echo
+    echo "PUSHING prod-beta"
+    rm -rf ./dist/.git
+    .travis/release.sh "prod-beta"
+elif [ "${TRAVIS_BRANCH}" = "master-stable" ]; then
+    for env in ci qa prod; do
         echo
-        echo
-        echo "PUSHING ${env}-beta"
+        echo "PUSHING ${env}-stable"
         rm -rf ./dist/.git
         .travis/release.sh "${env}-stable"
     done
-fi
-
-if [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
-    .travis/release.sh "${TRAVIS_BRANCH}"
 fi


### PR DESCRIPTION
in order to support the new dashboard n app consolidation efforts, advisor has gotta be able to target qa/ci beta specifically, this app allows us to do that while keeping everything else the same