### PR TITLE
Update tags query

### DIFF
--- a/src/AppActions.js
+++ b/src/AppActions.js
@@ -2,9 +2,11 @@ import * as ActionTypes from './AppConstants';
 
 import API from './Utilities/Api';
 
-const fetchData = async (url, headers, options) => {
+const fetchData = async (url, headers, options, search) => {
     await insights.chrome.auth.getUser();
-    const response = await API.get(url, headers, options);
+    const response = search ?
+        await API.get(`${url}?${search}`, headers, options) :
+        await API.get(`${url}`, headers, options);
     return response.data;
 };
 
@@ -26,17 +28,17 @@ export const fetchStatsStaleHosts = (options) => ({
     type: ActionTypes.STATS_STALEHOSTS_FETCH,
     payload: fetchData(ActionTypes.STATS_STALEHOSTS_FETCH_URL, {}, options)
 });
-export const fetchRules = (options) => ({
+export const fetchRules = (options, search) => ({
     type: ActionTypes.RULES_FETCH,
-    payload: fetchData(ActionTypes.RULES_FETCH_URL, {}, options)
+    payload: fetchData(ActionTypes.RULES_FETCH_URL, {}, options, search && search)
 });
-export const fetchRule = (options) => ({
+export const fetchRule = (options, search) => ({
     type: ActionTypes.RULE_FETCH,
-    payload: fetchData(`${ActionTypes.RULES_FETCH_URL}${options.rule_id}/`, {}, options.tags && { tags: options.tags })
+    payload: fetchData(`${ActionTypes.RULES_FETCH_URL}${options.rule_id}/`, {}, options, search && search)
 });
-export const fetchSystem = (ruleId, options) => ({
+export const fetchSystem = (ruleId, options, search) => ({
     type: ActionTypes.SYSTEM_FETCH,
-    payload: fetchData(`${ActionTypes.RULES_FETCH_URL}${encodeURI(ruleId)}/systems`, {}, options)
+    payload: fetchData(`${ActionTypes.RULES_FETCH_URL}${encodeURI(ruleId)}/systems`, {}, options, search && search)
 });
 export const setFilters = (filters) => ({
     type: ActionTypes.FILTERS_SET,

--- a/src/PresentationalComponents/Common/Tables.js
+++ b/src/PresentationalComponents/Common/Tables.js
@@ -24,6 +24,13 @@ export const paramParser = () => {
     }), {});
 };
 
+// create url from options
+export const encodeOptionsToURL = (options) => {
+    return Object.entries(options).reduce((acc, [key, value], index) => {
+        return acc += index === 0 ? `${key}=${value}` : `&${key}=${value}`;
+    }, '');
+};
+
 // capitalizes text string
 export const capitalize = (string) => string[0].toUpperCase() + string.substring(1);
 

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -10,7 +10,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Stack, StackItem } from '@patternfly/react-core/dist/js/layouts/Stack/index';
 import { Table, TableBody, TableHeader, cellWidth, fitContent, sortable } from '@patternfly/react-table';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core/dist/js/components/Tooltip/Tooltip';
-import { filterFetchBuilder, paramParser, pruneFilters, urlBuilder } from '../Common/Tables';
+import { encodeOptionsToURL, filterFetchBuilder, paramParser, pruneFilters, urlBuilder } from '../Common/Tables';
 
 import API from '../../Utilities/Api';
 import AnsibeTowerIcon from '@patternfly/react-icons/dist/js/icons/ansibeTower-icon';
@@ -74,11 +74,11 @@ const RulesTable = ({ rules, filters, rulesFetchStatus, setFilters, fetchRules, 
 
     const fetchRulesFn = useCallback(() => {
         urlBuilder(filters, selectedTags);
-        const options = selectedTags.length && ({ tags: selectedTags.join() });
-        fetchRules({
-            ...filterFetchBuilder(filters),
-            ...options
-        });
+        const options = selectedTags.length && ({ tags: selectedTags.map(tag => encodeURIComponent(tag)).join('&tags=') });
+        fetchRules(
+            options.tags ? {} : { ...filterFetchBuilder(filters), ...options },
+            options.tags && encodeOptionsToURL({ ...filterFetchBuilder(filters), ...options })
+        );
     }, [fetchRules, filters, selectedTags]);
 
     const onSort = (_event, index, direction) => {
@@ -521,7 +521,7 @@ const mapStateToProps = (state, ownProps) => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-    fetchRules: (url) => dispatch(AppActions.fetchRules(url)),
+    fetchRules: (options, search) => dispatch(AppActions.fetchRules(options, search)),
     addNotification: data => dispatch(addNotification(data)),
     setFilters: (filters) => dispatch(AppActions.setFilters(filters))
 });


### PR DESCRIPTION
This PR addresses [RHCLOUD-7889](https://projects.engineering.redhat.com/browse/RHCLOUD-7889). It will update the way we query the advisor api to get rules with particular host tags.

Per the 🎫 , we are moving from...

`?tags=tag1,tag2`

to

`?tags=tag1&tags=tag2`

Here's a screenshot of this working:
<img width="544" alt="Screen Shot 2020-07-27 at 10 43 19 AM" src="https://user-images.githubusercontent.com/4829473/88556012-834d3100-cff6-11ea-8090-6cffa6054014.png">
