### PR TITLE
fix: Change pathways card question icon to correct grey

### DIFF
--- a/src/PresentationalComponents/Common/Common.js
+++ b/src/PresentationalComponents/Common/Common.js
@@ -14,7 +14,7 @@ import { createIntl, createIntlCache } from 'react-intl';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 import PowerOffIcon from '@patternfly/react-icons/dist/esm/icons/power-off-icon';
 import React from 'react';
-import { global_Color_200 } from '@patternfly/react-tokens';
+import { global_secondary_color_100 } from '@patternfly/react-tokens';
 import messages from '../../Messages';
 import { strong } from '../../Utilities/intlHelper';
 
@@ -58,7 +58,7 @@ const QuestionTooltip = (text) => (
     content={<div>{text}</div>}
   >
     <span aria-label="Action">
-      <OutlinedQuestionCircleIcon color={global_Color_200.value} />
+      <OutlinedQuestionCircleIcon color={global_secondary_color_100.value} />
     </span>
   </Tooltip>
 );


### PR DESCRIPTION
There was a strange issue with this color, should be working now

Before:
![image](https://user-images.githubusercontent.com/20592948/161032240-92517216-8135-41b8-9377-9eb947abf106.png)

After:
![image](https://user-images.githubusercontent.com/20592948/161031914-e3a51430-abc2-40e1-accd-a3c950900df3.png)
