### PR TITLE
Pass pf react core to inventory to properly render inventory

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -2,6 +2,7 @@ import * as ReactRedux from 'react-redux';
 /* eslint-disable camelcase */
 import * as pfReactTable from '@patternfly/react-table';
 import * as reactRouterDom from 'react-router-dom';
+import { reactCore } from '@redhat-cloud-services/frontend-components-utilities/files/inventoryDependencies';
 
 import React, { useEffect, useRef, useState } from 'react';
 
@@ -100,7 +101,7 @@ const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification
     useEffect(() => {
         (async () => {
             const { inventoryConnector, mergeWithEntities, INVENTORY_ACTION_TYPES } = await insights.loadInventory({
-                ReactRedux, react: React, reactRouterDom, pfReactTable
+                ReactRedux, react: React, reactRouterDom, pfReactTable, pfReact: reactCore
             });
 
             getRegistry().register({

--- a/src/PresentationalComponents/Inventory/InventoryDetails.js
+++ b/src/PresentationalComponents/Inventory/InventoryDetails.js
@@ -3,6 +3,7 @@ import '@redhat-cloud-services/frontend-components-inventory-insights/index.css'
 import * as pfReactTable from '@patternfly/react-table';
 import * as reactRouterDom from 'react-router-dom';
 import * as ReactRedux from 'react-redux';
+import { reactCore } from '@redhat-cloud-services/frontend-components-utilities/files/inventoryDependencies';
 
 import { Grid, GridItem } from '@patternfly/react-core/dist/js/layouts/Grid/index';
 import React, { useEffect, useState } from 'react';
@@ -20,6 +21,7 @@ import { useStore } from 'react-redux';
 const InventoryDetails = ({ entity, match }) => {
     const [InventoryDetail, setInventoryDetail] = useState();
     const [AppInfo, setAppInfo] = useState();
+    const [InvWrapper, setInvWrapper] = useState();
     const store = useStore();
 
     const fetchInventoryDetails = async () => {
@@ -27,21 +29,24 @@ const InventoryDetails = ({ entity, match }) => {
             ReactRedux,
             react: React,
             reactRouterDom,
-            pfReactTable
+            pfReactTable,
+            pfReact: reactCore
         });
-        const { InventoryDetailHead, AppInfo } = inventoryConnector(store);
+        const { InventoryDetailHead, AppInfo, DetailWrapper } = inventoryConnector(store);
 
         getRegistry().register({
             ...mergeWithDetail(entitiesDetailsReducer(INVENTORY_ACTION_TYPES))
         });
         setInventoryDetail(() => InventoryDetailHead);
         setAppInfo(() => AppInfo);
+        setInvWrapper(() => DetailWrapper);
     };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     useEffect(() => { fetchInventoryDetails(); }, []);
+    const Wrapper = InvWrapper || React.Fragment;
 
-    return <React.Fragment>
+    return <Wrapper>
         <PageHeader className="pf-m-light ins-inventory-detail">
             {entity && <Breadcrumbs
                 current={entity.display_name || entity.id}
@@ -56,7 +61,7 @@ const InventoryDetails = ({ entity, match }) => {
                 </GridItem>
             </Grid>
         </Main>
-    </React.Fragment>;
+    </Wrapper>;
 };
 
 InventoryDetails.contextTypes = {

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -5,6 +5,7 @@ import * as AppActions from '../../AppActions';
 import * as ReactRedux from 'react-redux';
 import * as pfReactTable from '@patternfly/react-table';
 import * as reactRouterDom from 'react-router-dom';
+import { reactCore } from '@redhat-cloud-services/frontend-components-utilities/files/inventoryDependencies';
 
 import { DEBOUNCE_DELAY, SYSTEM_FILTER_CATEGORIES as SFC } from '../../AppConstants';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -156,7 +157,8 @@ const SystemsTable = ({ systemsFetchStatus, fetchSystems, systems, intl, filters
                 ReactRedux,
                 react: React,
                 reactRouterDom,
-                pfReactTable
+                pfReactTable,
+                pfReact: reactCore
             });
             getRegistry().register({
                 ...mergeWithEntities(


### PR DESCRIPTION
There is a new feature brewing in chrome, building chrome with webpack [1]. This PR passes newly required dependencies. In future we'll use Federated modules [2] so there won't be a need for these changes, but this is required as a mid-step solution.

Also, for enabling A/B testing of inventory detail we are working on new inventory component, for now this component will be undefined so use `React.Fragment` as fallback.

[1] https://github.com/RedHatInsights/insights-chrome/pull/842
[2] https://webpack.js.org/concepts/module-federation/