### PR TITLE
Rec/sys table, dedupes tag calls, fixes param filter overwrite

### DIFF
--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -33,7 +33,7 @@ const initialState = Immutable({
     ruleAckFetchStatus: '',
     hostAcks: {},
     hostAcksFetchStatus: '',
-    selectedTags: []
+    selectedTags: null
 });
 
 export const AdvisorStore = (state = initialState, action) => {

--- a/src/PresentationalComponents/Common/Tables.js
+++ b/src/PresentationalComponents/Common/Tables.js
@@ -3,7 +3,7 @@ export const urlBuilder = (filters, selectedTags) => {
     const url = new URL(window.location);
     const queryString = `?${Object.keys(filters).map(key => `${key}=${Array.isArray(filters[key]) ? filters[key].join() : filters[key]}`).join('&')}`;
     const params = new URLSearchParams(queryString);
-    selectedTags.length ? params.set('tags', selectedTags.join()) : params.delete('tags');
+    selectedTags !== null && selectedTags.length ? params.set('tags', selectedTags.join()) : params.delete('tags');
     window.history.replaceState(null, null, `${url.origin}${url.pathname}?${params.toString()}`);
     return `?${queryString}`;
 };

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -169,7 +169,7 @@ const RulesTable = ({ rules, filters, rulesFetchStatus, setFilters, fetchRules, 
             : [];
     };
 
-    useEffect(() => { !filterBuilding && fetchRulesFn(); }, [fetchRulesFn, filterBuilding, filters, selectedTags]);
+    useEffect(() => { !filterBuilding && selectedTags !== null && fetchRulesFn(); }, [fetchRulesFn, filterBuilding, filters, selectedTags]);
 
     // Builds table filters from url params
     useEffect(() => {
@@ -186,8 +186,8 @@ const RulesTable = ({ rules, filters, rulesFetchStatus, setFilters, fetchRules, 
             paramsObject.offset === undefined ? paramsObject.offset = 0 : paramsObject.offset = Number(paramsObject.offset[0]);
             paramsObject.limit === undefined ? paramsObject.limit = 10 : paramsObject.limit = Number(paramsObject.limit[0]);
 
-            setImpacting(paramsObject.impacting);
-            setFilters({ ...paramsObject });
+            setImpacting(filters.impacting || paramsObject.impacting);
+            setFilters({ ...filters, ...paramsObject });
         }
 
         setFilterBuilding(false);

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -134,7 +134,7 @@ const SystemsTable = ({ systemsFetchStatus, fetchSystems, systems, intl, filters
             paramsObject.display_name !== undefined && (paramsObject.display_name = paramsObject.display_name[0]);
             paramsObject.offset === undefined ? paramsObject.offset = 0 : paramsObject.offset = Number(paramsObject.offset[0]);
             paramsObject.limit === undefined ? paramsObject.limit = 10 : paramsObject.limit = Number(paramsObject.limit[0]);
-            setFilters({ ...paramsObject });
+            setFilters({ ...filters, ...paramsObject });
         } else if (filters.limit === undefined || filters.offest === undefined) {
             setFilters({ ...filters, offset: 0, limit: 10 });
         }
@@ -148,7 +148,7 @@ const SystemsTable = ({ systemsFetchStatus, fetchSystems, systems, intl, filters
     }, [filters, selectedTags]);
 
     useEffect(() => {
-        !filterBuilding && systemsFetchStatus !== 'pending' && fetchSystemsFn();
+        !filterBuilding && systemsFetchStatus !== 'pending' && selectedTags !== null && fetchSystemsFn();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fetchSystemsFn, filterBuilding, filters, selectedTags]);
 

--- a/src/PresentationalComponents/TagsToolbar/Common.js
+++ b/src/PresentationalComponents/TagsToolbar/Common.js
@@ -1,8 +1,10 @@
 const tagUrlBuilder = (tagsToSet) => {
-    const url = new URL(window.location);
-    let params = new URLSearchParams(url.search);
-    tagsToSet.length ? params.set('tags', tagsToSet.join()) : params.delete('tags');
-    window.history.replaceState(null, null, `${url.origin}${url.pathname}${params.toString().length ? '?' : ''}${params.toString()}`);
+    if (tagsToSet !== null) {
+        const url = new URL(window.location);
+        let params = new URLSearchParams(url.search);
+        tagsToSet.length ? params.set('tags', tagsToSet.join()) : params.delete('tags');
+        window.history.replaceState(null, null, `${url.origin}${url.pathname}${params.toString().length ? '?' : ''}${params.toString()}`);
+    }
 };
 
 export { tagUrlBuilder };

--- a/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
+++ b/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
@@ -34,6 +34,7 @@ const TagsToolbar = ({ selectedTags, setSelectedTags }) => {
             try {
                 const response = await API.get(`${BASE_URL}/tag/`);
                 setTags(response.data.tags);
+                params === null && selectedTags === null && setSelectedTags([]);
                 if (params.length) {
                     const tagsToSet = intersection(params.split(','), response.data.tags);
                     tagUrlBuilder(tagsToSet);
@@ -69,7 +70,7 @@ const TagsToolbar = ({ selectedTags, setSelectedTags }) => {
         tagUrlBuilder(tagsToSet);
     };
 
-    return <div className='tagsToolbarContainer'>
+    return selectedTags !== null && <div className='tagsToolbarContainer'>
         {<ManageTags
             handleModalToggle={(toggleModal) => setManageTagsModalOpen(toggleModal)}
             isModalOpen={manageTagsModalOpen}

--- a/src/SmartComponents/Rules/Details.js
+++ b/src/SmartComponents/Rules/Details.js
@@ -47,7 +47,7 @@ const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchR
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const fetchRulefn = () => {
-        const options = selectedTags.length && ({ tags: selectedTags.join() });
+        const options = selectedTags !== null && selectedTags.length && ({ tags: selectedTags.join() });
         fetchSystem({ rule_id: match.params.id, ...options });
         fetchRule({ rule_id: match.params.id, ...options });
     };
@@ -118,7 +118,7 @@ const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchR
 
     const ref = useRef();
     useEffect(() => {
-        JSON.stringify(ref.current) !== JSON.stringify(selectedTags) && fetchRulefn();
+        selectedTags !== null && JSON.stringify(ref.current) !== JSON.stringify(selectedTags) && fetchRulefn();
         ref.current = selectedTags;
     }, [fetchRulefn, selectedTags]);
 

--- a/src/SmartComponents/Topics/List.js
+++ b/src/SmartComponents/Topics/List.js
@@ -16,7 +16,7 @@ const TagsToolbar = asyncComponent(() => import(/* webpackChunkName: "TagsToolba
 
 const List = ({ fetchTopics, intl, selectedTags }) => {
     useEffect(() => {
-        const options = selectedTags.length && ({ tags: selectedTags.join() });
+        const options = selectedTags !== null && selectedTags.length && ({ tags: selectedTags.join() });
         fetchTopics(options);
     }, [fetchTopics, selectedTags]);
 


### PR DESCRIPTION
SO NOW we should....

* be able to navigate around app, tables  have filters persist correctly (restoration of a regression)
* only send call once tags on url have been sorted, means we'll see the response with data affecting the selected tags
* 🤸‍♀️🎈💰