### PR TITLE
chore: fix error in row count

### DIFF
--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -280,6 +280,8 @@ const BaseSystemAdvisor = () => {
       row.parent ? (row.parent = index - 1) : null
     );
 
+    systemAdvisorRef.current.rowCount = builtRows.length / 2;
+
     if (activeReports.length < 1 || builtRows.length < 1) {
       let EmptyState =
         (builtRows.length === 0 && NoMatchingRecommendations) ||
@@ -588,9 +590,6 @@ const BaseSystemAdvisor = () => {
 
         const activeRuleFirstReportsData = activeRuleFirst(reportsFetch);
         fetchKbaDetails(activeRuleFirstReportsData);
-
-        systemAdvisorRef.current.rowCount =
-          activeRuleFirstReportsData?.length || 0;
 
         setRows(
           buildRows(


### PR DESCRIPTION
This PR is intended to fix the incorrect row count after appliying a filter in Advisor System details table.

Before:
![image](https://user-images.githubusercontent.com/59481011/157309872-adc88ea8-ccc7-4331-925c-c08d508ef55b.png)

After:
![image](https://user-images.githubusercontent.com/59481011/157309971-8802740a-8033-4099-8b07-1589a18a5f8a.png)
