### PR TITLE
Fetch hostacks only once we have a rule_id, prevents dupe calls

### DIFF
--- a/src/SmartComponents/Rules/Details.js
+++ b/src/SmartComponents/Rules/Details.js
@@ -98,7 +98,7 @@ const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchR
     };
 
     useEffect(() => {
-        fetchHostAcks({ rule_id: rule.rule_id, limit: rule.hosts_acked_count });
+        rule.rule_id && fetchHostAcks({ rule_id: rule.rule_id, limit: rule.hosts_acked_count });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fetchHostAcks, rule.hosts_acked_count]);
 


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-5985


#### one call! (and cuz we're now waiting to call hostacks when we have rule_id all other functionality s the same)
![Screen Shot 2020-04-20 at 7 42 31 AM](https://user-images.githubusercontent.com/6640236/79748001-a3c06d80-82da-11ea-8160-a2f67ebb67b7.png)

