### PR TITLE
Keep Rec Header size consistent

### DIFF
--- a/src/SmartComponents/Recs/List.scss
+++ b/src/SmartComponents/Recs/List.scss
@@ -1,7 +1,9 @@
 .ins-c-recommendations-header {
-    display: inline-flex;
-    flex: 1 0 auto;
-    justify-content: space-between;
+    white-space: nowrap;
+    width: auto;
+    > * {
+        display:inline-block;
+    }
     .pf-c-button {
         line-height: var(--pf-global--LineHeight--sm);
     }


### PR DESCRIPTION
This PR reverts #749 in order to keep the Rec Header size consistent when users enter text into the search field. 

Addresses 🎫  -> https://projects.engineering.redhat.com/browse/RHCLOUD-9063

Before:
<img width="1440" alt="Screen Shot 2020-09-09 at 8 32 32 PM" src="https://user-images.githubusercontent.com/4829473/92668029-a5b3b900-f2db-11ea-9ef3-bd42ffa5a75c.png">

After:
<img width="1440" alt="Screen Shot 2020-09-09 at 8 33 50 PM" src="https://user-images.githubusercontent.com/4829473/92668091-cc71ef80-f2db-11ea-8ea7-9aa990891ff8.png">
