### PR TITLE
fix: ADVISOR-2123 - compact labels only in tables

### DIFF
--- a/src/PresentationalComponents/Cards/Pathways.js
+++ b/src/PresentationalComponents/Cards/Pathways.js
@@ -194,7 +194,6 @@ const Resolution = (props) => {
               text={RISK_OF_CHANGE_LABEL[resolution_risk.risk]}
               value={resolution_risk.risk}
               hideIcon
-              isCompact
             />
           </CardBody>
           <CardBody className="body">

--- a/src/PresentationalComponents/ExecutiveReport/Build.js
+++ b/src/PresentationalComponents/ExecutiveReport/Build.js
@@ -155,7 +155,7 @@ const BuildExecReport = ({
               title={intl.formatMessage(messages.systemsExposed)}
             >{`${rule.impacted_systems_count}`}</PanelItem>
             <PanelItem title={intl.formatMessage(messages.totalRisk)}>
-              <InsightsLabel variant={rule.total_risk} isCompact />
+              <InsightsLabel variant={rule.total_risk} />
             </PanelItem>
           </Panel>
         ))}

--- a/src/PresentationalComponents/Labels/CategoryLabel.js
+++ b/src/PresentationalComponents/Labels/CategoryLabel.js
@@ -66,7 +66,7 @@ CategoryLabel.propTypes = {
 };
 
 CategoryLabel.defaultProps = {
-  isCompact: true,
+  isCompact: false,
 };
 
 export default CategoryLabel;

--- a/src/PresentationalComponents/Labels/RecommendationLevel.js
+++ b/src/PresentationalComponents/Labels/RecommendationLevel.js
@@ -6,18 +6,18 @@ import { useIntl } from 'react-intl';
 
 const RecommendationLevel = (props) => {
   const intl = useIntl();
-  const { recommendation_level: lvl } = props;
+  const { recommendation_level: lvl, isCompact } = props;
 
-  const label = (text, lvl, color) => (
-    <Label color={color} isCompact>{`${text} - ${lvl}%`}</Label>
+  const label = (text, lvl, color, isCompact) => (
+    <Label color={color} isCompact={isCompact}>{`${text} - ${lvl}%`}</Label>
   );
 
   if (lvl >= 80) {
-    return label(intl.formatMessage(messages.high), lvl, 'red');
+    return label(intl.formatMessage(messages.high), lvl, 'red', isCompact);
   } else if (lvl < 80 && lvl >= 50) {
-    return label(intl.formatMessage(messages.medium), lvl, 'orange');
+    return label(intl.formatMessage(messages.medium), lvl, 'orange', isCompact);
   } else {
-    return label(intl.formatMessage(messages.low), lvl, 'blue');
+    return label(intl.formatMessage(messages.low), lvl, 'blue', isCompact);
   }
 };
 

--- a/src/PresentationalComponents/Labels/RuleLabels.js
+++ b/src/PresentationalComponents/Labels/RuleLabels.js
@@ -60,7 +60,7 @@ RuleLabels.propTypes = {
 };
 
 RuleLabels.defaultProps = {
-  isCompact: true,
+  isCompact: false,
 };
 
 export default RuleLabels;

--- a/src/PresentationalComponents/PathwaysTable/PathwaysTable.js
+++ b/src/PresentationalComponents/PathwaysTable/PathwaysTable.js
@@ -163,14 +163,18 @@ const PathwaysTable = () => {
                       {pathway.name}{' '}
                     </Link>
                     {pathway.has_incident && (
-                      <RuleLabels rule={{ tags: 'incident' }} />
+                      <RuleLabels rule={{ tags: 'incident' }} isCompact />
                     )}
                   </span>
                 ),
               },
               {
                 title: (
-                  <CategoryLabel key={key} labelList={pathway.categories} />
+                  <CategoryLabel
+                    key={key}
+                    labelList={pathway.categories}
+                    isCompact
+                  />
                 ),
               },
               {
@@ -192,7 +196,7 @@ const PathwaysTable = () => {
                 ),
               },
               {
-                title: <RecommendationLevel key={key} {...pathway} />,
+                title: <RecommendationLevel key={key} {...pathway} isCompact />,
               },
             ],
           },

--- a/src/PresentationalComponents/RuleDetails/RuleDetails.js
+++ b/src/PresentationalComponents/RuleDetails/RuleDetails.js
@@ -142,7 +142,7 @@ const BaseRuleDetails = ({
               <StackItem className="pf-u-display-inline-flex alignCenterOverride pf-u-pb-sm pf-u-pt-sm">
                 <span className="adv-l-stack-rule-details-item">
                   <span>
-                    <InsightsLabel value={rule.total_risk} isCompact />
+                    <InsightsLabel value={rule.total_risk} />
                   </span>
                   <Stack hasGutter className="description-stack-override">
                     <StackItem>
@@ -219,7 +219,6 @@ const BaseRuleDetails = ({
                           }
                           value={resolutionRisk}
                           hideIcon
-                          isCompact
                         />
                       </span>
                       <Stack hasGutter className="description-stack-override">

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -328,7 +328,7 @@ const RulesTable = () => {
                       {' '}
                       {value.description}{' '}
                     </Link>
-                    <RuleLabels rule={value} />
+                    <RuleLabels rule={value} isCompact />
                   </span>
                 ),
               },
@@ -342,7 +342,13 @@ const RulesTable = () => {
                 ),
               },
               {
-                title: <CategoryLabel key={key} labelList={[value.category]} />,
+                title: (
+                  <CategoryLabel
+                    key={key}
+                    labelList={[value.category]}
+                    isCompact
+                  />
+                ),
               },
               {
                 title: (

--- a/src/PresentationalComponents/TopicsTable/TopicsTable.js
+++ b/src/PresentationalComponents/TopicsTable/TopicsTable.js
@@ -67,7 +67,7 @@ const TopicsTable = ({ props }) => {
                     <span key={key}>
                       {' '}
                       {value.featured && (
-                        <Label color="blue" icon={<StarIcon />} isCompact>
+                        <Label color="blue" icon={<StarIcon />}>
                           {intl.formatMessage(messages.featured)}
                         </Label>
                       )}{' '}

--- a/src/SmartComponents/Topics/Details.js
+++ b/src/SmartComponents/Topics/Details.js
@@ -81,12 +81,7 @@ const Details = () => {
             <Title headingLevel="h3" size="2xl" className="pf-u-mb-lg">
               {topic.name}
               {topic.featured && (
-                <Label
-                  color="blue"
-                  className="adv-c-label"
-                  icon={<StarIcon />}
-                  isCompact
-                >
+                <Label color="blue" className="adv-c-label" icon={<StarIcon />}>
                   {intl.formatMessage(messages.featured)}
                 </Label>
               )}


### PR DESCRIPTION
[ADVISOR-2123](https://issues.redhat.com/browse/ADVISOR-2123)

Fix for an earlier change. Compact labels should only be in compact tables. So I removed compact labels from everywhere else. Please have a look if I missed something.

Example in Recommendations:
Before:
![image](https://user-images.githubusercontent.com/20592948/165760244-97cdc1cb-c240-471e-a597-e77726f4d72e.png)
After:
![image](https://user-images.githubusercontent.com/20592948/165760348-9c369593-787a-4b84-8cce-80cb2d5e689e.png)

and other pages...
