### PR TITLE
add export button on affected systems page

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -28,6 +28,7 @@ import { addNotification as notification } from '@redhat-cloud-services/frontend
 import { systemReducer } from '../../Store/AppReducer';
 import { updateReducers } from '../../Store';
 import { useIntl } from 'react-intl';
+import downloadReport from '../Common/DownloadHelper';
 
 const Inventory = ({
   tableProps,
@@ -37,6 +38,8 @@ const Inventory = ({
   selectedTags,
   workloads,
   SID,
+  permsExport,
+  exportTable,
 }) => {
   const store = useStore();
   const intl = useIntl();
@@ -441,6 +444,26 @@ const Inventory = ({
             })
           );
         }}
+        exportConfig={
+          permsExport && {
+            label: intl.formatMessage(messages.exportCsv),
+            // eslint-disable-next-line no-dupe-keys
+            label: intl.formatMessage(messages.exportJson),
+            onSelect: (_e, fileType) =>
+              downloadReport(
+                exportTable,
+                fileType,
+                filters,
+                selectedTags,
+                workloads,
+                SID
+              ),
+            isDisabled: !permsExport || entities?.rows?.length === 0,
+            tooltipText: permsExport
+              ? intl.formatMessage(messages.exportData)
+              : intl.formatMessage(messages.permsAction),
+          }
+        }
       />
     </React.Fragment>
   );
@@ -454,6 +477,8 @@ Inventory.propTypes = {
   selectedTags: PropTypes.any,
   workloads: PropTypes.any,
   SID: PropTypes.any,
+  permsExport: PropTypes.bool,
+  exportTable: PropTypes.string,
 };
 
 export default Inventory;

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -62,6 +62,7 @@ const OverviewDetails = () => {
   const SID = useSelector(({ filters }) => filters.SID);
   const ruleId = useParams().id;
   const addNotification = (data) => dispatch(notification(data));
+  const permsExport = usePermissions('advisor', PERMS.export).hasAccess;
 
   const {
     data: rule = {},
@@ -407,6 +408,8 @@ const OverviewDetails = () => {
                   selectedTags={selectedTags}
                   workloads={workloads}
                   SID={SID}
+                  permsExport={permsExport}
+                  exportTable="reports"
                 />
               </React.Fragment>
             )}


### PR DESCRIPTION
export feature is added to [affected systems table](https://console.redhat.com/insights/advisor/recommendations/hardening_yum%7CHARDENING_YUM_GPG_3RD_6?limit=20&offset=0&sort=-last_seen&name=). It seems there is an issue with the api endpoint. But UI work should work out of the box. Thus, this PR needs to be merged once the issue is resolved.

https://user-images.githubusercontent.com/59481011/139755930-eab9968d-b7ac-4a1c-9835-001e79ee7ca9.mp4



