### PR TITLE
Add default for undefined items

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -28,7 +28,7 @@ const Inventory = ({
   intl,
   rule,
   addNotification,
-  items,
+  items = [],
   afterDisableFn,
   onSortFn,
   filters,


### PR DESCRIPTION
Maybe fixes https://issues.redhat.com/browse/ADVISOR-1723

Items are not required and they can be empty, however there are several `items.length` calls.

There are two approaches how to fix it:

1) add default value `[]`
2) add safe accessors 

Let me know, what you prefer. I went with the first one as it makes more sense to me.