### PR TITLE
Remove name from text-input in DisableRule modal

### DIFF
--- a/src/PresentationalComponents/Modals/DisableRule.js
+++ b/src/PresentationalComponents/Modals/DisableRule.js
@@ -54,16 +54,12 @@ const DisableRule = ({ handleModalToggle, intl, isModalOpen, host, hosts, rule, 
         handleModalToggle(false);
     };
 
-    const handleKeyPress = (event) => {
-        if (event.key === 'Enter') { disableRule(); }
-    };
-
     return <Modal
         variant='small'
         title={intl.formatMessage(messages.disableRule)}
         isOpen={isModalOpen}
         onClose={() => { handleModalToggle(false); setJustificaton(''); }}
-        onKeyPress={handleKeyPress}
+        onKeyPress={(e) => e.key === 'Enter' && disableRule()}
         actions={[
             <Button key="confirm" variant="primary" onClick={() => disableRule()}>
                 {intl.formatMessage(messages.save)}
@@ -90,10 +86,9 @@ const DisableRule = ({ handleModalToggle, intl, isModalOpen, host, hosts, rule, 
                 <TextInput
                     type="text"
                     id="disable-rule-justification"
-                    name="disable-rule-justification"
                     aria-describedby="disable-rule-justification"
                     value={justification}
-                    onChange={(text) => { setJustificaton(text); }}
+                    onChange={(text) => setJustificaton(text)}
                 />
             </FormGroup>
         </Form>


### PR DESCRIPTION
This fixes https://projects.engineering.redhat.com/browse/RHCLOUD-8513

Before:

<img width="1440" alt="Screen Shot 2020-08-10 at 4 55 46 PM" src="https://user-images.githubusercontent.com/4829473/89830896-f98b8080-db2a-11ea-9f34-fd4c78298213.png">

After:

<img width="1440" alt="Screen Shot 2020-08-10 at 4 56 23 PM" src="https://user-images.githubusercontent.com/4829473/89830912-fd1f0780-db2a-11ea-85d9-e9e143ee9a99.png">
