### PR TITLE
Add key press handler for disable rule modal

### DIFF
--- a/src/PresentationalComponents/Modals/DisableRule.js
+++ b/src/PresentationalComponents/Modals/DisableRule.js
@@ -54,11 +54,16 @@ const DisableRule = ({ handleModalToggle, intl, isModalOpen, host, hosts, rule, 
         handleModalToggle(false);
     };
 
+    const handleKeyPress = (event) => {
+        if (event.key === 'Enter') { disableRule(); }
+    };
+
     return <Modal
         isSmall
         title={intl.formatMessage(messages.disableRule)}
         isOpen={isModalOpen}
         onClose={() => { handleModalToggle(false); setJustificaton(''); }}
+        onKeyPress={handleKeyPress}
         actions={[
             <Button key="confirm" variant="primary" onClick={() => disableRule()}>
                 {intl.formatMessage(messages.save)}


### PR DESCRIPTION
This PR is in response to page 5 of RHCLOUD 5247. It allows the user to press the enter key after adding justification for disabling a rule.