### PR TITLE
Add RemediationButton as dedicatedAction

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -2,7 +2,6 @@ import * as ReactRedux from 'react-redux';
 /* eslint-disable camelcase */
 import * as pfReactTable from '@patternfly/react-table';
 import * as reactRouterDom from 'react-router-dom';
-import { reactCore } from '@redhat-cloud-services/frontend-components-utilities/files/inventoryDependencies';
 
 import React, { useEffect, useRef, useState } from 'react';
 
@@ -16,6 +15,7 @@ import { getRegistry } from '@redhat-cloud-services/frontend-components-utilitie
 import global_BackgroundColor_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_100';
 import { injectIntl } from 'react-intl';
 import messages from '../../Messages';
+import { reactCore } from '@redhat-cloud-services/frontend-components-utilities/files/inventoryDependencies';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
 import { systemReducer } from '../../AppReducer';
 import { useStore } from 'react-redux';
@@ -139,16 +139,16 @@ const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification
             total={items.length}
             perPage={pageSize}
             tableProps={tableProps}
+            dedicatedAction={<RemediationButton
+                key='remediation-button'
+                isDisabled={selected.length === 0 || rule.playbook_count === 0}
+                dataProvider={remediationDataProvider}
+                onRemediationCreated={(result) => onRemediationCreated(result)}>
+                <AnsibeTowerIcon size='sm' color={global_BackgroundColor_100.value} />
+                &nbsp;{intl.formatMessage(messages.remediate)}
+            </RemediationButton>}
             actionsConfig={{
-                actions: [<RemediationButton
-                    key='remediation-button'
-                    isDisabled={selected.length === 0 || rule.playbook_count === 0}
-                    dataProvider={remediationDataProvider}
-                    onRemediationCreated={(result) => onRemediationCreated(result)}>
-                    <AnsibeTowerIcon size='sm' color={global_BackgroundColor_100.value} />
-                    &nbsp;{intl.formatMessage(messages.remediate)}
-                </RemediationButton>,
-                {
+                actions: ['', {
                     label: intl.formatMessage(messages.disableRuleForSystems),
                     props: { isDisabled: selected.length === 0 },
                     onClick: () => handleModalToggle(true)


### PR DESCRIPTION
This PR gives a fix for https://projects.engineering.redhat.com/browse/RHCLOUD-6054. This might not be the desired end fix, but it will make it so the wizard always mounts. It looks like vulnerability has a ticket out for this too.

Before:

<img width="597" alt="Screen Shot 2020-08-11 at 9 18 12 AM" src="https://user-images.githubusercontent.com/4829473/89901971-d953d400-dbb3-11ea-919a-c99f5866347f.png">

After:

<img width="597" alt="Screen Shot 2020-08-11 at 9 17 41 AM" src="https://user-images.githubusercontent.com/4829473/89901975-db1d9780-dbb3-11ea-8d0a-a7b6ba8b326a.png">