### PR TITLE
Only display Red Hat disabled rules alert if there are said rules

### DIFF
--- a/src/SmartComponents/Recs/List.js
+++ b/src/SmartComponents/Recs/List.js
@@ -1,8 +1,9 @@
 import './List.scss';
 
 import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components/components/PageHeader';
-import React, { Suspense, lazy, useState } from 'react';
+import React, { Suspense, lazy, useState, useEffect } from 'react';
 
+import API from '../../Utilities/Api';
 import { Alert } from '@patternfly/react-core/dist/esm/components/Alert/Alert';
 import { AlertActionCloseButton } from '@patternfly/react-core/dist/esm/components/Alert/AlertActionCloseButton';
 import DownloadExecReport from '../../PresentationalComponents/ExecutiveReport/Download';
@@ -10,7 +11,7 @@ import Loading from '../../PresentationalComponents/Loading/Loading';
 import { Main } from '@redhat-cloud-services/frontend-components/components/Main';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
-import { isGlobalFilter } from '../../AppConstants';
+import { isGlobalFilter, RULES_FETCH_URL } from '../../AppConstants';
 
 const RulesTable = lazy(() => import(/* webpackChunkName: "RulesTable" */ '../../PresentationalComponents/RulesTable/RulesTable'));
 const TagsToolbar = lazy(() => import(/* webpackChunkName: "TagsToolbar" */ '../../PresentationalComponents/TagsToolbar/TagsToolbar'));
@@ -20,13 +21,25 @@ let AdvisorRedHatDisabledRuleAlert = sessionStorage.getItem('AdvisorRedHatDisabl
 const List = () => {
     const intl = useIntl();
     const [redhatDisabledRuleAlert, setRedHatDisabledRuleAlert] = useState(AdvisorRedHatDisabledRuleAlert);
+    const [redHatDisabledRuleCount, setRedHatDisabledRuleCount] = useState(0);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const response = (await API.get(`${RULES_FETCH_URL}?rule_status=rhdisabled`)).data;
+                setRedHatDisabledRuleCount(response.meta.count);
+            } catch (error) {
+                setRedHatDisabledRuleCount(0);
+            }
+        })();
+    }, []);
 
     return <React.Fragment>
         {!isGlobalFilter() && <Suspense fallback={<Loading />}> <TagsToolbar /> </Suspense>}
         <PageHeader className='ins-c-recommendations-header'>
             <PageHeaderTitle title={`${intl.formatMessage(messages.insightsHeader)} ${intl.formatMessage(messages.recommendations).toLowerCase()}`} />
             <DownloadExecReport />
-            {redhatDisabledRuleAlert &&
+            {redhatDisabledRuleAlert && redHatDisabledRuleCount &&
                 <Alert
                     className='alertOverride'
                     variant="warning"


### PR DESCRIPTION
Does it make sense to announce about Red Hat Disabled rules if there aren't any rules just yet?  At the moment I don't believe we have any Red Hat disabled rules and not sure when that'll start happening.  So (to me at least) it seems better to make the alert conditional until we have such rules and the customer can be made aware of them then.