### PR TITLE
RH disabled filter now shows n/a systems with info tooltip

### DIFF
--- a/locales/translations.json
+++ b/locales/translations.json
@@ -7,6 +7,7 @@
   "ansibleSupportNo": "No Ansible remediation support",
   "ansibleSupportYes": "Ansible remediation support",
   "availability": "Availability",
+  "byEnabling": "By enabling this recommendation, it will impact {systems, plural, one {# system} other {# systems}}.",
   "cancel": "Cancel",
   "category": "Category",
   "categoryHeader": "Recently identified recommendations by category",

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1074,4 +1074,10 @@ export default defineMessages({
     defaultMessage:
       ' - Due to browser limitations, showing the first 1000 systems',
   },
+  byEnabling: {
+    id: 'byEnabling',
+    description: 'By enabling this recommendation',
+    defaultMessage:
+      'By enabling this recommendation, it will impact {systems, plural, one {# system} other {# systems}}.',
+  },
 });

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -426,11 +426,20 @@ const RulesTable = () => {
                 ),
               },
               {
-                title: (
-                  <div
-                    key={key}
-                  >{`${value.impacted_systems_count.toLocaleString()}`}</div>
-                ),
+                title:
+                  value.rule_status === 'rhdisabled' ? (
+                    <Tooltip
+                      content={intl.formatMessage(messages.byEnabling, {
+                        systems: value.impacted_systems_count,
+                      })}
+                    >
+                      <span>{intl.formatMessage(messages.nA)}</span>
+                    </Tooltip>
+                  ) : (
+                    <div
+                      key={key}
+                    >{`${value.impacted_systems_count.toLocaleString()}`}</div>
+                  ),
               },
               {
                 title: (


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/ADVISOR-1751

#### looks like
![Screen Shot 2021-06-07 at 8 01 36 AM](https://user-images.githubusercontent.com/6640236/121014245-c3795600-c767-11eb-991a-62076fb92f97.png)

![Screen Shot 2021-06-07 at 7 59 51 AM](https://user-images.githubusercontent.com/6640236/121014381-e86dc900-c767-11eb-92b0-1fcdda468da2.png)
