### PR TITLE
Add boolean to check if Rule value is up-to-date

### DIFF
--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -46,6 +46,7 @@ const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchR
     const [host, setHost] = useState(undefined);
     const [viewSystemsModalOpen, setViewSystemsModalOpen] = useState(false);
     const [filters, setFilters] = useState({ sort: 'display_name' });
+    const [isRuleUpdated, setIsRuleUpdated] = useState(false);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const fetchRulefn = (newSort, rule = true, system = true) => {
@@ -131,14 +132,22 @@ const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchR
 
     const ref = useRef();
     useEffect(() => {
-        selectedTags !== null && JSON.stringify(ref.current) !== JSON.stringify(selectedTags) && fetchRulefn();
+        if (selectedTags !== null && JSON.stringify(ref.current) !== JSON.stringify(selectedTags)) {
+            fetchRulefn();
+            setIsRuleUpdated(true);
+        }
+
         ref.current = selectedTags;
     }, [fetchRulefn, selectedTags]);
 
     useEffect(() => {
-        if (!rule.reports_shown && rule.rule_id) {
+        if (!rule.reports_shown && rule.rule_id && isRuleUpdated) {
             fetchRuleAck({ rule_id: rule.rule_id });
+        } else if (!isRuleUpdated) {
+            fetchRulefn();
+            setIsRuleUpdated(true);
         }
+        //eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fetchRuleAck, rule.reports_shown, rule.rule_id]);
 
     return <React.Fragment>


### PR DESCRIPTION
This PR is in response to this 🎫  -> https://projects.engineering.redhat.com/browse/RHCLOUD-8490

We are seeing some errors pop up when we navigate to the Rec Details page after unacking a rule in the recommendations table. The source of the issue comes from us not updating the rule in the redux store after unacking the rule. So the value of `reports_shown` is not accurate to the state of the database, and we are getting a 404 from the `/ack` endpoint because of it 🕵️ 🔎 🤔 