### PR TITLE
Hide feedback form if there is no onFeedbackChanged provided

### DIFF
--- a/src/PresentationalComponents/RuleDetails/RuleDetails.js
+++ b/src/PresentationalComponents/RuleDetails/RuleDetails.js
@@ -98,7 +98,7 @@ const BaseRuleDetails = ({
               {barDividedList(topicLinks())}
             </StackItem>
           )}
-          {isDetailsPage && (
+          {isDetailsPage && onFeedbackChanged && (
             <RuleRating
               ruleId={rule.rule_id}
               ruleRating={rule.rating}


### PR DESCRIPTION
OCP infrastructure is designed in a way that the feedback is given to the set of clusterId + ruleId. There are planned changes that should change the behavior to be clusters-wide. But for now, there will be a need to hide the feedback form for OCP recommendation details page.

RHEL example when the callback is not provided:
![Screenshot from 2021-08-23 22-28-18](https://user-images.githubusercontent.com/31385370/130515462-2f357e4d-e11f-490c-bd3d-13dc24b390fc.png)
