### PR TITLE
fix(Pathways): ADVISOR-2118 fix card and chart size

### DIFF
--- a/src/PresentationalComponents/Cards/Pathways.js
+++ b/src/PresentationalComponents/Cards/Pathways.js
@@ -95,7 +95,7 @@ const TotalRisk = (props) => {
     <Card
       isFlat
       isPlain
-      className="adv-c-card-pathway adv__background--global-100"
+      className="adv-c-card-pathway adv__background--global-100 pf-u-h-100"
     >
       <CardTitle>{intl.formatMessage(messages.totalRiskPathway)}</CardTitle>
       <CardBody className="body">
@@ -111,11 +111,11 @@ const TotalRisk = (props) => {
                     constrainToVisibleArea
                   />
                 }
-                height={300}
+                height={150}
                 width={300}
                 padding={{
                   bottom: 30,
-                  left: 35,
+                  left: 45,
                   right: 20,
                   top: 10,
                 }}
@@ -124,6 +124,7 @@ const TotalRisk = (props) => {
                 <ChartAxis dependentAxis showGrid />
                 <ChartGroup>
                   <ChartBar
+                    barWidth={16}
                     style={{
                       data: {
                         fill: ({ datum }) => datum.fill,
@@ -181,7 +182,7 @@ const Resolution = (props) => {
     <Card
       isFlat
       isPlain
-      className="adv-c-card-pathway adv__background--global-100"
+      className="adv-c-card-pathway adv__background--global-100 pf-u-h-100"
     >
       <CardTitle>{intl.formatMessage(messages.resolution)}</CardTitle>
       <Grid>


### PR DESCRIPTION
[ADVISOR-2118](https://issues.redhat.com/browse/ADVISOR-2118)

Before:
![image](https://user-images.githubusercontent.com/20592948/164220641-484a0605-10c8-47ac-ae8a-e64dd5a54906.png)
After:
![image](https://user-images.githubusercontent.com/20592948/164220660-06421c80-45ec-4d5b-8f36-a55ac308854f.png)

Chart height is smaller to be closer to the mockup, fixed triple digit chart value overflow, chart bar is a bit thicker and cards are the same height.
