### PR TITLE
Remove Red Hat from insights

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
     <head>
         <meta charset="UTF-8">
-    <title>Advisor | Red Hat Insights</title>
+    <title>Advisor | Insights</title>
         <esi:include src="/@@env/chrome/snippets/head.html"/>
     </head>
     <body>


### PR DESCRIPTION
### Remove Red Hat from insights

Since the branding has changed slightly we want to remove the words `Red Hat` from browser title as well.