### PR TITLE
fix(Pathways): ADVISOR-2364 - Chart x axis moved more to the right

### DIFF
--- a/src/PresentationalComponents/Cards/Pathways.js
+++ b/src/PresentationalComponents/Cards/Pathways.js
@@ -113,12 +113,15 @@ const TotalRisk = (props) => {
                     constrainToVisibleArea
                   />
                 }
+                domainPadding={{
+                  x: [20, 15],
+                }}
                 height={150}
                 width={300}
                 padding={{
                   bottom: 30,
                   left: 45,
-                  right: 20,
+                  right: 10,
                   top: 10,
                 }}
               >


### PR DESCRIPTION
[ADVISOR-2364](https://issues.redhat.com/browse/ADVISOR-2364)

In Pathway Detail moved the X axis to right

Before:
![image](https://user-images.githubusercontent.com/20592948/166908453-106aa802-7a26-4cd2-9e28-caa121b5b6c4.png)
After:
![image](https://user-images.githubusercontent.com/20592948/166908407-8ee474c1-1f9c-4b32-884a-7e9c8cfc7bba.png)
