### PR TITLE
Prevent multiple rendering when changing tabs

### DIFF
--- a/src/PresentationalComponents/ExecutiveReport/Download.js
+++ b/src/PresentationalComponents/ExecutiveReport/Download.js
@@ -5,14 +5,14 @@ import { RULES_FETCH_URL, STATS_REPORTS_FETCH_URL, STATS_SYSTEMS_FETCH_URL } fro
 import API from '../../Utilities/Api';
 import { DownloadButton } from '@redhat-cloud-services/frontend-components-pdf-generator';
 import ExportIcon from '@patternfly/react-icons/dist/js/icons/export-icon';
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 import buildExecReport from './Build';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
 
 const DownloadExecReport = () => {
     const intl = useIntl();
-    const [loading, setLoading] = React.useState(false);
+    const [loading, setLoading] = useState(false);
 
     const dataFetch = async () => {
         setLoading(true);
@@ -27,12 +27,15 @@ const DownloadExecReport = () => {
         return [report];
     };
 
-    return <DownloadButton
-        label={loading ? intl.formatMessage(messages.loading) : intl.formatMessage(messages.downloadExecutiveLabel)}
-        asyncFunction={dataFetch}
-        buttonProps={{ variant: 'link', icon: <ExportIcon className='iconOverride' />, component: 'a', className: 'downloadButtonOverride' }}
-        type={intl.formatMessage(messages.insightsHeader)}
-        fileName={`Insights-Executive-Report--${(new Date()).toUTCString().replace(/ /g, '-')}.pdf`} />;
+    return useMemo(() => {
+        return <DownloadButton
+            label={loading ? intl.formatMessage(messages.loading) : intl.formatMessage(messages.downloadExecutiveLabel)}
+            asyncFunction={dataFetch}
+            buttonProps={{ variant: 'link', icon: <ExportIcon className='iconOverride' />, component: 'a', className: 'downloadButtonOverride' }}
+            type={intl.formatMessage(messages.insightsHeader)}
+            fileName={`Insights-Executive-Report--${(new Date()).toUTCString().replace(/ /g, '-')}.pdf`} />;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [loading]);
 };
 
 export default DownloadExecReport;


### PR DESCRIPTION
This will render the button on initial render and everytime loading changes, so it'll prevent multiple renders.