### PR TITLE
Ensures no right margin on last filter chip item 🍩☠︎

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,21 +1,35 @@
 // Importing Global Variables
-@import '~@redhat-cloud-services/frontend-components-utilities/styles/variables';
+@import "~@redhat-cloud-services/frontend-components-utilities/styles/variables";
 
 // Temp nav styles
 ul.navigation-secondary {
-    margin-top: 20px;
-    li {
-      cursor: pointer;
-      font-size: 15px;
-      width: 100%;
-      box-shadow: none;
-      padding: 5px 0;
-      color: #1d1d1d;
-      span { margin-left: 50px; }
-      &:active, &.active{
-        background: #f5f5f5;
-        color: var(--pf-global--link--Color);
-      }
-      &:hover { color: var(--pf-global--link--Color); }
+  margin-top: 20px;
+  li {
+    cursor: pointer;
+    font-size: 15px;
+    width: 100%;
+    box-shadow: none;
+    padding: 5px 0;
+    color: #1d1d1d;
+    span {
+      margin-left: 50px;
+    }
+    &:active,
+    &.active {
+      background: #f5f5f5;
+      color: var(--pf-global--link--Color);
+    }
+    &:hover {
+      color: var(--pf-global--link--Color);
     }
   }
+}
+
+// Style overrides
+
+//https://issues.redhat.com/browse/ADVISOR-1618
+.ins-c-chip-filters {
+  div:last-of-type {
+    margin-right: 0px !important;
+  }
+}


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/ADVISOR-1618

also i know that sys-table text is incorrect, we already changed it samezies as the rec table, i might be that the inventory table doesn't accept the `deleteTitle` prop on the `activeFiltersConfig` ? 

![Screen Shot 2021-04-28 at 9 12 54 AM](https://user-images.githubusercontent.com/6640236/116409891-479ffb80-a802-11eb-80da-f19b7b3484a2.png)
![Screen Shot 2021-04-28 at 9 12 40 AM](https://user-images.githubusercontent.com/6640236/116409892-479ffb80-a802-11eb-8fe6-5b82c797ec02.png)
