### PR TITLE
[DO NOT MERGE] Async component example

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -4,7 +4,8 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPl
 const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
     rootFolder: resolve(__dirname, '../'),
-    debug: true
+    debug: true,
+    ...(process.env.BETA && { deployment: 'beta/apps' })
 });
 
 plugins.push(

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prod": "NODE_ENV=production webpack serve --config config/dev.webpack.config.js",
     "server:ctr": "node src/server/generateServerKey.js",
     "start": "NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
+    "start:beta": "NODE_ENV=development BETA=true webpack serve --config config/dev.webpack.config.js",
     "test": "jest --verbose --passWithNoTests",
     "translations": "npm-run-all translations:*",
     "translations:extract": "npx formatjs extract ./src/*.js --out-file ./build/messages/src/Messages.json",

--- a/profiles/local-frontend.js
+++ b/profiles/local-frontend.js
@@ -9,4 +9,9 @@ routes[`/beta/apps/${APP_ID}`] = { host: `http://${frontendHost}:8002` };
 routes[`/beta/${SECTION}/${APP_ID}`] = { host: `http://${frontendHost}:8002`  };
 routes[`/${SECTION}/${APP_ID}`] = { host: `http://${frontendHost}:8002`  };
 
+routes[`/apps/inventory`] = { host: `http://${frontendHost}:8003` };
+routes[`/beta/apps/inventory`] = { host: `http://${frontendHost}:8003` };
+routes[`/beta/${SECTION}/inventory`] = { host: `http://${frontendHost}:8003`  };
+routes[`/${SECTION}/inventory`] = { host: `http://${frontendHost}:8003`  };
+
 module.exports = { routes };

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -1,6 +1,7 @@
 import App from './App';
 import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations';
 import { NotificationsPortal } from '@redhat-cloud-services/frontend-components-notifications';
+import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 /* eslint-disable no-console */
@@ -16,6 +17,7 @@ const Widget = ({ useLogger }) => (
         <Provider store={(useLogger ? init(logger) : init()).getStore()}>
             <Router basename={getBaseName(window.location.pathname)}>
                 <React.Fragment>
+                    <AsyncComponent appName="inventory" module="./SampleSharedComponent" someProp="I am a prop send from advisor" />
                     <NotificationsPortal />
                     <App />
                 </React.Fragment>


### PR DESCRIPTION
This is an example PR of how to use `AsyncComponent` to use remote modules.

### Requirements
- install or update `@redhat-cloud-services/frontend-components` package
- use the `AsyncComponent`

```jsx
import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
...

<AsyncComponent appName="inventory" module="./SampleSharedComponent" someProp="I am a prop send from advisor" />
```

The `inventory./SampleSharedComponent` shared component is in this example: https://github.com/RedHatInsights/insights-inventory-frontend/pull/1096

![screenshot-ci foo redhat com_1337-2021 03 05-10_05_21](https://user-images.githubusercontent.com/22619452/110093729-5686a680-7d9b-11eb-900f-20cd611a1fe5.png)
