### PR TITLE
Adds loading to rec details inventory table component

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -9,6 +9,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import AnsibeTowerIcon from '@patternfly/react-icons/dist/js/icons/ansibeTower-icon';
 import DisableRule from '../../PresentationalComponents/Modals/DisableRule';
+import Loading from '../Loading/Loading';
 import PropTypes from 'prop-types';
 import RemediationButton from '@redhat-cloud-services/frontend-components-remediations/RemediationButton';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
@@ -130,7 +131,7 @@ const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification
             afterFn={afterDisableFn}
             hosts={selected} />
         }
-        {InventoryTable && <InventoryTable
+        {InventoryTable ? <InventoryTable
             ref={inventory}
             items={items}
             sortBy={calculateSort()}
@@ -182,7 +183,7 @@ const Inventory = ({ tableProps, onSelectRows, rows, intl, rule, addNotification
                 checked: selected.length === items.length ? 1 : selected.length === pageSize ? null : 0,
                 onSelect: () => { selected.length > 0 ? onSelectRows(-1, false) : bulkSelectfn(); }
             }}
-        />}
+        /> : <Loading />}
     </React.Fragment>;
 };
 


### PR DESCRIPTION
instead of gray screen of wtf while we're loading the inv sys table component, throw a loading screen that will then be replaced with the table once it loads (n then it has to load stuff as well, but hey no more gray screen of wtf)
#### looks like
<img width="1137" alt="Screen Shot 2020-09-03 at 5 03 27 PM" src="https://user-images.githubusercontent.com/6640236/92166957-8c0c0080-ee07-11ea-8803-2879af32307f.png">
