### PR TITLE
Tags query param mirrors component selectedTag value 💪😝🥺😵

### DIFF
--- a/src/PresentationalComponents/Common/Tables.js
+++ b/src/PresentationalComponents/Common/Tables.js
@@ -1,10 +1,11 @@
 // Builds returns url params from table filters, pushes to url if history object is passed
-export const urlBuilder = (filters, history) => {
+export const urlBuilder = (filters, selectedTags) => {
+    const url = new URL(window.location);
     const queryString = `?${Object.keys(filters).map(key => `${key}=${Array.isArray(filters[key]) ? filters[key].join() : filters[key]}`).join('&')}`;
-    history && history.replace({
-        search: queryString
-    });
-    return queryString;
+    const params = new URLSearchParams(queryString);
+    selectedTags.length ? params.set('tags', selectedTags.join()) : params.delete('tags');
+    window.history.replaceState(null, null, `${url.origin}${url.pathname}?${params.toString()}`);
+    return `?${queryString}`;
 };
 
 // transforms array of strings -> comma seperated strings, required by advisor api
@@ -16,8 +17,8 @@ export const filterFetchBuilder = (filters) => Object.assign({},
 );
 
 // parses url params for use in table/filter chips
-export const paramParser = (history) => {
-    const searchParams = new URLSearchParams(history.location.search);
+export const paramParser = () => {
+    const searchParams = new URLSearchParams(window.location.search);
     return Array.from(searchParams).reduce((acc, [key, value]) => ({
         ...acc, [key]: (value === 'true' || value === 'false') ? JSON.parse(value) : value.split(',')
     }), {});

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -39,7 +39,7 @@ import { injectIntl } from 'react-intl';
 import messages from '../../Messages';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
 
-const RulesTable = ({ rules, filters, rulesFetchStatus, setFilters, fetchRules, addNotification, history, intl, selectedTags }) => {
+const RulesTable = ({ rules, filters, rulesFetchStatus, setFilters, fetchRules, addNotification, intl, selectedTags }) => {
     const [cols] = useState([
         { title: intl.formatMessage(messages.description), transforms: [sortable] },
         { title: intl.formatMessage(messages.added), transforms: [sortable, cellWidth(15)] },
@@ -66,8 +66,9 @@ const RulesTable = ({ rules, filters, rulesFetchStatus, setFilters, fetchRules, 
     const sortIndices = { 1: 'description', 2: 'publish_date', 3: 'total_risk', 4: 'impacted_count', 5: 'playbook_count' };
 
     const fetchRulesFn = useCallback(() => {
+        const queryString = urlBuilder(filters, selectedTags);
+        setQueryString(queryString);
         const options = selectedTags.length && ({ tags: selectedTags.join() });
-
         fetchRules({
             ...filterFetchBuilder(filters),
             impacting,
@@ -172,8 +173,9 @@ const RulesTable = ({ rules, filters, rulesFetchStatus, setFilters, fetchRules, 
 
     // Builds table filters from url params
     useEffect(() => {
-        if (history.location.search && filterBuilding) {
-            const paramsObject = paramParser(history);
+        if (window.location.search && filterBuilding) {
+            const paramsObject = paramParser();
+            delete paramsObject.tags;
             paramsObject.text === undefined ? setSearchText('') : setSearchText(paramsObject.text);
             paramsObject.reports_shown = paramsObject.reports_shown === undefined || paramsObject.reports_shown[0] === 'undefined' ? undefined
                 : paramsObject.reports_shown;
@@ -191,15 +193,6 @@ const RulesTable = ({ rules, filters, rulesFetchStatus, setFilters, fetchRules, 
         setFilterBuilding(false);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
-
-    // Builds and pushes url params from table filters
-    useEffect(() => {
-        const queryString = urlBuilder(filters);
-        setQueryString(queryString);
-        history.replace({
-            search: queryString
-        });
-    }, [filters, history]);
 
     useEffect(() => {
         if (filters.sort !== undefined) {
@@ -504,7 +497,6 @@ RulesTable.propTypes = {
     filters: PropTypes.object,
     addNotification: PropTypes.func,
     setFilters: PropTypes.func,
-    history: PropTypes.object,
     intl: PropTypes.any,
     selectedTags: PropTypes.array
 };

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -18,7 +18,7 @@ import messages from '../../Messages';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
 import { systemReducer } from '../../AppReducer';
 
-const SystemsTable = ({ systemsFetchStatus, fetchSystems, systems, intl, filters, setFilters, history, selectedTags }) => {
+const SystemsTable = ({ systemsFetchStatus, fetchSystems, systems, intl, filters, setFilters, selectedTags }) => {
     const inventory = useRef(null);
     const [InventoryTable, setInventory] = useState();
     const store = useStore();
@@ -127,8 +127,9 @@ const SystemsTable = ({ systemsFetchStatus, fetchSystems, systems, intl, filters
     }, [debouncedSearchText]);
 
     useEffect(() => {
-        if (history.location.search) {
-            const paramsObject = paramParser(history);
+        if (window.location.search) {
+            const paramsObject = paramParser();
+            delete paramsObject.tags;
             paramsObject.sort !== undefined && (paramsObject.sort = paramsObject.sort[0]);
             paramsObject.display_name !== undefined && (paramsObject.display_name = paramsObject.display_name[0]);
             paramsObject.offset === undefined ? paramsObject.offset = 0 : paramsObject.offset = Number(paramsObject.offset[0]);
@@ -143,8 +144,8 @@ const SystemsTable = ({ systemsFetchStatus, fetchSystems, systems, intl, filters
     }, []);
 
     useEffect(() => {
-        urlBuilder(filters, history);
-    }, [filters, history]);
+        urlBuilder(filters, selectedTags);
+    }, [filters, selectedTags]);
 
     useEffect(() => {
         !filterBuilding && systemsFetchStatus !== 'pending' && fetchSystemsFn();
@@ -179,7 +180,6 @@ SystemsTable.propTypes = {
     systemsFetchStatus: PropTypes.string,
     systems: PropTypes.object,
     addNotification: PropTypes.func,
-    history: PropTypes.object,
     intl: PropTypes.any,
     filters: PropTypes.object,
     setFilters: PropTypes.func,

--- a/src/PresentationalComponents/TagsToolbar/Common.js
+++ b/src/PresentationalComponents/TagsToolbar/Common.js
@@ -1,0 +1,8 @@
+const tagUrlBuilder = (tagsToSet) => {
+    const url = new URL(window.location);
+    let params = new URLSearchParams(url.search);
+    tagsToSet.length ? params.set('tags', tagsToSet.join()) : params.delete('tags');
+    window.history.replaceState(null, null, `${url.origin}${url.pathname}${params.toString().length ? '?' : ''}${params.toString()}`);
+};
+
+export { tagUrlBuilder };

--- a/src/PresentationalComponents/TagsToolbar/TagsList.js
+++ b/src/PresentationalComponents/TagsToolbar/TagsList.js
@@ -15,11 +15,15 @@ import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import messages from '../../Messages';
 import { setSelectedTags } from '../../AppActions';
+import { tagUrlBuilder } from './Common';
 
 const TagsList = ({ setSelectedTags, selectedTags, showMoreCount, intl, tags, handleModalToggle }) => {
-    const updateSelectedTags = (value, e) => selectedTags.indexOf(e.target.name) > -1 ?
-        setSelectedTags(selectedTags.filter(item => item !== e.target.name))
-        : setSelectedTags([...selectedTags, e.target.name]);
+    const updateSelectedTags = (value, e) => {
+        const tagsToSet = selectedTags.indexOf(e.target.name) > -1 ?
+            selectedTags.filter(item => item !== e.target.name) : [...selectedTags, e.target.name];
+        setSelectedTags(tagsToSet);
+        tagUrlBuilder(tagsToSet);
+    };
 
     return <React.Fragment>
         {!showMoreCount && <ChipGroup>
@@ -70,7 +74,8 @@ TagsList.propTypes = {
     tags: PropTypes.object.isRequired,
     showMoreCount: PropTypes.number,
     handleModalToggle: PropTypes.func.isRequired,
-    intl: PropTypes.any
+    intl: PropTypes.any,
+    history: PropTypes.object
 };
 
 TagsList.defaultProps = {

--- a/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
+++ b/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
@@ -12,11 +12,14 @@ import PropTypes from 'prop-types';
 import TagIcon from '@patternfly/react-icons/dist/js/icons/tag-icon';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import { connect } from 'react-redux';
-import { injectIntl } from 'react-intl';
+import intersection from 'lodash/intersection';
 import messages from '../../Messages';
 import { setSelectedTags } from '../../AppActions';
+import { tagUrlBuilder } from './Common';
+import { useIntl } from 'react-intl';
 
-const TagsToolbar = ({ selectedTags, intl, setSelectedTags }) => {
+const TagsToolbar = ({ selectedTags, setSelectedTags }) => {
+    const intl = useIntl();
     const [isOpen, setIsOpen] = useState(false);
     const [tags, setTags] = useState([]);
     const [manageTagsModalOpen, setManageTagsModalOpen] = useState(false);
@@ -24,17 +27,31 @@ const TagsToolbar = ({ selectedTags, intl, setSelectedTags }) => {
     const onToggle = isOpen => setIsOpen(isOpen);
 
     useEffect(() => {
+        const url = new URL(window.location);
+        let params = new URLSearchParams(url.search);
+        params = params.get('tags');
         const fetchTags = async () => {
             try {
                 const response = await API.get(`${BASE_URL}/tag/`);
                 setTags(response.data.tags);
+                if (params.length) {
+                    const tagsToSet = intersection(params.split(','), response.data.tags);
+                    tagUrlBuilder(tagsToSet);
+                    setSelectedTags(tagsToSet);
+                }
             } catch (error) {
                 addNotification({ variant: 'danger', dismissable: true, title: intl.formatMessage(messages.error), description: `${error}` });
             }
         };
 
         fetchTags();
-    }, [intl]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+        tagUrlBuilder(selectedTags);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [window.location]);
 
     const titleFn = () => <React.Fragment>
         <TagIcon />&nbsp;
@@ -45,8 +62,12 @@ const TagsToolbar = ({ selectedTags, intl, setSelectedTags }) => {
             : intl.formatMessage(messages.noTags)}
     </React.Fragment>;
 
-    const onSelect = (e, selection) => selectedTags.includes(selection) ? setSelectedTags(selectedTags.filter(item => item !== selection))
-        : setSelectedTags([...selectedTags, selection]);
+    const onSelect = (e, selection) => {
+        const tagsToSet = selectedTags.includes(selection) ? selectedTags.filter(item => item !== selection)
+            : [...selectedTags, selection];
+        setSelectedTags(tagsToSet);
+        tagUrlBuilder(tagsToSet);
+    };
 
     return <div className='tagsToolbarContainer'>
         {<ManageTags
@@ -67,7 +88,7 @@ const TagsToolbar = ({ selectedTags, intl, setSelectedTags }) => {
             isDisabled={tags.length === 0}
         >
             {tags.slice(0, showMoreCount || tags.length).map(item =>
-                <SelectOption key={item} value={`${decodeURIComponent(item)}`}>
+                <SelectOption key={item} value={`${item}`}>
                     <Tooltip content={`${decodeURIComponent(item)}`} position={TooltipPosition.right}>
                         <span>{`${decodeURIComponent(item)}`}</span>
                     </Tooltip>
@@ -82,12 +103,17 @@ const TagsToolbar = ({ selectedTags, intl, setSelectedTags }) => {
     </div >;
 };
 
-TagsToolbar.propTypes = { selectedTags: PropTypes.array, addNotification: PropTypes.func, intl: PropTypes.any, setSelectedTags: PropTypes.func };
+TagsToolbar.propTypes = {
+    selectedTags: PropTypes.array,
+    addNotification: PropTypes.func,
+    intl: PropTypes.any,
+    setSelectedTags: PropTypes.func,
+    history: PropTypes.any
+};
 
-export default injectIntl(connect(
+export default connect(
     state => ({ selectedTags: state.AdvisorStore.selectedTags }),
     dispatch => ({
         addNotification: data => dispatch(addNotification(data)),
         setSelectedTags: (tags) => dispatch(setSelectedTags(tags))
-    }))
-(TagsToolbar));
+    }))(TagsToolbar);


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-6366

* as tags are selected, they'll show up in the url or be removed from it
* when navigating to ah page that has tags in the param, values on the page will reflect those tags
* navigating between pages, they'll be preserved, tags
* most importantly, everything works with even doofy tags `insights-client/contact=jcordes%40redhat.com` ie `tags=insights-client%2Fcontact%3Djcordes%2540redhat.com`


#### works from both the dropdown and the modal
<img width="2047" alt="Screen Shot 2020-05-05 at 1 42 14 PM" src="https://user-images.githubusercontent.com/6640236/81097721-4598aa80-8ed6-11ea-9817-201ddcda7899.png">
