### PR TITLE
Use consistent page titles across Insights - add subapp name to page titles

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -2,6 +2,11 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
+    documentTitle: {
+        id: 'documentTitle',
+        description: 'The title of the page as it appears in the browser tab',
+        defaultMessage: '{subnav} - Advisor | Red Hat Insights'
+    },
     rules: {
         id: 'rules',
         description: 'Used as a title',

--- a/src/PresentationalComponents/Inventory/InventoryDetails.js
+++ b/src/PresentationalComponents/Inventory/InventoryDetails.js
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import '@redhat-cloud-services/frontend-components-inventory-insights/index.css';
 
 import * as pfReactTable from '@patternfly/react-table';
@@ -17,8 +18,11 @@ import { entitiesDetailsReducer } from '../../AppReducer';
 import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/files/Registry';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
 import { useStore } from 'react-redux';
+import messages from '../../Messages';
+import { useIntl } from 'react-intl';
 
 const InventoryDetails = ({ entity, match }) => {
+    const intl = useIntl();
     const [InventoryDetail, setInventoryDetail] = useState();
     const [AppInfo, setAppInfo] = useState();
     const [InvWrapper, setInvWrapper] = useState();
@@ -42,9 +46,15 @@ const InventoryDetails = ({ entity, match }) => {
         setInvWrapper(() => DetailWrapper);
     };
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     useEffect(() => { fetchInventoryDetails(); }, []);
     const Wrapper = InvWrapper || React.Fragment;
+
+    useEffect(() => {
+        if (entity && (entity.display_name || entity.id)) {
+            const subnav = `${entity.display_name || entity.id} - ${messages.systems.defaultMessage}`;
+            document.title = intl.formatMessage(messages.documentTitle, { subnav });
+        }
+    }, [entity]);
 
     return <Wrapper>
         <PageHeader className="pf-m-light ins-inventory-detail">

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -168,6 +168,14 @@ const OverviewDetails = ({ match, fetchRuleAck, fetchTopics, fetchSystem, fetchR
         //eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fetchRuleAck, rule.rule_status, rule.rule_id]);
 
+    useEffect(() => {
+        if (rule && rule.description) {
+            const subnav = `${rule.description} - ${messages.recommendations.defaultMessage}`;
+            document.title = intl.formatMessage(messages.documentTitle, { subnav });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [rule]);
+
     return <React.Fragment>
         {viewSystemsModalOpen && <ViewHostAcks
             handleModalToggle={(toggleModal) => setViewSystemsModalOpen(toggleModal)}

--- a/src/SmartComponents/Recs/List.js
+++ b/src/SmartComponents/Recs/List.js
@@ -21,6 +21,8 @@ const List = () => {
     const [redhatDisabledRuleAlert, setRedHatDisabledRuleAlert] = useState(AdvisorRedHatDisabledRuleAlert);
     const [redHatDisabledRuleCount, setRedHatDisabledRuleCount] = useState(0);
 
+    document.title = intl.formatMessage(messages.documentTitle, { subnav: messages.recommendations.defaultMessage });
+
     useEffect(() => {
         (async () => {
             try {

--- a/src/SmartComponents/Systems/List.js
+++ b/src/SmartComponents/Systems/List.js
@@ -11,6 +11,8 @@ const SystemsTable = lazy(() => import(/* webpackChunkName: "SystemsTable" */ '.
 const List = () => {
     const intl = useIntl();
 
+    document.title = intl.formatMessage(messages.documentTitle, { subnav: messages.systems.defaultMessage });
+
     return <React.Fragment>
         <PageHeader>
             <PageHeaderTitle title={`${intl.formatMessage(messages.insightsHeader)} ${intl.formatMessage(messages.systems).toLowerCase()}`} />

--- a/src/SmartComponents/Topics/Details.js
+++ b/src/SmartComponents/Topics/Details.js
@@ -37,6 +37,14 @@ const Details = ({ match, fetchTopic, setFilters, topic, topicFetchStatus, intl,
         };
     }, [fetchTopic, match.params.id, setFilters]);
 
+    useEffect(() => {
+        if (topic && topic.name) {
+            const subnav = `${topic.name} - ${messages.topics.defaultMessage}`;
+            document.title = intl.formatMessage(messages.documentTitle, { subnav });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [topic]);
+
     return <React.Fragment>
         <PageHeader>
             <Breadcrumbs

--- a/src/SmartComponents/Topics/List.js
+++ b/src/SmartComponents/Topics/List.js
@@ -13,6 +13,8 @@ import routerParams from '@redhat-cloud-services/frontend-components-utilities/f
 import { workloadQueryBuilder } from '../../PresentationalComponents/Common/Tables';
 
 const List = ({ fetchTopics, intl, selectedTags, workloads, SID }) => {
+    document.title = intl.formatMessage(messages.documentTitle, { subnav: messages.topics.defaultMessage });
+
     useEffect(() => {
         let options = selectedTags !== null && selectedTags.length && ({ tags: selectedTags });
         workloads && (options = { ...options, ...workloadQueryBuilder(workloads, SID) });

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
     <head>
         <meta charset="UTF-8">
-    <title>Red Hat Advisor</title>
+    <title>Advisor | Red Hat Insights</title>
         <esi:include src="/@@env/chrome/snippets/head.html"/>
     </head>
     <body>


### PR DESCRIPTION
Not sure if this is the right/react way of doing this.  Feedback is most welcome.

Old issue: https://issues.redhat.com/browse/ADVISOR-608
Mocks: https://marvelapp.com/prototype/e5gcj47/screen/71812909

Screenshots of changes:
![recommendations_title](https://user-images.githubusercontent.com/4008744/98317284-f0c22200-2027-11eb-90b8-98e0de6a42d8.png)
![systems_title](https://user-images.githubusercontent.com/4008744/98317306-f881c680-2027-11eb-9782-f6127561f520.png)
![topics_title](https://user-images.githubusercontent.com/4008744/98317321-fe77a780-2027-11eb-9815-f33181a708b2.png)


