### PR TITLE
Update ClassicRedirect for urls with beta

### DIFF
--- a/src/SmartComponents/Recs/ClassicRedirect.js
+++ b/src/SmartComponents/Recs/ClassicRedirect.js
@@ -16,8 +16,9 @@ const ClassicRedirect = () => {
     const intl = useIntl();
     const dispatch = useDispatch();
     const pathname = window.location.pathname.split('/');
-    const id = pathname?.[5];
-    const classicId = pathname?.[6];
+    const starting_index = pathname.some(val => val === 'beta') ? 6 : 5;
+    const id = pathname?.[starting_index];
+    const classicId = pathname?.[starting_index + 1];
 
     useEffect(() => {
         (async () => {


### PR DESCRIPTION
I noticed a bug with the classic redirect when in the beta environments. I hardcoded the indices we are using to determine the `id` and `classicId` values, and they become set to the wrong values, because the indices I used do not account for `/beta`

For URL: https://cloud.redhat.com/beta/insights/advisor/recommendations/classic/decreased_vm_network_performance%7CVHOST_NET_KERNEL_MODULE_NOT_LOADED/1ffb3a80-8290-4b2f-ba9d-9e6422604fd6
<img width="1440" alt="Screen Shot 2020-10-20 at 9 25 02 AM" src="https://user-images.githubusercontent.com/4829473/96592326-47083480-12b6-11eb-9cd0-410d5ca3a523.png">
