### PR TITLE
Removes 'undefined' as reports_shown url param (when applicable)

### DIFF
--- a/src/PresentationalComponents/Common/Tables.js
+++ b/src/PresentationalComponents/Common/Tables.js
@@ -3,6 +3,10 @@ export const urlBuilder = (filters, selectedTags) => {
     const url = new URL(window.location);
     const queryString = `${Object.keys(filters).map(key => `${key}=${Array.isArray(filters[key]) ? filters[key].join() : filters[key]}`).join('&')}`;
     const params = new URLSearchParams(queryString);
+
+    //Removes invalid 'undefined' url param value
+    params.get('reports_shown') === 'undefined' && params.delete('reports_shown');
+
     selectedTags !== null && selectedTags.length ? params.set('tags', selectedTags.join()) : params.delete('tags');
     window.history.replaceState(null, null, `${url.origin}${url.pathname}?${params.toString()}`);
     return `?${queryString}`;


### PR DESCRIPTION
related to https://github.com/RedHatInsights/insights-advisor-api/pull/631

internally we need to track the undefined state, but visually, n as far as the url is concerned no need to broadcast this invalid url param

furthermore, if redirect to with the param attribute missing or undefined, will behave as expected (current state) will show all status of recs

#### looks like
<img width="1437" alt="Screen Shot 2020-08-31 at 11 34 53 AM" src="https://user-images.githubusercontent.com/6640236/91738409-67e9be80-eb7e-11ea-9fca-2d16cd185e1e.png">
<img width="1437" alt="Screen Shot 2020-08-31 at 11 34 43 AM" src="https://user-images.githubusercontent.com/6640236/91738410-67e9be80-eb7e-11ea-9239-8174b454dfb8.png">
