### PR TITLE
Update last-seen sorting

### DIFF
--- a/src/AppActions.js
+++ b/src/AppActions.js
@@ -38,7 +38,7 @@ export const fetchRule = (options, search) => ({
 });
 export const fetchSystem = (ruleId, options, search) => ({
     type: ActionTypes.SYSTEM_FETCH,
-    payload: fetchData(`${ActionTypes.RULES_FETCH_URL}${encodeURI(ruleId)}/systems`, {}, options, search && search)
+    payload: fetchData(`${ActionTypes.RULES_FETCH_URL}${encodeURI(ruleId)}/systems_detail`, {}, options, search && search)
 });
 export const setFilters = (filters) => ({
     type: ActionTypes.FILTERS_SET,

--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -24,7 +24,7 @@ import { useStore } from 'react-redux';
 let page = 1;
 let pageSize = 50;
 let rule_id = '';
-const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification, items, afterDisableFn, onSortFn, filters }) => {
+const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification, items, afterDisableFn, onSortFn, filters, count }) => {
     const inventory = useRef(null);
     const [InventoryTable, setInventoryTable] = useState();
     const [selected, setSelected] = useState([]);
@@ -35,7 +35,7 @@ const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification
 
     const sortIndices = {
         1: 'display_name',
-        2: 'updated'
+        2: 'last_seen'
     };
 
     const onSort = ({ index, direction }) => onSortFn(`${direction === 'asc' ? '' : '-'}${sortIndices[index]}`);
@@ -44,7 +44,7 @@ const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification
         const sortIndex = Number(Object.entries(sortIndices).find(item => item[1] === filters.sort || `-${item[1]}` === filters.sort)[0]);
         return {
             index: sortIndex,
-            key: sortIndex !== 2 ? sortIndices[sortIndex] : 'updated',
+            key: sortIndex !== 2 ? sortIndices[sortIndex] : 'last_seen',
             direction: filters.sort[0] === '-' ? 'desc' : 'asc'
         };
     };
@@ -110,7 +110,7 @@ const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification
                     systemReducer(
                         [
                             { title: intl.formatMessage(messages.name), transforms: [pfReactTable.sortable], key: 'display_name' },
-                            { title: intl.formatMessage(messages.lastSeen), transforms: [pfReactTable.sortable], key: 'updated' }
+                            { title: intl.formatMessage(messages.lastSeen), transforms: [pfReactTable.sortable], key: 'last_seen' }
                         ],
                         INVENTORY_ACTION_TYPES
                     )
@@ -132,12 +132,15 @@ const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification
         }
         {InventoryTable && <InventoryTable
             ref={inventory}
-            items={items}
+            items={items.map((system) => ({
+                id: system.system_uuid,
+                last_seen: system.last_seen
+            }))}
             sortBy={calculateSort()}
             onSort={onSort}
             onRefresh={onRefresh}
             page={page}
-            total={items.length}
+            total={count}
             perPage={pageSize}
             tableProps={tableProps}
             dedicatedAction={<RemediationButton
@@ -199,7 +202,8 @@ Inventory.propTypes = {
     addNotification: PropTypes.func,
     afterDisableFn: PropTypes.func,
     onSortFn: PropTypes.func,
-    filters: PropTypes.object
+    filters: PropTypes.object,
+    count: PropTypes.number
 };
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -136,7 +136,7 @@ const SystemsTable = ({ systemsFetchStatus, fetchSystems, systems, intl, filters
         const sortDirection = filters.sort[0] === '-' ? 'desc' : 'asc';
         return {
             index: sortIndex,
-            key: sortIndex !== 6 ? sortIndices[sortIndex] : 'updated',
+            key: sortIndex !== 6 ? sortIndices[sortIndex] : 'last_seen',
             direction: sortDirection
         };
     };
@@ -151,7 +151,7 @@ const SystemsTable = ({ systemsFetchStatus, fetchSystems, systems, intl, filters
             { title: intl.formatMessage(messages.important), transforms: [pfReactTable.sortable, pfReactTable.wrappable], key: 'important_hits' },
             { title: intl.formatMessage(messages.moderate), transforms: [pfReactTable.sortable, pfReactTable.wrappable], key: 'moderate_hits' },
             { title: intl.formatMessage(messages.low), transforms: [pfReactTable.sortable, pfReactTable.wrappable], key: 'low_hits' },
-            { title: intl.formatMessage(messages.lastSeen), transforms: [pfReactTable.sortable, pfReactTable.wrappable], key: 'updated' }];
+            { title: intl.formatMessage(messages.lastSeen), transforms: [pfReactTable.sortable, pfReactTable.wrappable], key: 'last_seen' }];
             const { inventoryConnector, mergeWithEntities, INVENTORY_ACTION_TYPES
             } = await insights.loadInventory({
                 ReactRedux,

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -46,7 +46,7 @@ const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchR
     const [disableRuleModalOpen, setDisableRuleModalOpen] = useState(false);
     const [host, setHost] = useState(undefined);
     const [viewSystemsModalOpen, setViewSystemsModalOpen] = useState(false);
-    const [filters, setFilters] = useState({ sort: '-updated' });
+    const [filters, setFilters] = useState({ sort: '-last_seen', limit: 50 });
     const [isRuleUpdated, setIsRuleUpdated] = useState(false);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -120,9 +120,9 @@ const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchR
     };
 
     const onSortFn = (sort) => {
-        setFilters({ sort });
-        sort === 'updated' && (sort = 'last_seen');
-        sort === '-updated' && (sort = '-last_seen');
+        setFilters({ ...filters, sort });
+        sort === 'last_seen' && (sort = 'last_seen');
+        sort === '-last_seen' && (sort = '-last_seen');
         fetchRulefn({ sort }, false);
     };
 
@@ -261,8 +261,8 @@ const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchR
                             {systemFetchStatus === 'fulfilled' &&
                                 <Inventory
                                     tableProps={{ canSelectAll: false, actionResolver }}
-                                    items={system.host_ids} rule={rule} afterDisableFn={afterDisableFn} filters={filters}
-                                    onSortFn={onSortFn} />}
+                                    items={system.data} rule={rule} afterDisableFn={afterDisableFn} filters={filters}
+                                    onSortFn={onSortFn} count={system.meta.count}/>}
                             {systemFetchStatus === 'pending' && (<Loading />)}
                         </React.Fragment>}
                         {systemFetchStatus === 'fulfilled' && !rule.reports_shown && <MessageState icon={BellSlashIcon}


### PR DESCRIPTION
This PR fixes https://projects.engineering.redhat.com/browse/RHCLOUD-8662

There are still a couple of things that need to be ironed out on this before we can get it in, but I wanted to get some general feedback before getting too far into the weeds on one particular path.

1. We need to wrap the incoming `last-seen` value in the `CullingInfo` component (Need to look into this more)
2. Currently above 50 systems for a given rule, this approach will break. I have switched from using `rule/<rule_id>/systems/` to using `rule/<rule_id>/systems_detail/` to get the `last-seen` information for each system. Unfortunately, where the former was not a paginated API, the latter does require `limit` and `offset` query parameters or else will default to `10` and `1`.
2.a. It is possible, although slow and _most likely_ a terrible idea, to use the `/systems/` endpoint to get each systems data...
2.b. It is not possible (to my current knowledge) to use a paginated API with the `InventoryTable`. It has pagination built into it. We can remove our calls to `onRefreshData` to use a custom pagination function, however, if the items being passed to the table change the pagination is reset to defaults.

I'm not exactly sure what the best approach is here given this information 🤷‍♂️ 🤔 ❓ 