### PR TITLE
Set flex value for Recs header

### DIFF
--- a/src/SmartComponents/Recs/List.scss
+++ b/src/SmartComponents/Recs/List.scss
@@ -1,5 +1,6 @@
 .ins-c-recommendations-header {
     display: inline-flex;
+    flex: 1 0 auto;
     justify-content: space-between;
     .pf-c-button {
         line-height: var(--pf-global--LineHeight--sm);


### PR DESCRIPTION
This PR addresses https://projects.engineering.redhat.com/browse/RHCLOUD-8707

**Before:**
<img width="1440" alt="Screen Shot 2020-09-09 at 2 52 36 PM" src="https://user-images.githubusercontent.com/4829473/92641020-235fd080-f2ac-11ea-893b-674d83046be2.png">

**After:**

1. Safari
<img width="1440" alt="Screen Shot 2020-09-09 at 2 43 38 PM" src="https://user-images.githubusercontent.com/4829473/92641084-383c6400-f2ac-11ea-9472-6dae211762fe.png">

2. Chrome
<img width="1440" alt="Screen Shot 2020-09-09 at 2 44 18 PM" src="https://user-images.githubusercontent.com/4829473/92641080-370b3700-f2ac-11ea-8d40-f2d600474076.png">

3. Firefox
<img width="1440" alt="Screen Shot 2020-09-09 at 2 43 22 PM" src="https://user-images.githubusercontent.com/4829473/92641041-2ce93880-f2ac-11ea-98a0-ab538bcc21d4.png">