### PR TITLE
fix(DetailsPathways): ADVISOR-2117 add margin to pathway date

### DIFF
--- a/src/SmartComponents/Recs/DetailsPathways.js
+++ b/src/SmartComponents/Recs/DetailsPathways.js
@@ -111,7 +111,7 @@ const PathwayDetails = () => {
                 </React.Fragment>
               }
             />
-            <p>
+            <p className="pf-u-mb-lg">
               {intl.formatMessage(messages.rulesDetailsModifieddate, {
                 date: (
                   <DateFormat


### PR DESCRIPTION
Added Bottom margin to date, but the gap looks too big to me

Before:
![image](https://user-images.githubusercontent.com/20592948/163213560-fa958255-3fbc-4e52-aa78-a00f27c71c95.png)

After:
![image](https://user-images.githubusercontent.com/20592948/163213659-95b59658-955b-440f-b065-1ad0d8292d75.png)



[ADVISOR-2117](https://issues.redhat.com/browse/ADVISOR-2117)
