### PR TITLE
HOTFIX for broken exec report button

### DIFF
--- a/src/PresentationalComponents/ExecutiveReport/_Download.scss
+++ b/src/PresentationalComponents/ExecutiveReport/_Download.scss
@@ -4,6 +4,7 @@
 }
 
 .downloadButtonOverride {
+    margin-top: -32px;
     float: right;
     @media only screen and (max-width: 585px) {
         float: none;


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/ADVISOR-2053

looks like someone changed the behavior of `PageHeaderTitle` component, children are no longer rendered inline 😭 

<img width="1021" alt="Screen Shot 2021-10-18 at 3 21 09 PM" src="https://user-images.githubusercontent.com/6640236/137793707-a4ec5433-9b15-442e-82d1-ac983ede49b7.png">

