### PR TITLE
Disable default columns in inventory table

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -144,6 +144,7 @@ const Inventory = ({
         />
       )}
       <InventoryTable
+        disableDefaultColumns
         ref={inventory}
         items={items}
         sortBy={calculateSort()}

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -249,6 +249,7 @@ const SystemsTable = () => {
 
   return systemsFetchStatus !== 'failed' ? (
     <InventoryTable
+      disableDefaultColumns
       tableProps={{ isStickyHeader: true }}
       ref={inventory}
       items={(


### PR DESCRIPTION
cc @AllenBW 

This ensures that nothing got broken when a new inventory is pushed in chrome.