### PR TITLE
Update rule rating success color to align with ansible check

### DIFF
--- a/src/PresentationalComponents/RuleRating/_RuleRating.scss
+++ b/src/PresentationalComponents/RuleRating/_RuleRating.scss
@@ -1,5 +1,5 @@
 .like {
-  color: var(--pf-global--success-color--200);
+  color: var(--pf-global--success-color--100);
 }
 
 .dislike {


### PR DESCRIPTION
similar to https://github.com/RedHatInsights/insights-advisor-frontend/pull/698/
#### looks like
<img width="995" alt="Screen Shot 2020-08-07 at 12 06 39 PM" src="https://user-images.githubusercontent.com/6640236/89665470-c1740b80-d8a6-11ea-989d-74bd39e0143e.png">
