### PR TITLE
Add key=value to tags toolbar

### DIFF
--- a/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
+++ b/src/PresentationalComponents/TagsToolbar/TagsToolbar.js
@@ -167,7 +167,7 @@ const TagsToolbar = ({ selectedTags, setSelectedTags }) => {
                                 selectedTags.find(selection => selection === tag.id)
                             }>
                                 <Tooltip content={`${tag.id}`} position={TooltipPosition.right}>
-                                    <span>{`${decodeURIComponent(tag.value)}`}</span>
+                                    <span>{`${decodeURIComponent(tag.key + '=' + tag.value)}`}</span>
                                 </Tooltip>
                             </SelectOption>
                             <Badge className='tags-select-badge'> {tag.count} </Badge>

--- a/src/PresentationalComponents/TagsToolbar/_TagsToolbar.scss
+++ b/src/PresentationalComponents/TagsToolbar/_TagsToolbar.scss
@@ -57,13 +57,14 @@
       color: var(--pf-global--BackgroundColor--100);
     }
   }
-  
+
   .pf-c-select {
     max-width: 400px !important;
   }
 
   .pf-c-check__label {
-    max-width: 350px !important;
+    max-width: 400px !important;
+    width: 400px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
The inventory tags dropdown has key=value.  Modifying ours to match.  Also allowing the width of the dropdown to change to match the max width of the longest key=value text.