### PR TITLE
Update Inv-Insights dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4322,9 +4322,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-inventory-insights": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory-insights/-/frontend-components-inventory-insights-2.5.2.tgz",
-      "integrity": "sha512-zx2RA+z3f3Wo80paHg+WuzhFl4akT4sxw0wGoEiBy84y2/IJnTTUYDswK53ULNf+IuMVtSypl9/hYLQ5b2ec3Q==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory-insights/-/frontend-components-inventory-insights-2.5.3.tgz",
+      "integrity": "sha512-SdXZWxQnc3a652PSaWIks76T5stVubKIP76uqForCZMK2fxK/cKgkaxIrl+4TR61neLwHGVJKg4AZrjWHmpjhg==",
       "requires": {
         "@redhat-cloud-services/frontend-components": ">=2.3.1",
         "@redhat-cloud-services/frontend-components-notifications": "*",
@@ -20499,7 +20499,8 @@
     "typescript": {
       "version": "3.9.7",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.4.10",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@react-pdf/renderer": "1.6.10",
     "@redhat-cloud-services/frontend-components": "2.3.8",
     "@redhat-cloud-services/frontend-components-charts": "2.3.1",
-    "@redhat-cloud-services/frontend-components-inventory-insights": "2.5.2",
+    "@redhat-cloud-services/frontend-components-inventory-insights": "2.5.3",
     "@redhat-cloud-services/frontend-components-notifications": "2.1.2",
     "@redhat-cloud-services/frontend-components-pdf-generator": "2.2.0",
     "@redhat-cloud-services/frontend-components-remediations": "2.1.0",


### PR DESCRIPTION
Updating the inventory-insights dependencies to reflect the new changes to the fec repo.

Here's how we're looking:
<img width="1440" alt="Screen Shot 2020-07-24 at 11 15 55 AM" src="https://user-images.githubusercontent.com/4829473/88407331-f6a93580-cd9f-11ea-8d7e-333b03f1af74.png">
