### PR TITLE
Turn off disable recs when selected.length = 0 in inventory

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -3,7 +3,7 @@ import * as pfReactTable from '@patternfly/react-table';
 import * as reactRouterDom from 'react-router-dom';
 
 import React, { useEffect, useRef, useState } from 'react';
-import { useStore } from 'react-redux';
+
 import  AnsibeTowerIcon  from '@patternfly/react-icons/dist/js/icons/ansibeTower-icon';
 import DisableRule from '../../PresentationalComponents/Modals/DisableRule';
 import PropTypes from 'prop-types';
@@ -15,6 +15,7 @@ import global_BackgroundColor_100 from '@patternfly/react-tokens/dist/js/global_
 import { injectIntl } from 'react-intl';
 import messages from '../../Messages';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
+import { useStore } from 'react-redux';
 
 let page = 1;
 let pageSize = 50;
@@ -120,6 +121,7 @@ const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification
                 </RemediationButton>,
                 {
                     label: intl.formatMessage(messages.disableRuleForSystems),
+                    props: { isDisabled: selected.length === 0 },
                     onClick: () => handleModalToggle(true)
                 }]
             }}


### PR DESCRIPTION
This PR is in response to RHCLOUD-5889, and it disables the action in the kebab dropdown menu on the inventory table when `selected.length === 0`.

Before:
![Screen Shot 2020-04-15 at 3 14 07 PM](https://user-images.githubusercontent.com/4829473/79378705-c5f96a80-7f2b-11ea-8c2a-faf307b86233.png)

After:
![Screen Shot 2020-04-15 at 3 12 53 PM](https://user-images.githubusercontent.com/4829473/79378623-a2362480-7f2b-11ea-8f69-a516d437b022.png)
