### PR TITLE
fix(Details): ADVISOR-2060 new labels in recommendations detail

### DIFF
--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -34,7 +34,6 @@ import Failed from '../../PresentationalComponents/Loading/Failed';
 import { Flex } from '@patternfly/react-core/dist/js/layouts/Flex/Flex';
 import { FlexItem } from '@patternfly/react-core/dist/js/layouts/Flex/FlexItem';
 import Inventory from '../../PresentationalComponents/Inventory/Inventory';
-import { Label } from '@patternfly/react-core/dist/js/components/Label/Label';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import MessageState from '../../PresentationalComponents/MessageState/MessageState';
@@ -52,6 +51,7 @@ import { useGetTopicsQuery } from '../../Services/Topics';
 import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import CategoryLabel from '../../PresentationalComponents/Labels/CategoryLabel';
 
 const OverviewDetails = () => {
   const intl = useIntl();
@@ -227,17 +227,17 @@ const OverviewDetails = () => {
                     }
                   />
                   <p>
-                    {intl.formatMessage(messages.rulesDetailsModifieddate, {
-                      date: (
-                        <DateFormat
-                          date={new Date(rule.publish_date)}
-                          type="onlyDate"
-                        />
-                      ),
-                    })}
-                    <Label className="adv-c-label-category" color="blue">
-                      {rule.category.name}
-                    </Label>
+                    <span className="pf-u-mr-md">
+                      {intl.formatMessage(messages.rulesDetailsModifieddate, {
+                        date: (
+                          <DateFormat
+                            date={new Date(rule.publish_date)}
+                            type="onlyDate"
+                          />
+                        ),
+                      })}
+                    </span>
+                    <CategoryLabel labelList={[rule.category]} />
                   </p>
                 </React.Fragment>
               }


### PR DESCRIPTION
[ADVISOR-2060](https://issues.redhat.com/browse/ADVISOR-2060)

Updated label in Recommendations detail page

Before:
![image](https://user-images.githubusercontent.com/20592948/163223285-94aa9aa3-aa38-4c0f-84a3-d0a18ef55ebb.png)

After:
![image](https://user-images.githubusercontent.com/20592948/163223228-c6af6652-86a9-4634-a0b8-b178512b609a.png)
