### PR TITLE
Update onKeyPress for DisableRule Modal

### DIFF
--- a/src/PresentationalComponents/Modals/DisableRule.js
+++ b/src/PresentationalComponents/Modals/DisableRule.js
@@ -64,7 +64,6 @@ const DisableRule = ({ handleModalToggle, intl, isModalOpen, host, hosts, rule, 
         title={intl.formatMessage(messages.disableRule)}
         isOpen={isModalOpen}
         onClose={() => { handleModalToggle(false); setJustificaton(''); }}
-        onKeyPress={(e) => e.key === 'Enter' && disableRule()}
         actions={[
             <Button key="confirm" variant="primary" onClick={() => disableRule()}>
                 {intl.formatMessage(messages.save)}
@@ -94,6 +93,7 @@ const DisableRule = ({ handleModalToggle, intl, isModalOpen, host, hosts, rule, 
                     aria-describedby="disable-rule-justification"
                     value={justification}
                     onChange={(text) => setJustificaton(text)}
+                    onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), disableRule())}
                 />
             </FormGroup>
         </Form>


### PR DESCRIPTION
This PR should fix a minor bug involving the `onKeyPress` prop. Currently, if a user presses enter with the DisableRule Modal open, the page reloads. The changes in this PR sets the `onKeyDown` prop on the `TextInput` component instead of on the Modal, and prevents the default event (the page reload) on Enter. This stops the page from being reloaded and acts the same as pressing the `Save` button on the modal.