### PR TITLE
Force-trigger debounce to fetch tags on mount

### DIFF
--- a/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
+++ b/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
@@ -30,7 +30,7 @@ const TagsToolbar = ({ selectedTags, setSelectedTags }) => {
     const [isOpen, setIsOpen] = useState(false);
     const [totalTags, setTotalTags] = useState();
     const [tags, setTags] = useState([]);
-    const [searchText, setSearchText] = useState('');
+    const [searchText, setSearchText] = useState();
     const [params, setParams] = useState();
     const [tagsCount, setTagsCount] = useState();
     const debouncedSearchText = debounce(searchText, DEBOUNCE_DELAY);
@@ -79,6 +79,11 @@ const TagsToolbar = ({ selectedTags, setSelectedTags }) => {
 
         return formattedTags;
     };
+
+    // Force triggers the debounce function on mount (i.e. deleting this will break things)
+    useEffect(() => {
+        setSearchText('');
+    }, []);
 
     useEffect(() => {
         setTagsCount(tags.flatMap(source => source.data).length);


### PR DESCRIPTION
This fixes the issue of tags not being fetched when the component mounts. This is because the debounce function is not being run ahead of time (as it was previously). This is a super hacky (but effective) way to make sure that the tags get fetched on mount by forcing the debounce function to run 💯