### PR TITLE
Add error handling for remediations

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -70,7 +70,13 @@ const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification
 
     const onRemediationCreated = result => {
         onSelectRows(-1, false);
-        addNotification(result.getNotification());
+        try {
+            result.remediation && addNotification(result.getNotification());
+        } catch (error) {
+            addNotification(
+                { variant: 'danger', dismissable: true, title: intl.formatMessage(messages.error), description: `${error}` }
+            );
+        }
     };
 
     const handleModalToggle = (disableRuleModalOpen) => {


### PR DESCRIPTION
This PR addresses RHCLOUD-5246 page 4. We are not getting a notification every time a playbook is created. This updates the Inventory component to either pass a successful notification or let the user know there's been some sort of error if either the remediation is not returned or if the notification fails to post.

I'm not sure if this is the intended fix. So just let me know 😁 🥳 