### PR TITLE
Filter out non-filterTypes from chips 

### DIFF
--- a/src/PresentationalComponents/Common/Tables.js
+++ b/src/PresentationalComponents/Common/Tables.js
@@ -42,7 +42,7 @@ export const capitalize = (string) => string[0].toUpperCase() + string.substring
 
 export const pruneFilters = (localFilters, filterCategories) => {
     const prunedFilters = Object.entries(localFilters);
-    return prunedFilters.length > 0 ? prunedFilters.map(item => {
+    return prunedFilters.length > 0 ? prunedFilters.reduce((arr, item) => {
         if (filterCategories[item[0]]) {
             const category = filterCategories[item[0]];
             const chips = Array.isArray(item[1]) ? item[1].map(value => {
@@ -50,12 +50,11 @@ export const pruneFilters = (localFilters, filterCategories) => {
                 return selectedCategoryValue ? { name: selectedCategoryValue.text || selectedCategoryValue.label, value } : { name: value, value };
             })
                 : [{ name: category.values.find(values => values.value === String(item[1])).label, value: item[1] }];
-            return { category: capitalize(category.title), chips, urlParam: category.urlParam };
-        } else {
-            return { category: 'Name', chips: [{ name: item[1], value: item[1] }], urlParam: item[0] };
-        }
-    })
-        : [];
+            return [...arr, { category: capitalize(category.title), chips, urlParam: category.urlParam }];
+        } else if (item[0] === 'text') {
+            return [...arr, { category: 'Name', chips: [{ name: item[1], value: item[1] }], urlParam: item[0] }];
+        } else { return arr; }
+    }, []) : [];
 };
 
 const workloadsMap = { SAP: 'sap_system' };


### PR DESCRIPTION
This PR fixes https://issues.redhat.com/browse/ADVISOR-1387

Right now we get an extra `Name` filter chip when `reports_shown` is found in the URL.
https://cloud.redhat.com/insights/advisor/recommendations?impacting=true&sort=-total_risk&limit=10&offset=0&total_risk=3&reports_shown=true

**Before:**
<img width="1440" alt="Screen Shot 2020-10-02 at 10 21 13 AM" src="https://user-images.githubusercontent.com/4829473/94933972-1b551400-0499-11eb-9a7c-1b4909d6f744.png">

**After:**
<img width="1440" alt="Screen Shot 2020-10-02 at 10 21 27 AM" src="https://user-images.githubusercontent.com/4829473/94933985-1ee89b00-0499-11eb-80d2-d9416ebffb4a.png">