### PR TITLE
Removes trailing slash from topics detail, matches recs table

### DIFF
--- a/src/PresentationalComponents/TopicsTable/TopicsTable.js
+++ b/src/PresentationalComponents/TopicsTable/TopicsTable.js
@@ -33,7 +33,7 @@ const TopicsTable = ({ topics, topicsFetchStatus, intl }) => {
         return isValidSearchText ? [{
             topic: value,
             cells: [{
-                title: <span key={key}><Link key={key} to={`/topics/${value.slug}/`}> {value.name} </Link></span>,
+                title: <span key={key}><Link key={key} to={`/topics/${value.slug}`}> {value.name} </Link></span>,
                 props: { colSpan: 2 }
             }, {
                 title: <span key={key}> {value.featured && <Label> <StarIcon />&nbsp;{intl.formatMessage(messages.featured)}</Label>} </span>


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-4011

#### being done here
<img width="1311" alt="Screen Shot 2020-03-16 at 6 53 16 AM" src="https://user-images.githubusercontent.com/6640236/76749565-0dd17a00-6753-11ea-929e-2b22e697b5f7.png">
