### PR TITLE
Tooltip to tag select, (for those really long tags) ⚜️

### DIFF
--- a/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
+++ b/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
@@ -2,6 +2,7 @@ import './_TagsToolbar.scss';
 
 import React, { useEffect, useState } from 'react';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core/dist/js/components/Select/index';
+import { Tooltip, TooltipPosition } from '@patternfly/react-core/dist/js/components/Tooltip/Tooltip';
 
 import API from '../../Utilities/Api';
 import { BASE_URL } from '../../AppConstants';
@@ -41,7 +42,7 @@ const TagsToolbar = ({ selectedTags, intl, setSelectedTags }) => {
             <React.Fragment>
                 {intl.formatMessage(messages.filterResults)} {selectedTags.length === 0 && intl.formatMessage(messages.allSystems)}
             </React.Fragment>
-            : intl.formatMessage(messages.noTags) }
+            : intl.formatMessage(messages.noTags)}
     </React.Fragment>;
 
     const onSelect = (e, selection) => selectedTags.includes(selection) ? setSelectedTags(selectedTags.filter(item => item !== selection))
@@ -65,7 +66,10 @@ const TagsToolbar = ({ selectedTags, intl, setSelectedTags }) => {
             ariaLabelledBy='select-group-input'
             isDisabled={tags.length === 0}
         >
-            {tags.slice(0, showMoreCount || tags.length).map(item => <SelectOption key={item} value={`${decodeURIComponent(item)}`} />)}
+            {tags.slice(0, showMoreCount || tags.length).map(item =>
+                <Tooltip key={item} content={`${decodeURIComponent(item)}`} position={TooltipPosition.right}>
+                    <SelectOption value={`${decodeURIComponent(item)}`} />
+                </Tooltip>)}
             {(showMoreCount > 0 && tags.length > showMoreCount) ? <Button key='view all tags'
                 variant='link' onClick={(toggleModal) => setManageTagsModalOpen(toggleModal)}>
                 {intl.formatMessage(messages.countMore, { count: tags.length - showMoreCount })}


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-5347

Activated on hover, can't copy/paste names n such

#### looks like
<img width="1053" alt="Screen Shot 2020-03-24 at 7 50 42 AM" src="https://user-images.githubusercontent.com/6640236/77423261-40a7ed80-6da5-11ea-965e-4691a9c60845.png">
<img width="1052" alt="Screen Shot 2020-03-24 at 7 50 47 AM" src="https://user-images.githubusercontent.com/6640236/77423272-44d40b00-6da5-11ea-9f58-c40353d2d02a.png">
