### PR TITLE
Prepends 'Advisor' to all page titles/breadcrumbs

### DIFF
--- a/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
+++ b/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
@@ -7,7 +7,6 @@ import { Breadcrumb } from '@patternfly/react-core/dist/js/components/Breadcrumb
 import { BreadcrumbItem } from '@patternfly/react-core/dist/js/components/Breadcrumb/BreadcrumbItem';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { capitalize } from '../Common/Tables';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import messages from '../../Messages';
@@ -20,8 +19,8 @@ const Breadcrumbs = ({ current, fetchRule, match, ruleFetchStatus, rule, intl })
         const crumbs = [];
         const splitUrl = match.url.split('/');
 
-        // add recommendations base
-        crumbs.push({ title: capitalize(splitUrl[1]), navigate: `/${splitUrl[1]}` });
+        // add base
+        crumbs.push({ title: `${intl.formatMessage(messages.insightsHeader)} ${splitUrl[1]}`, navigate: `/${splitUrl[1]}` });
 
         // if applicable, add :id breadcrumb
         if (match.params.id !== undefined && match.params.inventoryId !== undefined) {

--- a/src/SmartComponents/Recs/List.js
+++ b/src/SmartComponents/Recs/List.js
@@ -18,7 +18,7 @@ const List = () => {
     return <React.Fragment>
         <Suspense fallback={<Loading />}> <TagsToolbar /> </Suspense>
         <PageHeader className='ins-c-recommendations-header'>
-            <PageHeaderTitle title={intl.formatMessage(messages.recommendations)} />
+            <PageHeaderTitle title={`${intl.formatMessage(messages.insightsHeader)} ${intl.formatMessage(messages.recommendations).toLowerCase()}`} />
             <DownloadExecReport />
         </PageHeader>
         <Main><Suspense fallback={<Loading />}><RulesTable /></Suspense></Main>

--- a/src/SmartComponents/Systems/List.js
+++ b/src/SmartComponents/Systems/List.js
@@ -15,7 +15,7 @@ const List = () => {
     return <React.Fragment>
         <Suspense fallback={<Loading />}><TagsToolbar /></Suspense>
         <PageHeader>
-            <PageHeaderTitle title={intl.formatMessage(messages.systems)} />
+            <PageHeaderTitle title={`${intl.formatMessage(messages.insightsHeader)} ${intl.formatMessage(messages.systems).toLowerCase()}`} />
         </PageHeader>
         <Main><Suspense fallback={<Loading />}><SystemsTable /></Suspense></Main>
     </React.Fragment>;

--- a/src/SmartComponents/Topics/List.js
+++ b/src/SmartComponents/Topics/List.js
@@ -23,7 +23,7 @@ const List = ({ fetchTopics, intl, selectedTags }) => {
     return <React.Fragment>
         <TagsToolbar />
         <PageHeader>
-            <PageHeaderTitle title={intl.formatMessage(messages.topics)} />
+            <PageHeaderTitle title={`${intl.formatMessage(messages.insightsHeader)} ${intl.formatMessage(messages.topics).toLowerCase()}`} />
         </PageHeader>
         <Main>
             <TopicsTable />


### PR DESCRIPTION
fixs https://projects.engineering.redhat.com/browse/RHCLOUD-8445

#### looks like teen spirit
<img width="1021" alt="Screen Shot 2020-08-18 at 8 45 02 AM" src="https://user-images.githubusercontent.com/6640236/90514665-7623ed80-e12f-11ea-8e02-eac2c49e46d7.png">
