### PR TITLE
Removes duplicate rec detail breadcrumb

### DIFF
--- a/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
+++ b/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
@@ -25,9 +25,8 @@ const Breadcrumbs = ({ current, fetchRule, match, ruleFetchStatus, rule, intl })
         crumbs.push({ title: titleCase(splitUrl[1]), navigate: `/${splitUrl[1]}` });
         // if applicable, add tab
         if (splitUrl[1] === 'recommendations') {
-            splitUrl[1] + splitUrl[2] !== 'recommendationssystems' ?
-                crumbs.push({ title: intl.formatMessage(messages.recommendations), navigate: '/recommendations' })
-                : crumbs.push({ title: intl.formatMessage(messages.systems), navigate: '/recommendations/systems' });
+            splitUrl[1] + splitUrl[2] === 'recommendationssystems' &&
+                crumbs.push({ title: intl.formatMessage(messages.systems), navigate: '/recommendations/systems' });
         }
 
         // if applicable, add :id breadcrumb


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-4186

#### looks like this now
<img width="1303" alt="Screen Shot 2020-04-07 at 11 20 50 AM" src="https://user-images.githubusercontent.com/6640236/78687299-04ef4680-78c2-11ea-95e3-fac178791ab4.png">
<img width="1304" alt="Screen Shot 2020-04-07 at 11 21 06 AM" src="https://user-images.githubusercontent.com/6640236/78687304-0587dd00-78c2-11ea-918d-cd9322f7bfc3.png">
