### PR TITLE
[RFR] Add large margins to Affected Systems Title

### DIFF
--- a/src/SmartComponents/Rules/Details.js
+++ b/src/SmartComponents/Rules/Details.js
@@ -206,7 +206,7 @@ const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchR
                             </CardFooter>
                         </Card>}
                         {rule.reports_shown && <React.Fragment>
-                            <Title headingLevel='h3' size='2xl'>
+                            <Title className='titleOverride' headingLevel='h3' size='2xl'>
                                 {intl.formatMessage(messages.affectedSystems)}
                             </Title>
                             {systemFetchStatus === 'fulfilled' &&

--- a/src/SmartComponents/Rules/Details.scss
+++ b/src/SmartComponents/Rules/Details.scss
@@ -6,6 +6,10 @@
   margin-bottom: var(--pf-global--spacer--md);
 }
 
+.titleOverride {
+  margin-bottom: var(--pf-global--spacer--lg);
+}
+
 .pf-c-card__body {
   padding-bottom: var(--pf-global--spacer--md);
 }

--- a/src/SmartComponents/Topics/Details.js
+++ b/src/SmartComponents/Topics/Details.js
@@ -69,7 +69,7 @@ const Details = ({ match, fetchTopic, setFilters, topic, topicFetchStatus, intl,
         <Main>
             <React.Fragment>
                 {topicFetchStatus === '' || topicFetchStatus === 'pending' || topicFetchStatus === 'fulfilled' && <React.Fragment>
-                    <Title headingLevel="h3" size="2xl" className='titlePaddingOverride'>
+                    <Title headingLevel="h3" size="2xl" className='titleOverride'>
                         {intl.formatMessage(messages.recommendations)}
                     </Title>
                     {filters.topic && <RulesTable />}

--- a/src/SmartComponents/Topics/_Details.scss
+++ b/src/SmartComponents/Topics/_Details.scss
@@ -9,3 +9,7 @@
 .textOverride {
     margin-top: var(--pf-global--spacer--md);
 }
+
+.titleOverride {
+    margin-bottom: var(--pf-global--spacer--lg);
+}


### PR DESCRIPTION
This PR is in response to RHCLOUD-5244 (page 3 of the google doc). We are adding large bottom margins to the `Affected Systems` title. 
![Screen Shot 2020-03-24 at 11 01 25 AM](https://user-images.githubusercontent.com/4829473/77440565-d8fe9c00-6dbe-11ea-9e00-4e7fc5795fc9.png)
