### PR TITLE
 Adds tagging support to rec details page

### DIFF
--- a/src/AppActions.js
+++ b/src/AppActions.js
@@ -32,11 +32,11 @@ export const fetchRules = (options) => ({
 });
 export const fetchRule = (options) => ({
     type: ActionTypes.RULE_FETCH,
-    payload: fetchData(`${ActionTypes.RULES_FETCH_URL}${options.rule_id}/`)
+    payload: fetchData(`${ActionTypes.RULES_FETCH_URL}${options.rule_id}/`, {}, options.tags && { tags: options.tags })
 });
 export const fetchSystem = (options) => ({
     type: ActionTypes.SYSTEM_FETCH,
-    payload: fetchData(`${ActionTypes.RULES_FETCH_URL}${options.rule_id}/systems/`)
+    payload: fetchData(`${ActionTypes.RULES_FETCH_URL}${options.rule_id}/systems/`, {}, options.tags && { tags: options.tags })
 });
 export const setFilters = (filters) => ({
     type: ActionTypes.FILTERS_SET,

--- a/src/PresentationalComponents/Modals/DisableRule.js
+++ b/src/PresentationalComponents/Modals/DisableRule.js
@@ -17,16 +17,23 @@ import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import messages from '../../Messages';
 
-const DisableRule = ({ handleModalToggle, intl, isModalOpen, host, hosts, rule, afterFn, setAck, addNotification, setSystem, setRule }) => {
+const DisableRule = ({ handleModalToggle, intl, isModalOpen, host, hosts, rule, afterFn, setAck, addNotification, setSystem, setRule,
+    selectedTags }) => {
     const [justification, setJustificaton] = useState('');
     const [singleSystem, setSingleSystem] = useState(host !== undefined || hosts.length > 0);
 
     const bulkHostActions = async () => {
         const data = { systems: hosts, justification };
         try {
-            const response = await API.post(`${BASE_URL}/rule/${rule.rule_id}/ack_hosts/`, {}, data);
-            setSystem({ host_ids: response.data.host_ids });
-            setRule({ ...rule, hosts_acked_count: response.data.count + rule.hosts_acked_count });
+            const response = await API.post(`${BASE_URL}/rule/${rule.rule_id}/ack_hosts/`,
+                {}, data);
+            if (selectedTags.length > 0) {
+                afterFn && afterFn();
+            } else {
+                setSystem({ host_ids: response.data.host_ids });
+                setRule({ ...rule, hosts_acked_count: response.data.count + rule.hosts_acked_count });
+            }
+
         } catch (error) {
             addNotification({ variant: 'danger', dismissable: true, title: intl.formatMessage(messages.error), description: `${error}` });
         }
@@ -100,8 +107,8 @@ DisableRule.propTypes = {
     hosts: PropTypes.array,
     addNotification: PropTypes.func,
     setRule: PropTypes.func,
-    setSystem: PropTypes.func
-
+    setSystem: PropTypes.func,
+    selectedTags: PropTypes.array
 };
 
 DisableRule.defaultProps = {
@@ -121,4 +128,6 @@ const mapDispatchToProps = dispatch => ({
     setSystem: data => dispatch(setSystem(data))
 });
 
-export default injectIntl(connect(null, mapDispatchToProps)(DisableRule));
+export default injectIntl(connect(({ AdvisorStore }) => ({
+    selectedTags: AdvisorStore.selectedTags
+}), mapDispatchToProps)(DisableRule));


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-5007

dupe of https://github.com/RedHatInsights/insights-advisor-frontend/pull/579/ for prod-beta

works fine with host_ack actions n rule enable/disable


#### look now we respect tags in this view
<img width="1313" alt="Screen Shot 2020-03-09 at 12 07 16 PM" src="https://user-images.githubusercontent.com/6640236/76233490-a40b1a80-61fe-11ea-9339-dc3ae88e23f2.png">
<img width="1309" alt="Screen Shot 2020-03-09 at 12 07 04 PM" src="https://user-images.githubusercontent.com/6640236/76233491-a4a3b100-61fe-11ea-95b3-cb52dd468e0e.png">
