### PR TITLE
ADVISOR-2057 Systems are not selected after remediation 

### DIFF
--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -121,14 +121,26 @@ const BaseSystemAdvisor = () => {
     setRows(allRows);
   };
 
+  const onRemediationCreated = (result) => {
+    onBulkSelect(false);
+    try {
+      result.remediation && addNotification(result.getNotification());
+    } catch (error) {
+      addNotification({
+        variant: 'danger',
+        dismissable: true,
+        title: intl.formatMessage(messages.error),
+        description: `${error}`,
+      });
+    }
+  };
+
   const actions = [
     <RemediationButton
       key="remediation-button"
       isDisabled={selectedAnsibleRules.length === 0}
       dataProvider={() => processRemediation(selectedAnsibleRules)}
-      onRemediationCreated={(result) =>
-        addNotification(result.getNotification())
-      }
+      onRemediationCreated={(result) => onRemediationCreated(result)}
     >
       {intl.formatMessage(messages.remediate)}
     </RemediationButton>,


### PR DESCRIPTION
After remediating systems, the selected systems are no longer selected.
To view changes
- navigate to systems tab in advisor
- select a system with at least 1 tag (ex. $uper_device has 5)
- select any combination of items available in the table
- click remediation button
- follow through remediation process ('create playbook and continue to press next)
- Once you reach the end and items have been added to a playbook, select 'return to application' or the x on the top right of the modal
- here you should see that the previously selected items are no longer selected