### PR TITLE
fix(SystemsTable): ADVISOR-2104 - Update sysState not state for recs

### DIFF
--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -41,7 +41,7 @@ const SystemsTable = () => {
   const selectedTags = useSelector(({ filters }) => filters.selectedTags);
   const workloads = useSelector(({ filters }) => filters.workloads);
   const SID = useSelector(({ filters }) => filters.SID);
-  const filters = useSelector(({ filters }) => filters.recState);
+  const filters = useSelector(({ filters }) => filters.sysState);
   const setFilters = (filters) => dispatch(updateSysFilters(filters));
   const permsExport = usePermissions('advisor', PERMS.export).hasAccess;
   const [filterBuilding, setFilterBuilding] = useState(true);
@@ -154,7 +154,7 @@ const SystemsTable = () => {
           sort: filters.sort,
           limit: filters.limit,
           offset: filters.offset,
-          hits: ['yes'],
+          hits: ['all'],
         });
       } else {
         itemsToRemove.map((item) => {


### PR DESCRIPTION
This fixes the filters on the SystemsTable and makes them work properly again.

**How to test:**

1. Open the Advisor app on the Systems page
2. Verify that filters work and trigger a reload of the table with proper results.

