### PR TITLE
In lieu correct MD, adds styles to generic content, to match satellite

### DIFF
--- a/src/PresentationalComponents/RuleDetails/RuleDetails.js
+++ b/src/PresentationalComponents/RuleDetails/RuleDetails.js
@@ -43,7 +43,9 @@ const RuleDetails = ({ children, rule, intl, topics, header, isDetailsPage }) =>
         </React.Fragment>
     ));
 
-    const ruleDescription = (data) => typeof data === 'string' && Boolean(data) && <ReactMarkdown source={data} escapeHtml={false} />;
+    const ruleDescription = (data, isGeneric) => typeof data === 'string' && Boolean(data) && <span className={isGeneric && 'genericOverride'}>
+        <ReactMarkdown source={data} escapeHtml={false} />
+    </span>;
 
     return <Split gutter='sm'>
         <SplitItem>
@@ -51,7 +53,7 @@ const RuleDetails = ({ children, rule, intl, topics, header, isDetailsPage }) =>
                 {header && <StackItem>
                     {header}
                 </StackItem>}
-                <StackItem>{isDetailsPage ? ruleDescription(rule.generic) : ruleDescription(rule.summary)}</StackItem>
+                <StackItem>{isDetailsPage ? ruleDescription(rule.generic, true) : ruleDescription(rule.summary)}</StackItem>
                 {rule.node_id && (
                     <StackItem>
                         <a rel="noopener noreferrer" target="_blank" href={`https://access.redhat.com/node/${rule.node_id}`}>

--- a/src/PresentationalComponents/RuleDetails/_RuleDetails.scss
+++ b/src/PresentationalComponents/RuleDetails/_RuleDetails.scss
@@ -42,3 +42,10 @@ hr {
 .batteryTextMarginOverride {
   padding-top: 3px;
 }
+
+.genericOverride {
+  p {
+    margin-top: 0;
+    margin-bottom: var(--pf-global--spacer--md);
+  }
+}


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-6064

this is the wrong fix. adding css to content to make it look the same everywhere, when the content oughta be written in markdown, s just plain wrong.  alas, here we are 🔪🦹‍♀️😢


#### the after, we add <p> spacing to generic, but not the summary (which would be extra unexpected n bad)
<img width="1039" alt="Screen Shot 2020-04-28 at 8 53 51 AM" src="https://user-images.githubusercontent.com/6640236/80489836-70ab5900-892e-11ea-9f49-f2730a75229d.png">
<img width="1038" alt="Screen Shot 2020-04-28 at 8 53 22 AM" src="https://user-images.githubusercontent.com/6640236/80489846-7608a380-892e-11ea-987c-930cbb6eaee7.png">
