### PR TITLE
ADVISOR-2000, bulkselector displays correct sign when item selected

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -429,6 +429,8 @@ const Inventory = ({
               ? 1
               : selected.length === filters.limit
               ? null
+              : selected.length > 0
+              ? null
               : 0,
           onSelect: () => {
             selected.length > 0 ? onSelectRows(-1, false) : bulkSelectfn();

--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -204,6 +204,20 @@ const Inventory = ({
     return pruneFilters(localFilters, SFC);
   };
 
+  const checkedStatus = () => {
+    if (
+      (selected.length === entities?.rows?.length ||
+        selected.length === entities?.total) &&
+      entities?.total > 0
+    ) {
+      return 1;
+    } else if (selected.length === filters.limit || selected.length > 0) {
+      return null;
+    } else {
+      return 0;
+    }
+  };
+
   const activeFiltersConfig = {
     deleteTitle: intl.formatMessage(messages.resetFilters),
     filters: buildFilterChips(),
@@ -422,16 +436,7 @@ const Inventory = ({
                 : {}),
             },
           ],
-          checked:
-            (selected.length === entities?.rows?.length ||
-              selected.length === entities?.total) &&
-            entities?.total > 0
-              ? 1
-              : selected.length === filters.limit
-              ? null
-              : selected.length > 0
-              ? null
-              : 0,
+          checked: checkedStatus(),
           onSelect: () => {
             selected.length > 0 ? onSelectRows(-1, false) : bulkSelectfn();
             calculateSelectedItems();


### PR DESCRIPTION
To view, run the app (must be in beta)

- Click recommendations in the left menu, 
- Selected pathways tab
- Select a pathway
- Click systems tab
- Select a system
Where before the bulkselector would remain empty besides a '1 selected', it now displays a ' -  ' 

