### PR TITLE
Don't truncate system table column headings

### DIFF
--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -1,4 +1,6 @@
 /* eslint camelcase: 0 */
+import './SystemsTable.scss';
+
 import * as AppActions from '../../AppActions';
 import * as ReactRedux from 'react-redux';
 import * as pfReactTable from '@patternfly/react-table';
@@ -143,12 +145,12 @@ const SystemsTable = ({ systemsFetchStatus, fetchSystems, systems, intl, filters
             const rows = [{
                 title: intl.formatMessage(messages.name), transforms: [pfReactTable.sortable, pfReactTable.cellWidth(80)], key: 'display_name'
             },
-            { title: intl.formatMessage(messages.numberRuleHits), transforms: [pfReactTable.sortable, pfReactTable.cellWidth(1)], key: 'hits' },
-            { title: intl.formatMessage(messages.critical), transforms: [pfReactTable.sortable, pfReactTable.cellWidth(1)], key: 'critical_hits' },
-            { title: intl.formatMessage(messages.important), transforms: [pfReactTable.sortable, pfReactTable.cellWidth(1)], key: 'important_hits' },
-            { title: intl.formatMessage(messages.moderate), transforms: [pfReactTable.sortable, pfReactTable.cellWidth(1)], key: 'moderate_hits' },
-            { title: intl.formatMessage(messages.low), transforms: [pfReactTable.sortable, pfReactTable.cellWidth(1)], key: 'low_hits' },
-            { title: intl.formatMessage(messages.lastSeen), transforms: [pfReactTable.sortable, pfReactTable.cellWidth(10)], key: 'updated' }];
+            { title: intl.formatMessage(messages.numberRuleHits), transforms: [pfReactTable.sortable, pfReactTable.wrappable], key: 'hits' },
+            { title: intl.formatMessage(messages.critical), transforms: [pfReactTable.sortable, pfReactTable.wrappable], key: 'critical_hits' },
+            { title: intl.formatMessage(messages.important), transforms: [pfReactTable.sortable, pfReactTable.wrappable], key: 'important_hits' },
+            { title: intl.formatMessage(messages.moderate), transforms: [pfReactTable.sortable, pfReactTable.wrappable], key: 'moderate_hits' },
+            { title: intl.formatMessage(messages.low), transforms: [pfReactTable.sortable, pfReactTable.wrappable], key: 'low_hits' },
+            { title: intl.formatMessage(messages.lastSeen), transforms: [pfReactTable.sortable, pfReactTable.wrappable], key: 'updated' }];
             const { inventoryConnector, mergeWithEntities, INVENTORY_ACTION_TYPES
             } = await insights.loadInventory({
                 ReactRedux,

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.scss
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.scss
@@ -5,3 +5,11 @@
 .pf-c-table th, td {
   padding-right: 0px !important;
 }
+
+.pf-c-table tr > :last-child {
+  padding-left: var(--pf-global--spacer--xs);
+}
+
+.pf-c-table .pf-c-table__sort {
+  min-width: initial;
+}

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.scss
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.scss
@@ -1,0 +1,7 @@
+.pf-c-table__sort-indicator {
+  margin-left: var(--pf-global--spacer--xs);
+}
+
+.pf-c-table th, td {
+  padding-right: 0px !important;
+}


### PR DESCRIPTION
@AllenBW, my attempt at https://projects.engineering.redhat.com/browse/RHCLOUD-8282.  Not sure if this is the right way to go about fixing this tho and the last_seen column treatment is a bit experimental.  I've hidden it for a bit when the screen width really squeezes the system name column.  Feel free to close this if you've got something else (ie better :smile:) in mind.