### PR TITLE
Consumes api updates to culling attributes on stats endpoint

### DIFF
--- a/src/PresentationalComponents/Charts/SystemInventory.js
+++ b/src/PresentationalComponents/Charts/SystemInventory.js
@@ -17,7 +17,7 @@ const SystemInventory = ({ staleHosts, intl }) => {
     </Split>;
 
     return <Stack className='stackOverride' aria-label='System inventory' widget-type='InsightsSystemInventoryChart'>
-        {staleHosts &&  staleHosts.warn_count > 0  || staleHosts.hide_count > 0 ? <React.Fragment>
+        {staleHosts &&  staleHosts.warn_count > 0  || staleHosts.stale_count > 0 ? <React.Fragment>
             <StackItem >
                 {iconMessage(<ExclamationTriangleIcon color='var(--pf-global--warning-color--100)' />,
                     intl.formatMessage(messages.overviewSystemInventoryStale, { systems: staleHosts.warn_count }),
@@ -25,7 +25,7 @@ const SystemInventory = ({ staleHosts, intl }) => {
             </StackItem>
             <StackItem>
                 {iconMessage(<ExclamationCircleIcon color='var(--pf-global--danger-color--100)' />,
-                    intl.formatMessage(messages.overviewSystemInventoryRemoved, { systems: staleHosts.hide_count }),
+                    intl.formatMessage(messages.overviewSystemInventoryRemoved, { systems: staleHosts.stale_count }),
                     '/inventory?staleness=stale')}
             </StackItem>
         </React.Fragment>


### PR DESCRIPTION
followup to https://projects.engineering.redhat.com/browse/RHCLOUD-3832 and https://projects.engineering.redhat.com/browse/RHCLOUD-4190 we now consume the correct endpoints and the systems list returns non-nulls for `stale_at`


<img width="1315" alt="Screen Shot 2020-03-04 at 3 05 01 PM" src="https://user-images.githubusercontent.com/6640236/75919128-fe852f00-5e2a-11ea-9a5f-1ff68df57f7b.png">
<img width="1307" alt="Screen Shot 2020-03-04 at 3 04 48 PM" src="https://user-images.githubusercontent.com/6640236/75919129-fe852f00-5e2a-11ea-8de1-c1fa35747d19.png">
<img width="331" alt="Screen Shot 2020-03-04 at 2 58 13 PM" src="https://user-images.githubusercontent.com/6640236/75919132-ff1dc580-5e2a-11ea-97b6-f44db03c75ce.png">
