### PR TITLE
Update ClassicRedirect to consume systems/classic

### DIFF
--- a/locales/translations.json
+++ b/locales/translations.json
@@ -49,6 +49,7 @@
   "incidentTooltip": "Indicates configurations that are currently affecting your systems",
   "insightsHeader": "Advisor",
   "installClient": "Install the client on the RHEL system.",
+  "invalidPathname": "Invalid pathname",
   "inventoryIdNotFound": "No system found in inventory for the given Advisor ID",
   "is": "is",
   "is not": "is not",

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -939,5 +939,10 @@ export default defineMessages({
         id: 'inventoryIdNotFound',
         description: 'Thrown as error when classic id does not correspond to an inventory id',
         defaultMessage: 'No system found in inventory for the given Advisor ID'
+    },
+    invalidPathname: {
+        id: 'invalidPathname',
+        description: 'Message thrown when classic redirect receives invalid path',
+        defaultMessage: 'Invalid pathname'
     }
 });

--- a/src/SmartComponents/Recs/Recs.js
+++ b/src/SmartComponents/Recs/Recs.js
@@ -7,14 +7,14 @@ const List = asyncComponent(() => import(/* webpackChunkName: "List" */ './List'
 const Details = asyncComponent(() => import(/* webpackChunkName: "Details" */ './Details'));
 const InventoryDetails = asyncComponent(() =>
     import(/* webpackChunkName: "InventoryDetails" */ '../../PresentationalComponents/Inventory/InventoryDetails'));
-const ClassicRedirect = asyncComponent(() => import(/* webpackChunkName: "ClassicRedirect" */ './ClassicRedirect'));
+const ClassicRedirect = asyncComponent(() => import(/* webpackChunkName: "ClassicRedirect" */ '../Common/ClassicRedirect'));
 
 const Recs = () => <React.Fragment>
     <Switch>
         <Route exact path='/recommendations' component={List} />
         <Route exact path='/recommendations/by_id/:id' component={List} />
         <Route exact path='/recommendations/:id' component={Details} />
-        <Route path='/recommendations/classic/:id/:classicId/' component={ClassicRedirect}/>
+        <Route exact path='/recommendations/classic/:id/:classicId/' component={ClassicRedirect}/>
         <Route path='/recommendations/by_id/:id/:inventoryId/' component={InventoryDetails} />
         <Route path='/recommendations/:id/:inventoryId/' component={InventoryDetails} />
         <Redirect path='*' to='/recommendations' push />

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -6,11 +6,13 @@ import asyncComponent from '../../Utilities/asyncComponent';
 const List = asyncComponent(() => import(/* webpackChunkName: "List" */ './List'));
 const Details = asyncComponent(() =>
     import(/* webpackChunkName: "InventoryDetails" */ '../../PresentationalComponents/Inventory/InventoryDetails'));
+const ClassicRedirect = asyncComponent(() => import(/* webpackChunkName: "ClassicRedirect" */ '../Common/ClassicRedirect'));
 
 const Systems = () => <React.Fragment>
     <Switch>
         <Route exact path='/systems' component={List} />
         <Route exact path='/systems/:inventoryId/' component={Details} />
+        <Route exact path='/systems/classic/:classicId' component={ClassicRedirect} />
         <Redirect path='*' to='/systems' push />
     </Switch>
 </React.Fragment>;


### PR DESCRIPTION
This PR adds additional functionality to the `ClassicRedirect` component. Using a switch statement we can now handle both `recommendations/classic` and `systems/classic`.

Resolves: https://issues.redhat.com/browse/ADVISOR-1455