### PR TITLE
Set Input's value to searchText when TagToolbar dropdown opens

### DIFF
--- a/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
+++ b/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
@@ -73,7 +73,7 @@ const TagsToolbar = ({ selectedTags, setSelectedTags }) => {
     </React.Fragment>;
 
     const onToggle = isOpen => {
-        setSearchText();
+        setSearchText('');
         setIsOpen(isOpen);
     };
 


### PR DESCRIPTION
Not sure if this is intended or a (very minor) bug ... but I found if you open the TagsToolbar dropdown, it 'remembers' the previous search text and hence filters the list, but the input box is empty.  Thus you might be unsure/confused why you aren't getting a full list of tags being displayed in the drop down.  This PR populates the input box with the previous search term so you know what it was and why the list is being filtered.

The other alternative is to `setSearchText('');`so there isn't any filtering and you get the full list of tags.

How to reproduce 'problem' ...
1. Open the tags toolbar dropdown
2. Enter in some text in the filter tags search textbox to filter the tags, eg 'ocp'
3. Click away from the filter tags dropdown to close it
4. Open the tags toolbar again
5. The tag list is still filtered by the 'ocp' text, but it isn't obvious that its being filtered by the text 'ocp' 

I know, its only minor but had me scratching my head once or twice.  And sure, as soon as you start typing something new into the text box, the list is filtered by the new text, so its really not that big of a deal.  Feel free to close this PR if you think this is unnecessary.