### PR TITLE
ADVISOR-2127

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -640,6 +640,7 @@ const RulesTable = () => {
   const activeFiltersConfig = {
     deleteTitle: intl.formatMessage(messages.resetFilters),
     filters: buildFilterChips(),
+    showDeleteButton: true,
     onDelete: (_event, itemsToRemove, isAll) => {
       if (isAll) {
         setSearchText('');
@@ -731,11 +732,7 @@ const RulesTable = () => {
               SID,
               dispatch
             ),
-          isDisabled:
-            !permsExport ||
-            !filters.impacting ||
-            (Array.isArray(filters.impacting) &&
-              !filters.impacting.every((item) => item === 'true')),
+          isDisabled: !permsExport,
           tooltipText: permsExport
             ? intl.formatMessage(messages.exportData)
             : intl.formatMessage(messages.permsAction),


### PR DESCRIPTION
The ticket description is
'Always keep the reset filters text and default filter available. Right now, when we cancel the filter, it all disappears. AND when removing the filter, it disables the export functionality which is a bug.'

With the changes I made the 'Reset Filter' button is always present, and the export functionality is always available.
To see the changes
Go to Advisor,
Click recommendations,
Delete the two default filters 'systems impacted' , and 'status enabled'
You'll see that you can still select the export button
And you'll see that now the 'Reset Filter' button is still present, and onClick the filters are restored.