### PR TITLE
Disables tag dropdown when there aren't any tags

### DIFF
--- a/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
+++ b/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
@@ -36,7 +36,12 @@ const TagsToolbar = ({ selectedTags, intl, setSelectedTags }) => {
     }, [intl]);
 
     const titleFn = () => <React.Fragment>
-        <TagIcon />&nbsp;{intl.formatMessage(messages.filterResults)} {selectedTags.length === 0 && intl.formatMessage(messages.allSystems)}
+        <TagIcon />&nbsp;
+        {tags.length > 0 ?
+            <React.Fragment>
+                {intl.formatMessage(messages.filterResults)} {selectedTags.length === 0 && intl.formatMessage(messages.allSystems)}
+            </React.Fragment>
+            : intl.formatMessage(messages.noTags) }
     </React.Fragment>;
 
     const onSelect = (e, selection) => selectedTags.includes(selection) ? setSelectedTags(selectedTags.filter(item => item !== selection))
@@ -58,6 +63,7 @@ const TagsToolbar = ({ selectedTags, intl, setSelectedTags }) => {
             isExpanded={isOpen}
             placeholderText={titleFn()}
             ariaLabelledBy='select-group-input'
+            isDisabled={tags.length === 0}
         >
             {tags.slice(0, showMoreCount || tags.length).map(item => <SelectOption key={item} value={item} />)}
             {showMoreCount > 0 && tags.length > showMoreCount && <Button key='view all tags'

--- a/src/PresentationalComponents/TagsToolbar/_TagsToolbar.scss
+++ b/src/PresentationalComponents/TagsToolbar/_TagsToolbar.scss
@@ -19,6 +19,16 @@
     width: 220px;
     font-size: small;
   }
+
+  .pf-c-select__toggle.pf-m-disabled,
+  .pf-c-select__toggle:disabled {
+    background-color: var(--pf-global--BackgroundColor--100);
+
+    .pf-c-select__toggle-arrow {
+      color: var(--pf-global--BackgroundColor--100);
+    }
+  }
+  
   .pf-c-select {
     max-width: 400px !important;
   }


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-5141

#### looks like
<img width="1273" alt="Screen Shot 2020-03-13 at 9 32 10 AM" src="https://user-images.githubusercontent.com/6640236/76625516-cd34ef00-650d-11ea-9f0f-45d5e4347b8e.png">




cc @kybaker 