### PR TITLE
fix: ADVISOR-1903 - Update "Ansible" to "remediation"

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -273,7 +273,7 @@ export const FILTER_CATEGORIES = {
   },
   has_playbook: {
     type: 'checkbox',
-    title: 'ansible support',
+    title: 'remediation',
     urlParam: 'has_playbook',
     values: [
       {
@@ -281,18 +281,10 @@ export const FILTER_CATEGORIES = {
           intl.formatMessage(messages.ansibleSupportYes),
           intlSettings
         ),
-        text: intlHelper(
-          intl.formatMessage(messages.ansibleSupportYes),
-          intlSettings
-        ),
         value: 'true',
       },
       {
         label: intlHelper(
-          intl.formatMessage(messages.ansibleSupportNo),
-          intlSettings
-        ),
-        text: intlHelper(
           intl.formatMessage(messages.ansibleSupportNo),
           intlSettings
         ),

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -59,10 +59,20 @@ export default defineMessages({
     description: 'Systems title used in exec report',
     defaultMessage: 'Systems exposed',
   },
-  ansible: {
-    id: 'ansible',
-    description: 'Recommendation table column title',
-    defaultMessage: 'Ansible',
+  remediation: {
+    id: 'remediation',
+    description: 'Remediation table column title',
+    defaultMessage: 'Remediation',
+  },
+  playbook: {
+    id: 'playbook',
+    description: 'Remediation/Playbook table cell text',
+    defaultMessage: 'Playbook',
+  },
+  manual: {
+    id: 'manual',
+    description: 'Maunal table cell text',
+    defaultMessage: 'Manual',
   },
   rulesTableHideReportsErrorEnabled: {
     id: 'rulestable.hidereports.errorenabling',
@@ -463,7 +473,7 @@ export default defineMessages({
   overviewRemediateBody: {
     id: 'overview.remediate.body',
     description: 'Overview, body for remediate',
-    defaultMessage: `Easily generate an Ansible playbook to 
+    defaultMessage: `Easily generate an Ansible playbook to
         quickly and effectively remediate Insights findings`,
   },
   overviewRemediateAction: {
@@ -1075,13 +1085,13 @@ export default defineMessages({
   },
   ansibleSupportYes: {
     id: 'ansibleSupportYes',
-    description: 'Ansible remediation support',
-    defaultMessage: 'Ansible remediation support',
+    description: 'Ansible playbook',
+    defaultMessage: 'Ansible playbook',
   },
   ansibleSupportNo: {
     id: 'ansibleSupportNo',
-    description: 'No Ansible remediation support',
-    defaultMessage: 'No Ansible remediation support',
+    description: 'Manual',
+    defaultMessage: 'Manual',
   },
   yes: {
     id: 'yes',

--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -14,7 +14,6 @@ import {
 } from '../Common/Tables';
 import { useDispatch, useSelector, useStore } from 'react-redux';
 
-import AnsibeTowerIcon from '@patternfly/react-icons/dist/js/icons/ansibeTower-icon';
 import DisableRule from '../../PresentationalComponents/Modals/DisableRule';
 import { Get } from '../../Utilities/Api';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
@@ -147,7 +146,7 @@ const Inventory = ({
   };
 
   const handleRefresh = (options) => {
-    /* Rec table doesn't use the same sorting params as sys table, switching between the two results in the rec table blowing up cuz its trying to 
+    /* Rec table doesn't use the same sorting params as sys table, switching between the two results in the rec table blowing up cuz its trying to
     read the endpoint with incorrect sorting params, if we hold of on updating the sysable url params when using the this component in pathways, it
     solves this issue for the time being*/
     const { name, display_name } = options;
@@ -343,8 +342,7 @@ const Inventory = ({
             dataProvider={remediationDataProvider}
             onRemediationCreated={(result) => onRemediationCreated(result)}
           >
-            <AnsibeTowerIcon size="sm" className="ins-c-background__default" />
-            &nbsp;{intl.formatMessage(messages.remediate)}
+            {intl.formatMessage(messages.remediate)}
           </RemediationButton>
         }
         actionsConfig={{

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -100,13 +100,8 @@ const RulesTable = () => {
       transforms: [sortable, cellWidth(15)],
     },
     {
-      title: (
-        <React.Fragment>
-          <AnsibeTowerIcon size="md" /> {intl.formatMessage(messages.ansible)}
-        </React.Fragment>
-      ),
+      title: intl.formatMessage(messages.remediation),
       transforms: [sortable, cellWidth(15), fitContent],
-      dataLabel: intl.formatMessage(messages.ansible),
     },
   ]);
 
@@ -452,9 +447,12 @@ const RulesTable = () => {
                 title: (
                   <div className="ins-c-center-text " key={key}>
                     {value.playbook_count ? (
-                      <CheckCircleIcon className="ansibleCheck" />
+                      <span>
+                        <AnsibeTowerIcon size="sm" />{' '}
+                        {intl.formatMessage(messages.playbook)}
+                      </span>
                     ) : (
-                      intl.formatMessage(messages.no)
+                      intl.formatMessage(messages.manual)
                     )}
                   </div>
                 ),

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -3,7 +3,6 @@ import './SystemAdvisor.scss';
 import {
   AnsibeTowerIcon,
   ChartSpikeIcon,
-  CheckCircleIcon,
   CheckIcon,
   ExternalLinkAltIcon,
   PficonSatelliteIcon,
@@ -106,14 +105,8 @@ const BaseSystemAdvisor = () => {
       transforms: [sortable],
     },
     {
-      title: (
-        <span>
-          {AnsibeTowerIcon && <AnsibeTowerIcon size="md" />}{' '}
-          {intl.formatMessage(messages.ansible)}
-        </span>
-      ),
+      title: intl.formatMessage(messages.remediation),
       transforms: [sortable, fitContent],
-      dataLabel: intl.formatMessage(messages.ansible),
     },
   ];
 
@@ -139,10 +132,7 @@ const BaseSystemAdvisor = () => {
         addNotification(result.getNotification())
       }
     >
-      {AnsibeTowerIcon && (
-        <AnsibeTowerIcon size="sm" className="ins-c-background__default" />
-      )}{' '}
-      Remediate
+      {intl.formatMessage(messages.remediate)}
     </RemediationButton>,
   ];
 
@@ -244,9 +234,12 @@ const BaseSystemAdvisor = () => {
               title: (
                 <div className="ins-c-center-text" key={key}>
                   {resolution.has_playbook ? (
-                    <CheckCircleIcon className="successColorOverride" />
+                    <span>
+                      <AnsibeTowerIcon size="sm" />{' '}
+                      {intl.formatMessage(messages.playbook)}
+                    </span>
                   ) : (
-                    'No'
+                    intl.formatMessage(messages.manual)
                   )}
                 </div>
               ),


### PR DESCRIPTION
This updates all places mentioning "Ansible" to use the new wording.

The changes can be seen on the "Recommendations" page as well as any SystemsAdvisory page and the "Advisor" tab in the Inventory application. 