### PR TITLE
[RFR] Fix bug where tag checkboxes remain checked

### DIFF
--- a/src/PresentationalComponents/TagsToolbar/TagsList.js
+++ b/src/PresentationalComponents/TagsToolbar/TagsList.js
@@ -34,7 +34,7 @@ const TagsList = ({ setSelectedTags, selectedTags, showMoreCount, intl, tags, ha
                 {tags.slice(0, showMoreCount || tags.length).map(item => <DataListItem aria-labelledby="tag-list-item" key={item}>
                     <DataListItemRow>
                         <DataListCheck aria-labelledby={`${item}-check`} name={item} onChange={updateSelectedTags}
-                            isChecked={selectedTags.indexOf(item) > -1} />
+                            checked={selectedTags.indexOf(item) > -1} />
                         <DataListItemCells dataListCells={[
                             <DataListCell key="primary content">
                                 {`${decodeURIComponent(item)}`}


### PR DESCRIPTION
This PR is in response to RHCLOU-5628. It adds a useEffect and useState to 🤞 fix the issue where tags are remaining checked in the modal. Here's where you can find an example of this happening: https://projects.engineering.redhat.com/browse/RHCLOUD-5628. Here's what it should do:
1. Before closing the chips
![Screen Shot 2020-04-07 at 10 45 27 AM](https://user-images.githubusercontent.com/4829473/78683259-11bd6b80-78bd-11ea-910b-634990d21b7f.png)
2. After closing a chip 
![Screen Shot 2020-04-07 at 10 45 37 AM](https://user-images.githubusercontent.com/4829473/78683285-17b34c80-78bd-11ea-8528-9bef4fa1e048.png)

