### PR TITLE
ADVISOR-2462, bulk selector dropdown is improved.

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -374,16 +374,12 @@ const Inventory = ({
               },
             },
             {
-              ...(entities?.rows?.length > filters.limit
-                ? {
-                    title: intl.formatMessage(messages.selectPage, {
-                      items: filters.limit,
-                    }),
-                    onClick: () => {
-                      onSelectRows(0, true);
-                    },
-                  }
-                : {}),
+              title: intl.formatMessage(messages.selectPage, {
+                items: entities?.rows?.length,
+              }),
+              onClick: () => {
+                onSelectRows(0, true);
+              },
             },
             {
               ...(entities?.rows?.length > 0


### PR DESCRIPTION
Bulk selector dropdown now shoes the correct 'select page' option number, and there is no empty space in the dropdown before changing the items displayed per page. 
To view changes 
- Run the app
- Click recomendations tab in the left menu
- Navigate to pathways
- Select a pathway
- select the systems tab
- open the bulk selector
Here you will see that where the empty space was, there now displays 'Select Page (20 items)'

- Edit the items show per page by clicking the pagination
- select something like 50 per page
In the bulk select, the 'select page' option will be updated with the current items per page

 
