### PR TITLE
Encoded tags are decoded where rendered! 🥳

### DIFF
--- a/src/PresentationalComponents/TagsToolbar/TagsList.js
+++ b/src/PresentationalComponents/TagsToolbar/TagsList.js
@@ -25,7 +25,7 @@ const TagsList = ({ setSelectedTags, selectedTags, showMoreCount, intl, tags, ha
         {!showMoreCount && <ChipGroup>
             {selectedTags.map(currentChip => (
                 <Chip key={currentChip} onClick={() => updateSelectedTags(null, { target: { name: currentChip } })}>
-                    {currentChip}
+                    {decodeURIComponent(currentChip)}
                 </Chip>
             ))}
         </ChipGroup>}
@@ -37,7 +37,7 @@ const TagsList = ({ setSelectedTags, selectedTags, showMoreCount, intl, tags, ha
                             isChecked={selectedTags.indexOf(item) > -1} />
                         <DataListItemCells dataListCells={[
                             <DataListCell key="primary content">
-                                {`${item}`}
+                                {`${decodeURIComponent(item)}`}
                             </DataListCell>]} />
                     </DataListItemRow>
                 </DataListItem>)}

--- a/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
+++ b/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
@@ -65,7 +65,7 @@ const TagsToolbar = ({ selectedTags, intl, setSelectedTags }) => {
             ariaLabelledBy='select-group-input'
             isDisabled={tags.length === 0}
         >
-            {tags.slice(0, showMoreCount || tags.length).map(item => <SelectOption key={item} value={item} />)}
+            {tags.slice(0, showMoreCount || tags.length).map(item => <SelectOption key={item} value={`${decodeURIComponent(item)}`} />)}
             {(showMoreCount > 0 && tags.length > showMoreCount) ? <Button key='view all tags'
                 variant='link' onClick={(toggleModal) => setManageTagsModalOpen(toggleModal)}>
                 {intl.formatMessage(messages.countMore, { count: tags.length - showMoreCount })}


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-4917

#### looks like....
<img width="688" alt="Screen Shot 2020-03-23 at 3 41 07 PM" src="https://user-images.githubusercontent.com/6640236/77358571-7bb40d80-6d20-11ea-8355-42c2be371f9f.png">
<img width="723" alt="Screen Shot 2020-03-23 at 3 35 00 PM" src="https://user-images.githubusercontent.com/6640236/77358573-7bb40d80-6d20-11ea-99b3-5ccada882dc3.png">
