### PR TITLE
fix: Change pathways card question icon to grey

### DIFF
--- a/src/PresentationalComponents/Common/Common.js
+++ b/src/PresentationalComponents/Common/Common.js
@@ -14,7 +14,7 @@ import { createIntl, createIntlCache } from 'react-intl';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 import PowerOffIcon from '@patternfly/react-icons/dist/esm/icons/power-off-icon';
 import React from 'react';
-import { global_info_color_100 } from '@patternfly/react-tokens';
+import { global_Color_200 } from '@patternfly/react-tokens';
 import messages from '../../Messages';
 import { strong } from '../../Utilities/intlHelper';
 
@@ -58,7 +58,7 @@ const QuestionTooltip = (text) => (
     content={<div>{text}</div>}
   >
     <span aria-label="Action">
-      <OutlinedQuestionCircleIcon color={global_info_color_100.value} />
+      <OutlinedQuestionCircleIcon color={global_Color_200.value} />
     </span>
   </Tooltip>
 );


### PR DESCRIPTION
Changed the icon color from blue to grey. No specific grey was specified, so I used the same color code from other apps

![image](https://user-images.githubusercontent.com/20592948/159882618-37521f63-35c5-41e1-b90e-928996a317cc.png)