### PR TITLE
Maintain selected state across all ManagedTags modal open/closes

### DIFF
--- a/src/PresentationalComponents/TagsToolbar/ManageTags.js
+++ b/src/PresentationalComponents/TagsToolbar/ManageTags.js
@@ -56,13 +56,18 @@ const ManageTags = ({ toggleModal, fetchTags, selectedTags, setSelectedTags, isO
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [perPage, page]);
 
-    useEffect(() => {
-        setSelected(selectedTags.length ? selectedTags.map(id => ({
+    const populateSelected = () => {
+        return selectedTags.length ? selectedTags.map(id => ({
             id,
             namespace: id.split('/')[0],
             key: decodeURIComponent(id.split('/')[1].split('=')[0]),
             value: decodeURIComponent(id.split('/')[1].split('=')[1])
-        })) : []);
+        })) : [];
+    };
+
+    useEffect(() => {
+        setSelected(populateSelected());
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedTags, setSelected]);
 
     const onDelete = (e, items, isAll) => {
@@ -97,7 +102,7 @@ const ManageTags = ({ toggleModal, fetchTags, selectedTags, setSelectedTags, isO
                 setPerPage(10);
                 setPage(1);
                 setSearchText();
-                setSelected([]);
+                setSelected(populateSelected());
                 toggleModal();
             }}
             filters={[
@@ -132,7 +137,6 @@ const ManageTags = ({ toggleModal, fetchTags, selectedTags, setSelectedTags, isO
             })))}
             onApply={() => {
                 setSelectedTags(selected.map(tag => tag.id));
-                setSelected([]);
             }}
             tableProps={{ canSelectAll: false }}
             primaryToolbarProps={{


### PR DESCRIPTION
@AllenBW @LI0131, I noticed a problem with the ManageTags modal when you close it by cancelling or clicking the X.  The 'selected' variable is set to `[]` so the next time you open the modal, the selected tags checkboxes aren't selected anymore.  The 'selectedTags' global variable still maintains the correct number of selected tags.

How to reproduce the problem:
1. Open TagsToolbar and select a tag (or multiple tags)
2. Click on the link to open the ManagedTags modal
3. Notice the checkboxes for the selected tags will be checked and there are filter chips for the selected tags.  All good so far ...
4. Here's the kicker though ... Click on Cancel (or X) to close the modal
5. Notice in the tags toolbar that it has the correct count for the number of selected tags
6. Open up the modal again
7. The checkboxes for the selected tags are not selected anymore and the filter chips are not created.  Womp womp!
8. Close the modal and notice that the tags toolbar still has the correct count of number of selected tags

This behaviour also happens in the Modal if you clear the filter chips but then press Cancel (or X).  The tags toolbar still shows the correct number of selected tags, but if you open up the manage tags modal, no tags are selected.  Womp womp.

My patch seems to resolve this ok, but there's probably a better way.
