### PR TITLE
Update RuleDetails for compact mode

### DIFF
--- a/src/PresentationalComponents/RuleDetails/RuleDetails.js
+++ b/src/PresentationalComponents/RuleDetails/RuleDetails.js
@@ -39,7 +39,7 @@ const RuleDetails = ({ children, rule, resolutionRisk, intl, topics, header, isD
         <ReactMarkdown source={data} escapeHtml={false} />
     </span>;
 
-    return <Split hasGutter>
+    return <Split className='ins-c-rule-details__split' hasGutter>
         <SplitItem>
             <Stack hasGutter>
                 {header && <StackItem>

--- a/src/PresentationalComponents/RuleDetails/_RuleDetails.scss
+++ b/src/PresentationalComponents/RuleDetails/_RuleDetails.scss
@@ -3,6 +3,14 @@ hr {
   margin: var(--pf-global--spacer--md) 0 var(--pf-global--spacer--md) 0;
 }
 
+.ins-c-rule-details__split {
+  display: inline-flex;
+  justify-content: space-around;
+  .pf-l-split__item {
+    position: relative;
+  }
+}
+
 .ins-c-rule-details__stack {
   width: 600px;
 
@@ -61,5 +69,17 @@ hr {
   p {
     margin-top: 0;
     margin-bottom: var(--pf-global--spacer--md);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .ins-c-center-text {
+    text-align: left !important;
+  }
+  .ins-c-rule-details__split {
+    display: block;
+    .pf-l-split__item {
+      margin: var(--pf-global--spacer--md);
+    }
   }
 }

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -185,6 +185,7 @@ const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchR
                         <Flex>
                             <FlexItem align={{ default: 'alignRight' }}>
                                 <Dropdown
+                                    className='ins-c-rec-details__actions_dropdown'
                                     onSelect={() => setActionsDropdownOpen(!actionsDropdownOpen)}
                                     position='right'
                                     toggle={<DropdownToggle

--- a/src/SmartComponents/Recs/Details.scss
+++ b/src/SmartComponents/Recs/Details.scss
@@ -1,3 +1,5 @@
+@import '~@redhat-cloud-services/frontend-components-utilities/files/Utilities/_all';
+
 .pageHeaderOverride {
   padding-bottom: 0px;
 }
@@ -16,4 +18,10 @@
 
 .categoryLabel {
   margin-left: var(--pf-global--spacer--md)
+}
+
+@media only screen and (max-width: 768px) {
+  .ins-c-rec-details__actions_dropdown {
+    @include rem('top', -55px);
+  }
 }


### PR DESCRIPTION
Fixes some of the styling for compact mode

Before:

<img width="586" alt="Screen Shot 2020-08-11 at 12 55 08 PM" src="https://user-images.githubusercontent.com/4829473/89928014-31e79900-dbd5-11ea-9424-c952517c7706.png">

<img width="586" alt="Screen Shot 2020-08-11 at 12 55 29 PM" src="https://user-images.githubusercontent.com/4829473/89928021-3318c600-dbd5-11ea-8280-cd65ec9426ab.png">

After:

<img width="589" alt="Screen Shot 2020-08-11 at 12 54 03 PM" src="https://user-images.githubusercontent.com/4829473/89928031-37dd7a00-dbd5-11ea-959c-a0a2086865c5.png">
<img width="586" alt="Screen Shot 2020-08-11 at 12 54 29 PM" src="https://user-images.githubusercontent.com/4829473/89928033-39a73d80-dbd5-11ea-9af7-d3dd2580ce47.png">
