### PR TITLE
Reconfigures system un/ack to use filtered (tags workload) fetch 🍦

### DIFF
--- a/locales/translations.json
+++ b/locales/translations.json
@@ -1,4 +1,5 @@
 {
+  "actions": "Actions",
   "added": "Added",
   "affectedSystems": "Affected systems",
   "all": "All",
@@ -107,6 +108,8 @@
   "readless": "Read less",
   "readmore": "Read more",
   "recNumAndPercentage": "{count} ({total}% of total)",
+  "recSuccessfullyDisabled": "Recommendation successfully disabled",
+  "recSuccessfullyEnabled": "Recommendation successfully enabled",
   "recommendation": "Recommendation",
   "recommendations": "Recommendations",
   "recommended": "Recommended",
@@ -130,8 +133,6 @@
   "ruleIsDisabledForSystemsBody": "Recommendation is disabled for {systems, plural, one {# system} other {# systems}}",
   "ruleIsDisabledJustification": "This recommendation has been disabled for all systems for the following reason:",
   "ruleIsDisabledTooltip": "Indicates this recommendation across all systems will not be shown in reports and dashboards.",
-  "ruleSuccessfullyDisabled": "Recommendation successfully disabled",
-  "ruleSuccessfullyEnabled": "Recommendation successfully enabled",
   "rules": "Rules",
   "rulesdetails.publishdate": "Publish date: {date}",
   "rulesdetails.totalriskbody": "The total risk of this remediation is <strong>{risk}</strong>, based on the combination of likelihood and impact to remediate.",

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -104,13 +104,13 @@ export default defineMessages({
     description: 'Exclaiming that the recommendationis disabled',
     defaultMessage: 'Recommendation is disabled',
   },
-  ruleSuccessfullyDisabled: {
-    id: 'ruleSuccessfullyDisabled',
-    description: 'Explaining that the rule was disabled successfully',
+  recSuccessfullyDisabled: {
+    id: 'recSuccessfullyDisabled',
+    description: 'Explaining that the rec was disabled successfully',
     defaultMessage: 'Recommendation successfully disabled',
   },
-  ruleSuccessfullyEnabled: {
-    id: 'ruleSuccessfullyEnabled',
+  recSuccessfullyEnabled: {
+    id: 'recSuccessfullyEnabled',
     description: 'Explaining that the rule was enabled successfully',
     defaultMessage: 'Recommendation successfully enabled',
   },
@@ -1054,5 +1054,10 @@ export default defineMessages({
     id: 'yes',
     description: 'yes',
     defaultMessage: 'Yes',
+  },
+  actions: {
+    id: 'actions',
+    description: 'actions',
+    defaultMessage: 'Actions',
   },
 });

--- a/src/PresentationalComponents/Common/DownloadHelper.js
+++ b/src/PresentationalComponents/Common/DownloadHelper.js
@@ -23,17 +23,15 @@ const downloadHelper = async (
     let options = selectedTags.length && { tags: selectedTags };
     workloads &&
       (options = { ...options, ...workloadQueryBuilder(workloads, SID) });
-    const data = await Promise.all([
-      (
-        await API.get(
-          `${BASE_URL}/export/${exportTable}.${
-            format === 'json' ? 'json' : 'csv'
-          }`,
-          {},
-          { ...filters, ...options }
-        )
-      ).data,
-    ]);
+    const data = (
+      await API.get(
+        `${BASE_URL}/export/${exportTable}.${
+          format === 'json' ? 'json' : 'csv'
+        }`,
+        {},
+        { ...filters, ...options }
+      )
+    ).data;
     let formattedData = format === 'json' ? JSON.stringify(data) : data;
     downloadFile(formattedData, fileName(exportTable), format);
   } catch (error) {

--- a/src/PresentationalComponents/Export/SystemsPdf.js
+++ b/src/PresentationalComponents/Export/SystemsPdf.js
@@ -4,9 +4,9 @@ import React, { useMemo, useState } from 'react';
 import { leadPage, tablePage } from './SystemsPdfBuild';
 
 import API from '../../Utilities/Api';
+import { BASE_URL } from '../../AppConstants';
 import { DownloadButton } from '@redhat-cloud-services/frontend-components-pdf-generator';
 import PropTypes from 'prop-types';
-import { SYSTEMS_FETCH_URL } from '../../AppConstants';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
@@ -26,25 +26,23 @@ const SystemsPdf = ({ filters, systemsCount }) => {
     let options = selectedTags.length && { tags: selectedTags };
     workloads &&
       (options = { ...options, ...workloadQueryBuilder(workloads, SID) });
-    const [systems] = await Promise.all([
-      (
-        await API.get(
-          SYSTEMS_FETCH_URL,
-          {},
-          { ...filters, ...options, limit: systemsCount }
-        )
-      ).data,
-    ]);
+    const systems = (
+      await API.get(
+        `${BASE_URL}/export/systems/`,
+        {},
+        { ...filters, ...options, limit: systemsCount }
+      )
+    ).data;
     const firstPage = leadPage({
-      systemsTotal: systems.meta.count,
-      systems: systems.data.slice(0, 18),
+      systemsTotal: systems?.length,
+      systems: systems.slice(0, 18),
       filters,
       tags: selectedTags,
       intl,
     });
 
-    const otherPages = systems.data
-      .slice(18, systems.data.length)
+    const otherPages = systems
+      .slice(18, systems.length)
       .reduce((resultArray, item, index) => {
         const chunkIndex = Math.floor(index / 31);
         !resultArray[chunkIndex] && (resultArray[chunkIndex] = []);

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -201,7 +201,7 @@ const RulesTable = () => {
             variant: 'success',
             timeout: true,
             dismissable: true,
-            title: intl.formatMessage(messages.ruleSuccessfullyEnabled),
+            title: intl.formatMessage(messages.recSuccessfullyEnabled),
           });
           fetchRulesFn();
         } catch (error) {


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/ADVISOR-1705

kills the surprise list of systems that shows up after ack/unacking systems on the rec detail page

also reconfigures syspdf to use unpaginated endpoint, PDF EXPORT 100K SYSTEMS PEEEPS