### PR TITLE
Add filter chips to Tags Toolbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4181,9 +4181,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-2.3.4.tgz",
-      "integrity": "sha512-bhOw/HTO9SNwy4aAL3K26SrmuSXYN5NNdU3yVvbt/p3flgNEDd9Uew6Mw9DXZyJ5n84hHNpYzJbtZ4x7t6B16w==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-2.3.5.tgz",
+      "integrity": "sha512-95eNhBA1G0QfwYk0k0ZSveX53CZR/Bw38OEHrMdsnuegZVoaiE99DSOf4Um/FMh0zRt6eRPV2fcEU6Fj1wyTuw==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "sanitize-html": "^1.25.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@patternfly/react-table": "4.12.1",
     "@patternfly/react-tokens": "4.6.0",
     "@react-pdf/renderer": "1.6.10",
-    "@redhat-cloud-services/frontend-components": "2.3.4",
+    "@redhat-cloud-services/frontend-components": "2.3.5",
     "@redhat-cloud-services/frontend-components-charts": "2.3.1",
     "@redhat-cloud-services/frontend-components-inventory-insights": "2.5.2",
     "@redhat-cloud-services/frontend-components-notifications": "2.1.1",

--- a/src/PresentationalComponents/TagsToolbar/ManageTags.js
+++ b/src/PresentationalComponents/TagsToolbar/ManageTags.js
@@ -89,7 +89,7 @@ const ManageTags = ({ toggleModal, fetchTags, selectedTags, setSelectedTags, tot
             }))
         }}
         loaded={ loaded }
-        width='auto'
+        width='50%'
         isOpen={ isOpen }
         toggleModal={() => {
             setPerPage(10);
@@ -145,6 +145,7 @@ const ManageTags = ({ toggleModal, fetchTags, selectedTags, setSelectedTags, tot
 ManageTags.propTypes = {
     toggleModal: PropTypes.func.isRequired,
     fetchTags: PropTypes.func.isRequired,
+    totalTags: PropTypes.number.isRequired,
     isOpen: PropTypes.bool.isRequired,
     selectedTags: PropTypes.array,
     setSelectedTags: PropTypes.func

--- a/src/PresentationalComponents/TagsToolbar/ManageTags.js
+++ b/src/PresentationalComponents/TagsToolbar/ManageTags.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { DEBOUNCE_DELAY } from '../../AppConstants';
 import PropTypes from 'prop-types';
@@ -9,6 +9,24 @@ import messages from '../../Messages';
 import { setSelectedTags } from '../../AppActions';
 import { useIntl } from 'react-intl';
 
+const buildFilterChips = (selected) => {
+    const filters = selected.map(tag => tag.namespace).filter(
+        (value, index, self) =>
+            self.indexOf(value) === index
+    ).map(category => ({
+        category,
+        chips: selected.filter(tag =>
+            tag.namespace === category
+        ).map(tag => ({
+            name: tag.value,
+            id: tag.id,
+            value: true
+        })),
+        urlParam: 'tags'
+    }));
+    return { filters };
+};
+
 const ManageTags = ({ toggleModal, fetchTags, selectedTags, setSelectedTags, totalTags, isOpen }) => {
     const [tags, setTags] = useState();
     const [loaded, setLoaded] = useState(false);
@@ -18,6 +36,7 @@ const ManageTags = ({ toggleModal, fetchTags, selectedTags, setSelectedTags, tot
     const [searchText, setSearchText] = useState();
     const intl = useIntl();
     const debouncedSearchText = debounce(searchText, DEBOUNCE_DELAY);
+    const activeFiltersConfig = useMemo(() => buildFilterChips(selected), [selected]);
 
     useEffect(() => {
         (async () => {
@@ -37,11 +56,25 @@ const ManageTags = ({ toggleModal, fetchTags, selectedTags, setSelectedTags, tot
     }, [perPage, page]);
 
     useEffect(() => {
-        setSelected(selectedTags.length ? selectedTags.map(id => ({ id, selected: true })) : []);
+        setSelected(selectedTags.length ? selectedTags.map(id => ({
+            id,
+            namespace: id.split('/')[0],
+            key: decodeURIComponent(id.split('/')[1].split('=')[0]),
+            value: decodeURIComponent(id.split('/')[1].split('=')[1])
+        })) : []);
     }, [selectedTags, setSelected]);
 
+    const onDelete = (e, items, isAll) => {
+        if (isAll) {
+            setSelected([]);
+        } else {
+            const ids = items.flatMap(item => item.chips.map(chip => chip.id));
+            setSelected(selected.filter(tag => ids.filter(id => id !== tag.id).length));
+        }
+    };
+
     return <TagModal
-        systemName={intl.formatMessage(messages.insightsHeader).toLowerCase()}
+        title={intl.formatMessage(messages.tagsCount, { count: totalTags })}
         {...loaded && {
             loaded,
             pagination: {
@@ -50,7 +83,7 @@ const ManageTags = ({ toggleModal, fetchTags, selectedTags, setSelectedTags, tot
                 count: totalTags
             },
             rows: tags.map(tag => ({
-                id: tag.id,
+                ...tag,
                 selected: selected.find(selection => selection.id === tag.id),
                 cells: [tag.key, tag.value, tag.namespace, tag.count]
             }))
@@ -89,19 +122,29 @@ const ManageTags = ({ toggleModal, fetchTags, selectedTags, setSelectedTags, tot
             { title: intl.formatMessage(messages.systems) }
         ] }
         selected={selected}
-        onSelect={(selected) => setSelected(selected.map(tag => ({ id: tag.id, selected: true })))}
+        onSelect={(selected) => setSelected(selected.map(tag => ({
+            id: tag.id,
+            namespace: tag.namespace,
+            value: tag.value,
+            selected: true
+        })))}
         onApply={() => {
             setSelectedTags(selected.map(tag => tag.id));
             setSelected([]);
         }}
         tableProps={{ canSelectAll: false }}
+        primaryToolbarProps={{
+            activeFiltersConfig: {
+                ...activeFiltersConfig,
+                onDelete
+            }
+        }}
     />;
 };
 
 ManageTags.propTypes = {
     toggleModal: PropTypes.func.isRequired,
     fetchTags: PropTypes.func.isRequired,
-    totalTags: PropTypes.number.isRequired,
     isOpen: PropTypes.bool.isRequired,
     selectedTags: PropTypes.array,
     setSelectedTags: PropTypes.func


### PR DESCRIPTION
This PR adds the config for filter chips on the Tags Modal. This will be ready to go once we get https://github.com/RedHatInsights/frontend-components/pull/645 and the deps updated appropriately. Here's what they look like.

<img width="764" alt="Screen Shot 2020-07-22 at 2 56 49 PM" src="https://user-images.githubusercontent.com/4829473/88216825-a6a96200-cc2b-11ea-8376-9d9f9360b4b4.png">

Here's what happens if you select a lot of different tags.

<img width="750" alt="Screen Shot 2020-07-22 at 2 59 23 PM" src="https://user-images.githubusercontent.com/4829473/88217071-030c8180-cc2c-11ea-9b02-1cfd8a9316fd.png">
