### PR TITLE
fix(intl): Fix missing translation for "xx-XX" locale

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -7,7 +7,7 @@ import messages from './Messages';
 import { strong } from './Utilities/intlHelper';
 
 const cache = createIntlCache();
-const locale = navigator.language;
+const locale = navigator.language.slice(0, 2);
 const intl = createIntl({
     // eslint-disable-next-line no-console
     onError: console.log,

--- a/src/entry-dev.js
+++ b/src/entry-dev.js
@@ -12,7 +12,7 @@ import logger from 'redux-logger';
 import messages from '../locales/data.json';
 
 ReactDOM.render(
-    <IntlProvider locale={navigator.language} messages={messages} onError={console.log}>
+    <IntlProvider locale={navigator.language.slice(0, 2)} messages={messages} onError={console.log}>
         <Provider store={init(logger).getStore()}>
             <Router basename={getBaseName(window.location.pathname)}>
                 <React.Fragment>

--- a/src/entry.js
+++ b/src/entry.js
@@ -11,7 +11,7 @@ import { init } from './Store';
 import messages from '../locales/data.json';
 
 ReactDOM.render(
-    <IntlProvider locale={navigator.language} messages={messages} onError={console.log}>
+    <IntlProvider locale={navigator.language.slice(0, 2)} messages={messages} onError={console.log}>
         <Provider store={init().getStore()}>
             <Router basename={getBaseName(window.location.pathname)}>
                 <React.Fragment>


### PR DESCRIPTION
For the translations, we rely on the browser's language, which we can get from `navigator.language`  in JS.  
This returns a string code which is defined in `BCP 47`

This is the list of available locales 
```
ar-SA Arabic Saudi Arabia
cs-CZ Czech Czech Republic
da-DK Danish Denmark
de-DE German Germany
el-GR Modern Greek Greece
en-AU English Australia
en-GB English United Kingdom
en-IE English Ireland
en-US English United States
en-ZA English South Africa
es-ES Spanish Spain
es-MX Spanish Mexico
fi-FI Finnish Finland
fr-CA French Canada
fr-FR French France
he-IL Hebrew Israel
hi-IN Hindi India
hu-HU Hungarian Hungary
id-ID Indonesian Indonesia
it-IT Italian Italy
ja-JP Japanese Japan
ko-KR Korean Republic of Korea
nl-BE Dutch Belgium
nl-NL Dutch Netherlands
no-NO Norwegian Norway
pl-PL Polish Poland
pt-BR Portuguese Brazil
pt-PT Portuguese Portugal
ro-RO Romanian Romania
ru-RU Russian Russian Federation
sk-SK Slovak Slovakia
sv-SE Swedish Sweden
th-TH Thai Thailand
tr-TR Turkish Turkey
zh-CN Chinese China
zh-HK Chinese Hong Kong
zh-TW Chinese Taiwan

The English ones are:
en-AU English Australia
en-GB English United Kingdom
en-IE English Ireland
en-US English United States
en-ZA English South Africa
es-ES Spanish Spain
es-MX Spanish Mexico
```
 

For example, my browser's language is "en-US", as a result, it uses the default values and floods the console log with warnings messages. 
![Screenshot from 2020-08-25 11-36-14](https://user-images.githubusercontent.com/3369346/91160166-5b222200-e6c9-11ea-8720-9a81ff3a5bbc.png)


On top of that, there's a known issue on Chrome so we can't rely on "xx-XX" locale

https://bugs.chromium.org/p/chromium/issues/detail?id=802006&can=2&q=regional&colspec=ID%20Pri%20M%20Stars%20ReleaseBlock%20Component%20Status%20Owner%20Summary%20OS%20Modified

 

so my suggestion is to use `navigator.language.slice(0, 2) `  to get the general language (ex, fr, es, en, pl) 