### PR TITLE
Changes rec table filter text

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -1,6 +1,7 @@
 {
   "en": {
     "rules": "Rules",
+    "recommendation": "Recommendation",
     "recommendations": "Recommendations",
     "added": "Added",
     "rule": "Rule",

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -1,5 +1,6 @@
 {
   "rules": "Rules",
+  "recommendation": "Recommendation",
   "recommendations": "Recommendations",
   "added": "Added",
   "rule": "Rule",

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -7,6 +7,11 @@ export default defineMessages({
         description: 'Used as a title',
         defaultMessage: 'Rules'
     },
+    recommendation: {
+        id: 'recommendation',
+        description: 'Recommendation',
+        defaultMessage: 'Recommendation'
+    },
     recommendations: {
         id: 'recommendations',
         description: 'Used as a title',

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -295,11 +295,12 @@ const RulesTable = ({ rules, filters, rulesFetchStatus, setFilters, fetchRules, 
     ];
 
     const filterConfigItems = [{
-        label: intl.formatMessage(messages.description).toLowerCase(),
+        label: intl.formatMessage(messages.recommendation).toLowerCase(),
         filterValues: {
             key: 'text-filter',
             onChange: (event, value) => setSearchText(value),
-            value: searchText
+            value: searchText,
+            placeholder: intl.formatMessage(messages.search)
         }
     }, {
         label: FC.total_risk.title,

--- a/src/PresentationalComponents/RulesTable/_RulesTable.scss
+++ b/src/PresentationalComponents/RulesTable/_RulesTable.scss
@@ -1,5 +1,11 @@
 .pf-c-check__label {
     #battery_svg {
-        height: 1.25rem; 
+        height: 1.25rem;
+    }
+}
+
+.ins-c-conditional-filter .ins-c-conditional-filter__group .pf-c-dropdown__toggle-text {
+    @media screen and (min-width: 884px) {
+        min-width: 150px !important;
     }
 }


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-7224

#### looks like this (important we maintain tiny screen behaviors) 
<img width="875" alt="Screen Shot 2020-07-01 at 8 13 40 AM" src="https://user-images.githubusercontent.com/6640236/86243362-40717800-bb74-11ea-8dcc-4a8dc36a546a.png">
<img width="941" alt="Screen Shot 2020-07-01 at 8 13 49 AM" src="https://user-images.githubusercontent.com/6640236/86243366-423b3b80-bb74-11ea-84ca-904f6d40d010.png">

