### PR TITLE
Pass react redux to inventory loader as well

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import * as pfReactTable from '@patternfly/react-table';
 import * as reactRouterDom from 'react-router-dom';
+import * as ReactRedux from 'react-redux';
 
 import React, { useEffect, useRef, useState } from 'react';
 
@@ -99,7 +100,7 @@ const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification
     useEffect(() => {
         (async () => {
             const { inventoryConnector, mergeWithEntities, INVENTORY_ACTION_TYPES } = await insights.loadInventory({
-                react: React, reactRouterDom, pfReactTable
+                ReactRedux, react: React, reactRouterDom, pfReactTable
             });
 
             getRegistry().register({

--- a/src/PresentationalComponents/Inventory/InventoryDetails.js
+++ b/src/PresentationalComponents/Inventory/InventoryDetails.js
@@ -2,6 +2,7 @@ import '@redhat-cloud-services/frontend-components-inventory-insights/index.css'
 
 import * as pfReactTable from '@patternfly/react-table';
 import * as reactRouterDom from 'react-router-dom';
+import * as ReactRedux from 'react-redux';
 
 import { Grid, GridItem } from '@patternfly/react-core/dist/js/layouts/Grid/index';
 import React, { useEffect, useState } from 'react';
@@ -23,6 +24,7 @@ const InventoryDetails = ({ entity, match }) => {
 
     const fetchInventoryDetails = async () => {
         const { inventoryConnector, mergeWithDetail, INVENTORY_ACTION_TYPES } = await insights.loadInventory({
+            ReactRedux,
             react: React,
             reactRouterDom,
             pfReactTable

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -2,6 +2,7 @@
 import * as AppActions from '../../AppActions';
 import * as pfReactTable from '@patternfly/react-table';
 import * as reactRouterDom from 'react-router-dom';
+import * as ReactRedux from 'react-redux';
 
 import { DEBOUNCE_DELAY, SYSTEM_FILTER_CATEGORIES as SFC } from '../../AppConstants';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -150,6 +151,7 @@ const SystemsTable = ({ systemsFetchStatus, fetchSystems, systems, intl, filters
             { title: intl.formatMessage(messages.lastSeen), transforms: [pfReactTable.sortable, pfReactTable.cellWidth(10)], key: 'updated' }];
             const { inventoryConnector, mergeWithEntities, INVENTORY_ACTION_TYPES
             } = await insights.loadInventory({
+                ReactRedux,
                 react: React,
                 reactRouterDom,
                 pfReactTable


### PR DESCRIPTION
We are working on inventory refactoring, since we'd like to fully use hooks and such we have to use App's react dependency. With this being used react-redux needs to be passed from application as well. If you are cautious about the size of your bundle I can pick only the functions really required by inventory.