### PR TITLE
Adds incident label to system details page

### DIFF
--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -50,6 +50,7 @@ import PrimaryToolbar from '@redhat-cloud-services/frontend-components/PrimaryTo
 import PropTypes from 'prop-types';
 import RemediationButton from '@redhat-cloud-services/frontend-components-remediations/RemediationButton';
 import ReportDetails from '../../PresentationalComponents/ReportDetails';
+import RuleLabels from '../../PresentationalComponents/RuleLabels/RuleLabels';
 import { addNotification as addNotificationAction } from '@redhat-cloud-services/frontend-components-notifications/';
 import { capitalize } from '../../PresentationalComponents/Common/Tables';
 import messages from '../../Messages';
@@ -200,7 +201,13 @@ const BaseSystemAdvisor = () => {
           selected,
           disableSelection: !resolution.has_playbook,
           cells: [
-            { title: <div> {rule.description}</div> },
+            {
+              title: (
+                <span>
+                  {rule.description} <RuleLabels rule={rule} />
+                </span>
+              ),
+            },
             {
               title: (
                 <div key={key}>


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/ADVISOR-1882

#### adds incident label to system details page, tada
![Screen Shot 2021-07-26 at 8 13 01 AM](https://user-images.githubusercontent.com/6640236/126987090-4ee03e14-c2a4-4336-8f7b-17bd0c4ef764.png)
