### PR TITLE
When perpage is less than length, hide selection option (rec details)🛠

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -161,8 +161,8 @@ const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification
                     }
                 },
                 {
-                    ...items && items.length > 0 ? {
-                        title: intl.formatMessage(messages.selectPage, { items: pageSize || 0 }),
+                    ...items && items.length > pageSize ? {
+                        title: intl.formatMessage(messages.selectPage, { items: pageSize }),
                         onClick: () => {
                             onSelectRows(0, true);
                         }


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-5270

<img width="899" alt="Screen Shot 2020-07-01 at 11 16 14 AM" src="https://user-images.githubusercontent.com/6640236/86261795-02cd1900-bb8d-11ea-9359-9b8b2d63724f.png">
<img width="892" alt="Screen Shot 2020-07-01 at 11 15 37 AM" src="https://user-images.githubusercontent.com/6640236/86261805-052f7300-bb8d-11ea-8671-623639881e57.png">
