### PR TITLE
Fix styling of autoacks alert on small screen sizes

### DIFF
--- a/src/PresentationalComponents/ExecutiveReport/_Download.scss
+++ b/src/PresentationalComponents/ExecutiveReport/_Download.scss
@@ -5,4 +5,8 @@
 
 .downloadButtonOverride {
     float: right;
+    @media only screen and (max-width: 585px) {
+        float: none;
+        padding-left: 0px;
+    }
 }

--- a/src/SmartComponents/Recs/List.scss
+++ b/src/SmartComponents/Recs/List.scss
@@ -1,5 +1,4 @@
 .ins-c-recommendations-header {
-    white-space: nowrap;
     width: auto;
     .pf-c-title {
         display:inline-block;
@@ -10,5 +9,13 @@
     .alertOverride {
         font-size: var(--pf-global--FontSize--md);
         margin-top: var(--pf-global--spacer--lg);
+    }
+    @media only screen and (max-width: 585px) {
+        .pf-c-title {
+            display: block;
+        }
+        .alertOverride {
+            margin-top: var(--pf-global--spacer--sm);
+        }
     }
 }


### PR DESCRIPTION
Noticed the styling of the Autoack alert was mangled on smaller screen sizes.  This PR tries to make it purty(er).  Please LMK if there is a better / more-patternfly-ish way of doing this.

Before style fix:
![before](https://user-images.githubusercontent.com/4008744/96405201-14136180-1220-11eb-8729-ed32afed14f9.png)

After style fix:
![after](https://user-images.githubusercontent.com/4008744/96405237-29888b80-1220-11eb-8a94-dfe32837dbe3.png)

At the breakpoint of style fix:
![at_breakpoint](https://user-images.githubusercontent.com/4008744/96405264-36a57a80-1220-11eb-916f-d79270a8b157.png)
