### PR TITLE
Make system table pagination compact

### DIFF
--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -162,7 +162,7 @@ const SystemsTable = ({ systemsFetchStatus, fetchSystems, systems, intl, filters
                 perPage: Number(filters.limit),
                 onSetPage(event, page) { onSetPage(page); },
                 onPerPageSelect(event, perPage) { setFilters({ ...filters, limit: perPage, offset: 0 }); },
-                isCompact: false
+                isCompact: true
             }}
             filterConfig={{ items: filterConfigItems }}
             activeFiltersConfig={activeFiltersConfig}


### PR DESCRIPTION
This PR is for RHCLOUD-5247. It makes all the pagination on the Systems Table compact per the doc.

Before:
<img width="1121" alt="Screen Shot 2020-04-20 at 11 52 44 AM" src="https://user-images.githubusercontent.com/4829473/79772063-a2546c80-82fd-11ea-8712-cc396eaea506.png">

After:
<img width="1121" alt="Screen Shot 2020-04-20 at 11 53 39 AM" src="https://user-images.githubusercontent.com/4829473/79772080-a7192080-82fd-11ea-8978-02c137adb2d6.png">
