### PR TITLE
Manage all tags text always available 🤗👩‍🏭 

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -274,6 +274,11 @@ export default defineMessages({
         description: 'Accepts a count of items, appends the text more',
         defaultMessage: '{count} more'
     },
+    countMoreTags: {
+        id: 'countMoreTags',
+        description: 'Accepts a count of additional taks available',
+        defaultMessage: '{count} more tags available'
+    },
     recommended: {
         id: 'recommended',
         description: 'Recommended',
@@ -465,6 +470,11 @@ export default defineMessages({
         id: 'noTags',
         description: 'When there exist no tags for an account',
         defaultMessage: 'No tags available'
+    },
+    manageTags: {
+        id: 'manageTags',
+        description: 'Manage tags',
+        defaultMessage: 'Manage tags'
     },
     topicAddEditDescription: {
         id: 'topicAddEditDescription',

--- a/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
+++ b/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
@@ -95,11 +95,12 @@ const TagsToolbar = ({ selectedTags, setSelectedTags }) => {
                     </Tooltip>
                 </SelectOption>
             )}
-            {(showMoreCount > 0 && tags.length > showMoreCount) ? <Button key='view all tags'
+            <Button key='manage all tags'
                 variant='link' onClick={(toggleModal) => setManageTagsModalOpen(toggleModal)}>
-                {intl.formatMessage(messages.countMore, { count: tags.length - showMoreCount })}
+                {(showMoreCount > 0 && tags.length > showMoreCount) ?
+                    intl.formatMessage(messages.countMoreTags, { count: tags.length - showMoreCount }) : intl.formatMessage(messages.manageTags)
+                }
             </Button>
-                : <React.Fragment />}
         </Select>
     </div >;
 };


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-6742

#### looks like thissssssss when we have less than 20 tags
<img width="1112" alt="Screen Shot 2020-06-11 at 7 39 26 AM" src="https://user-images.githubusercontent.com/6640236/84381527-2e289d80-abb7-11ea-8097-e3a5162a1d82.png">

#### and this when we have more!
<img width="1113" alt="Screen Shot 2020-06-11 at 7 38 48 AM" src="https://user-images.githubusercontent.com/6640236/84381547-34b71500-abb7-11ea-968b-4fee788be4f7.png">
