### PR TITLE
Fix "view affected" message intl disclosure

### DIFF
--- a/src/PresentationalComponents/RuleDetails/RuleDetails.js
+++ b/src/PresentationalComponents/RuleDetails/RuleDetails.js
@@ -114,22 +114,13 @@ const BaseRuleDetails = ({
                   key={`${rule.rule_id}-link`}
                   to={`/recommendations/${rule.rule_id}`}
                 >
-                  {intl.formatMessage(
-                    ...(isOpenShift
-                      ? [
-                          // OpenShift's intl object should be used to obtain messages
-                          intl.messages.viewAffectedClusters,
-                          {
-                            clusters: rule.impacted_clusters_count,
-                          },
-                        ]
-                      : [
-                          messages.viewAffectedSystems,
-                          {
-                            systems: rule.impacted_systems_count,
-                          },
-                        ])
-                  )}
+                  {isOpenShift
+                    ? intl.formatMessage(intl.messages.viewAffectedClusters, {
+                        clusters: rule.impacted_clusters_count,
+                      })
+                    : intl.formatMessage(messages.viewAffectedSystems, {
+                        systems: rule.impacted_systems_count,
+                      })}
                 </Link>
               </StackItem>
             )}


### PR DESCRIPTION
The patch changes how the `RuleDetails` component decides whether to render the "View affected items" message (see the screenshot). TBH, even the before/after changes look equal, the older way didn't cause this link to be rendered. 

Tested it locally, and now it works as expected.

![Frame 1 (8)](https://user-images.githubusercontent.com/31385370/137459650-1fdea937-f1f1-42a0-b687-db98fa2309ba.png)
