### PR TITLE
Adds reboot required filter to rec table

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -146,6 +146,12 @@ export const FILTER_CATEGORIES = {
             { label: 'No Ansible remediation support', text: 'No Ansible remediation support', value: 'false' }
         ]
     },
+    reboot: {
+        type: 'checkbox', title: 'Reboot required', urlParam: 'reboot', values: [
+            { label: 'Yes', text: 'Yes', value: 'true' },
+            { label: 'No', text: 'No', value: 'false' }
+        ]
+    },
     reports_shown: {
         type: 'radio', title: 'status', urlParam: 'reports_shown', values: [
             { label: intlHelper(intl.formatMessage(messages.all), intlSettings), value: 'undefined' },

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -181,6 +181,7 @@ const RulesTable = ({ rules, filters, rulesFetchStatus, setFilters, fetchRules, 
             paramsObject.incident !== undefined && !Array.isArray(paramsObject.incident) && (paramsObject.incident = [`${paramsObject.incident}`]);
             paramsObject.offset === undefined ? paramsObject.offset = 0 : paramsObject.offset = Number(paramsObject.offset[0]);
             paramsObject.limit === undefined ? paramsObject.limit = 10 : paramsObject.limit = Number(paramsObject.limit[0]);
+            paramsObject.reboot !== undefined && !Array.isArray(paramsObject.reboot) && (paramsObject.reboot = [`${paramsObject.reboot}`]);
 
             setFilters({ ...filters, ...paramsObject });
         }
@@ -392,6 +393,17 @@ const RulesTable = ({ rules, filters, rulesFetchStatus, setFilters, fetchRules, 
             onChange: (event, values) => addFilterParam(FC.has_playbook.urlParam, values),
             value: filters.has_playbook,
             items: FC.has_playbook.values
+        }
+    },  {
+        label: FC.reboot.title,
+        type: FC.reboot.type,
+        id: FC.reboot.urlParam,
+        value: `checkbox-${FC.reboot.urlParam}`,
+        filterValues: {
+            key: `${FC.reboot.urlParam}-filter`,
+            onChange: (event, values) => addFilterParam(FC.reboot.urlParam, values),
+            value: filters.reboot,
+            items: FC.reboot.values
         }
     }, {
         label: FC.reports_shown.title,


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-6191

plays well with all the persistence jazz we've come to expect 

##### What it looks like! (updated text to say yes no)
<img width="578" alt="Screen Shot 2020-06-05 at 8 20 17 AM" src="https://user-images.githubusercontent.com/6640236/83875623-6fc3cf00-a705-11ea-990a-503bd81325e5.png">
<img width="1439" alt="Screen Shot 2020-06-05 at 8 20 25 AM" src="https://user-images.githubusercontent.com/6640236/83875626-70f4fc00-a705-11ea-8bc0-fff5a7a5fe0c.png">


##### having both values selected is like having no values selected
<img width="1438" alt="Screen Shot 2020-06-05 at 8 06 42 AM" src="https://user-images.githubusercontent.com/6640236/83874544-a993d600-a703-11ea-884e-0d7616014e04.png">

##### located inbetween ansible support and status
<img width="546" alt="Screen Shot 2020-06-05 at 8 06 28 AM" src="https://user-images.githubusercontent.com/6640236/83874566-af89b700-a703-11ea-97d4-b1b40513bb2e.png">

##### What it looks like! 
<img width="1437" alt="Screen Shot 2020-06-05 at 8 06 19 AM" src="https://user-images.githubusercontent.com/6640236/83874567-b0224d80-a703-11ea-92ef-877f70371364.png">


