### PR TITLE
Make sure impacting is true when rule_status is enabled

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -101,7 +101,7 @@ const RulesTable = ({ rules, filters, rulesFetchStatus, setFilters, fetchRules, 
     };
 
     const toggleRulesDisabled = (rule_status) => {
-        setFilters({ ...filters, rule_status, offset: 0, ...(rule_status !== 'enabled' && { impacting: false }) });
+        setFilters({ ...filters, rule_status, offset: 0, ...(rule_status !== 'enabled' && { impacting: false } || { impacting: true }) });
     };
 
     const handleOnCollapse = (event, rowId, isOpen) => {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ADVISOR-1532 ... I think.

Was able to reproduce issue.  Go to recommendations page and export data is enabled by default because rule_status = enabled and impacting is true.  Change rule status to disabled (or anything other than enabled) and export data is disabled ... all good so far.  But then change rule_status back to enabled and the export data button is still disabled.

Before patch:
![before](https://user-images.githubusercontent.com/4008744/103860234-17273b00-5107-11eb-949e-7546ab3fb78a.png)

After patch:
![after](https://user-images.githubusercontent.com/4008744/103860285-25755700-5107-11eb-905d-ce9ac604a9d4.png)
