### PR TITLE
Properly persist clearing the Red Hat disabled rule alert

### DIFF
--- a/src/SmartComponents/Recs/List.js
+++ b/src/SmartComponents/Recs/List.js
@@ -16,10 +16,9 @@ import { useIntl } from 'react-intl';
 const RulesTable = lazy(() => import(/* webpackChunkName: "RulesTable" */ '../../PresentationalComponents/RulesTable/RulesTable'));
 const TagsToolbar = lazy(() => import(/* webpackChunkName: "TagsToolbar" */ '../../PresentationalComponents/TagsToolbar/TagsToolbar'));
 
-let AdvisorRedHatDisabledRuleAlert = sessionStorage.getItem('AdvisorRedHatDisabledRuleAlert') || true;
-
 const List = () => {
     const intl = useIntl();
+    const AdvisorRedHatDisabledRuleAlert = JSON.parse(sessionStorage.getItem('AdvisorRedHatDisabledRuleAlert') || 'true');
     const [redhatDisabledRuleAlert, setRedHatDisabledRuleAlert] = useState(AdvisorRedHatDisabledRuleAlert);
     const [redHatDisabledRuleCount, setRedHatDisabledRuleCount] = useState(0);
 


### PR DESCRIPTION
Actually works this time.   Whodathunk 'false' === true !?!  Programming101 fail for Mark :facepalm: 

But anyway, should I use localStorage instead of sessionStorage though?  Then the alert will never be back :terminator: