### PR TITLE
feat(SystemsTable): ADVISOR-1959 - Use grouped OS selection via helpers

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -11,6 +11,9 @@ const insightsProxy = {
   https: false,
   ...(process.env.BETA && { deployment: 'beta/apps' }),
 };
+const LOCAL_INVENTORY_FRONTEND = !!process.env.INVENTORY_FRONTEND_PORT;
+const INVENTORY_FRONTEND_HOST = 'stage.foo.redhat.com';
+const INVENTORY_FRONTEND_PORT = '8003';
 
 const webpackProxy = {
   deployment: process.env.BETA ? 'beta/apps' : 'apps',
@@ -18,7 +21,16 @@ const webpackProxy = {
   env: process.env.CHROME_ENV ? process.env.CHROME_ENV : 'stage-stable', // pick chrome env ['stage-beta', 'stage-stable', 'prod-beta', 'prod-stable']
   useProxy: true,
   proxyVerbose: true,
-  routes: {},
+  routes: {
+    ...(LOCAL_INVENTORY_FRONTEND && {
+      '/apps/inventory': {
+        host: `http://${INVENTORY_FRONTEND_HOST}:${INVENTORY_FRONTEND_PORT}`,
+      },
+      '/beta/apps/inventory': {
+        host: `http://${INVENTORY_FRONTEND_HOST}:${INVENTORY_FRONTEND_PORT}`,
+      },
+    }),
+  },
   customProxy: [
     // {
     //   context: (path) => path.includes('/api/'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@redhat-cloud-services/frontend-components-translations": "3.2.3",
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.8",
         "@reduxjs/toolkit": "1.6.1",
+        "@scalprum/react-core": "^0.1.9",
         "classnames": "2.3.1",
         "dot": "1.1.3",
         "marked": "4.0.10",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@redhat-cloud-services/frontend-components-translations": "3.2.3",
     "@redhat-cloud-services/frontend-components-utilities": "^3.2.8",
     "@reduxjs/toolkit": "1.6.1",
+    "@scalprum/react-core": "^0.1.9",
     "classnames": "2.3.1",
     "dot": "1.1.3",
     "marked": "4.0.10",


### PR DESCRIPTION
This updates the OS filter to use the helpers provided by the Inventory applications as federated modules.

**Note:** Currently the inventory helpers are only deployed to `/beta`