### PR TITLE
fix(Pathways): ADVISOR-2119 fix missing category name when only one

### DIFF
--- a/src/PresentationalComponents/Cards/Pathways.js
+++ b/src/PresentationalComponents/Cards/Pathways.js
@@ -90,7 +90,9 @@ const TotalRisk = (props) => {
   } = props;
 
   const catString = (cats) =>
-    cats.length > 1 ? categories.map((cat) => cat.name).join(', ') : cats.name;
+    cats.length > 1
+      ? categories.map((cat) => cat.name).join(', ')
+      : cats[0]?.name;
   return (
     <Card
       isFlat


### PR DESCRIPTION
[ADVISOR-2119](https://issues.redhat.com/browse/ADVISOR-2119)

Before:
![image](https://user-images.githubusercontent.com/20592948/164228067-2d934a87-91c3-485a-8d4b-3046e1391bb7.png)

After:
![image](https://user-images.githubusercontent.com/20592948/164228193-8a33ba9d-eb1a-412e-b971-ba65298fd441.png)

When there was only one item in the array of categories, the single item would not be displayed
