### PR TITLE
fix: reset loading state to active state when dowload fails

### DIFF
--- a/src/PresentationalComponents/ExecutiveReport/Download.js
+++ b/src/PresentationalComponents/ExecutiveReport/Download.js
@@ -50,6 +50,7 @@ const DownloadExecReport = ({ isDisabled }) => {
 
       return [report];
     } catch (e) {
+      setLoading(false);
       dispatch(addNotification(exportNotifications.error));
 
       return [];


### PR DESCRIPTION
We should change current behaviour from showing 'Loading' state when download report fails to active button state. 

Before:
![Screenshot from 2022-03-08 13-32-12](https://user-images.githubusercontent.com/59481011/158143014-9adf60e3-067e-45dd-ad19-f522e620945a.png)

After:
![image](https://user-images.githubusercontent.com/59481011/158143677-563f9dee-8fba-4aab-b876-c98865b00d7f.png)

 