### PR TITLE
Adds support for local storage, persists state with valid value

### DIFF
--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -36,7 +36,8 @@ const initialState = Immutable({
     selectedTags: null
 });
 
-export const AdvisorStore = (state = initialState, action) => {
+// eslint-disable-next-line new-cap
+export const getAdvisorStore = (previousState) => (state =  Immutable(previousState) || initialState, action) => {
     switch (action.type) {
         case `${ActionTypes.RULE_FETCH}_PENDING`:
             return state.set('ruleFetchStatus', 'pending');

--- a/src/Store/index.js
+++ b/src/Store/index.js
@@ -1,31 +1,41 @@
-import promiseMiddleware from 'redux-promise-middleware';
-import { compose } from 'redux';
-import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/files/Registry';
 import { notifications, notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications';
-import { AdvisorStore } from '../AppReducer';
+
+import { compose } from 'redux';
+import { getAdvisorStore } from '../AppReducer';
+import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/files/Registry';
+import promiseMiddleware from 'redux-promise-middleware';
 
 let registry;
 
-export function init (...middleware) {
+const localStorage = store => next => action => {
+    const activeStore = store.getState().AdvisorStore;
+    sessionStorage.setItem('AdvisorStore', JSON.stringify(activeStore));
+    next(action);
+};
+
+export function init(...middleware) {
     const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
     registry = getRegistry(
         {},
         [...middleware, promiseMiddleware, notificationsMiddleware({
             errorTitleKey: ['message'],
             errorDescriptionKey: ['response.data.detail']
-        })],
+        }),
+        localStorage],
         composeEnhancers
     );
-    registry.register({ AdvisorStore });
+
+    const previousAdvisorStore = JSON.parse(sessionStorage.getItem('AdvisorStore'));
+    registry.register({ AdvisorStore: getAdvisorStore(previousAdvisorStore) });
     registry.register({ notifications });
 
     return registry;
 }
 
-export function getStore () {
+export function getStore() {
     return registry.getStore();
 }
 
-export function register (...args) {
+export function register(...args) {
     return registry.register(...args);
 }


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-6403


SO what we do here with this work is propagate advisor store into sessionStorage and use it to hydrate the store on app load. The goal being, when you navigate away from advisor then return all filter settings will be preserved/restored. 