### PR TITLE
Align items in Recs header

### DIFF
--- a/src/SmartComponents/Recs/List.js
+++ b/src/SmartComponents/Recs/List.js
@@ -1,3 +1,5 @@
+import './List.scss';
+
 import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components/components/PageHeader';
 import React, { Suspense, lazy } from 'react';
 
@@ -15,7 +17,7 @@ const List = () => {
 
     return <React.Fragment>
         <Suspense fallback={<Loading />}> <TagsToolbar /> </Suspense>
-        <PageHeader>
+        <PageHeader className='ins-c-recommendations-header'>
             <PageHeaderTitle title={intl.formatMessage(messages.recommendations)} />
             <DownloadExecReport />
         </PageHeader>

--- a/src/SmartComponents/Recs/List.scss
+++ b/src/SmartComponents/Recs/List.scss
@@ -1,0 +1,7 @@
+.ins-c-recommendations-header {
+    display: inline-flex;
+    justify-content: space-between;
+    .pf-c-button {
+        line-height: var(--pf-global--LineHeight--sm);
+    }
+}


### PR DESCRIPTION
This PR aligns the Recommendations title and the export Executive Report button in the recommendations header.

Before:

<img width="1440" alt="Screen Shot 2020-08-06 at 2 12 53 PM" src="https://user-images.githubusercontent.com/4829473/89568246-050c3e00-d7f1-11ea-9269-863374ae92c9.png">

After:

<img width="1440" alt="Screen Shot 2020-08-06 at 2 53 28 PM" src="https://user-images.githubusercontent.com/4829473/89570758-a0eb7900-d7f4-11ea-8789-937c0b978ba2.png">
