### PR TITLE
Add Redirect component for Classic ids

### DIFF
--- a/locales/translations.json
+++ b/locales/translations.json
@@ -52,6 +52,7 @@
   "incidentTooltip": "Indicates configurations that are currently affecting your systems",
   "insightsHeader": "Advisor",
   "installClient": "Install the client on the RHEL system.",
+  "inventoryIdNotFound": "No system found in inventory for the given Advisor ID",
   "is": "is",
   "is not": "is not",
   "justificationNote": "Justification note",

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -979,5 +979,10 @@ export default defineMessages({
         id: 'redhatDisabledRuleAlertTitle',
         description: 'Red Hat disabled rule alert title',
         defaultMessage: 'Red Hat has proactively disabled certain low risk recommendations'
+    },
+    inventoryIdNotFound: {
+        id: 'inventoryIdNotFound',
+        description: 'Thrown as error when classic id does not correspond to an inventory id',
+        defaultMessage: 'No system found in inventory for the given Advisor ID'
     }
 });

--- a/src/SmartComponents/Recs/ClassicRedirect.js
+++ b/src/SmartComponents/Recs/ClassicRedirect.js
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+
+import Api from '../../Utilities/Api';
+import Loading from '../../PresentationalComponents/Loading/Loading';
+import MessageState from '../../PresentationalComponents/MessageState/MessageState';
+import { Redirect } from 'react-router-dom';
+import TimesCircleIcon from '@patternfly/react-icons/dist/js/icons/times-circle-icon';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
+import messages from '../../Messages';
+import { useDispatch } from 'react-redux';
+import { useIntl } from 'react-intl';
+
+const ClassicRedirect = () => {
+    const [fetchStatus, setFetchStatus] = useState('pending');
+    const [inventoryId, setInventoryId] = useState();
+    const intl = useIntl();
+    const dispatch = useDispatch();
+    const pathname = window.location.pathname.split('/');
+    const id = pathname?.[5];
+    const classicId = pathname?.[6];
+
+    useEffect(() => {
+        (async () => {
+            try {
+                setInventoryId((await Api.get(`/api/inventory/v1/hosts?insights_id=${classicId}`)).data.results[0].id);
+                setFetchStatus('fulfilled');
+            } catch (error) {
+                dispatch(addNotification({
+                    variant: 'danger', dismissable: true, title: intl.formatMessage(messages.error), description: `${error}` }));
+                setFetchStatus('rejected');
+            }
+        })();
+    }, [setInventoryId, setFetchStatus, classicId, intl, dispatch]);
+
+    return <React.Fragment>
+        {fetchStatus === 'pending' && <Loading/>}
+        {fetchStatus === 'fulfilled' && <Redirect to={`/recommendations/${id}/${inventoryId}/`}/>}
+        {fetchStatus === 'rejected' && <MessageState
+            icon={TimesCircleIcon} title={intl.formatMessage(messages.inventoryIdNotFound)}/>}
+    </React.Fragment>;
+};
+
+export default ClassicRedirect;

--- a/src/SmartComponents/Recs/Recs.js
+++ b/src/SmartComponents/Recs/Recs.js
@@ -7,12 +7,14 @@ const List = asyncComponent(() => import(/* webpackChunkName: "List" */ './List'
 const Details = asyncComponent(() => import(/* webpackChunkName: "Details" */ './Details'));
 const InventoryDetails = asyncComponent(() =>
     import(/* webpackChunkName: "InventoryDetails" */ '../../PresentationalComponents/Inventory/InventoryDetails'));
+const ClassicRedirect = asyncComponent(() => import(/* webpackChunkName: "ClassicRedirect" */ './ClassicRedirect'));
 
 const Recs = () => <React.Fragment>
     <Switch>
         <Route exact path='/recommendations' component={List} />
         <Route exact path='/recommendations/by_id/:id' component={List} />
         <Route exact path='/recommendations/:id' component={Details} />
+        <Route path='/recommendations/classic/:id/:classicId/' component={ClassicRedirect}/>
         <Route path='/recommendations/by_id/:id/:inventoryId/' component={InventoryDetails} />
         <Route path='/recommendations/:id/:inventoryId/' component={InventoryDetails} />
         <Redirect path='*' to='/recommendations' push />


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/ADVISOR-1403 by creating a component which handles the api request for the inventory id corresponding to the given classic id and redirects to `InventoryDetails`.

When redirect fails:

<img width="1440" alt="Screen Shot 2020-10-20 at 8 13 47 AM" src="https://user-images.githubusercontent.com/4829473/96584506-51bdcc00-12ac-11eb-8b81-2cf2c1301720.png">

