### PR TITLE
fix: ADVISOR-2054 - Recommendation expansion description padding

### DIFF
--- a/src/PresentationalComponents/RuleDetails/_RuleDetails.scss
+++ b/src/PresentationalComponents/RuleDetails/_RuleDetails.scss
@@ -7,7 +7,7 @@ hr {
 
 .ins-c-rule-details__split {
   display: inline-flex;
-  justify-content: space-around;
+  justify-content: space-between;
   .pf-l-split__item {
     position: relative;
   }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/20592948/158643800-30c29090-d984-4038-b27b-b579fceb0dfd.png)

After:
![image](https://user-images.githubusercontent.com/20592948/158643667-bbdd736d-9d3e-460c-a430-209dc7292770.png)
