### PR TITLE
Bulk Selector Refactor for Advisor : ADVISOR-2472

### DIFF
--- a/src/Store/AppReducer.js
+++ b/src/Store/AppReducer.js
@@ -11,11 +11,43 @@ export function systemReducer(cols, INVENTORY_ACTION_TYPES) {
       };
       return {
         ...state,
+        selected: state.selected || [],
         columns: cols.map((cell) => ({
           ...cell,
           ...state.columns.find(({ key }) => cell.key === key),
         })),
       };
+    },
+
+    [`${'SELECT_ENTITY'}`]: (state, action) => {
+      let newSelectedState;
+      let id = action.payload.id;
+      if (state?.selected) {
+        if (id === -1) {
+          newSelectedState = [];
+        } else if (Array.isArray(id)) {
+          newSelectedState = id;
+          state.rows.map((item) => {
+            item.selected = true;
+          });
+          return {
+            ...state,
+            selected: newSelectedState,
+          };
+        } else if (!state?.selected.includes(id)) {
+          newSelectedState = [...state.selected, id];
+        } else if (state?.selected.includes(id)) {
+          newSelectedState = [...state.selected.filter((item) => item !== id)];
+        }
+        return {
+          ...state,
+          selected: newSelectedState,
+        };
+      } else {
+        return {
+          state,
+        };
+      }
     },
   });
 }


### PR DESCRIPTION
This change fixes the issues regarding the bulk selector in advisor pathway details page. 
Right now, when trying to view more systems, all selected items are cleared. To replicate

Click recommendations in the left menu,
Selected pathways tab
Select a pathway
Click systems tab
Select a system or two
Press a new page (look at the pagination button, select the '>' button the view items 20-40 as opposed to 1-20. 
Old Behavior: selected is clear

New Behavior: When moving pages , state is carried across. Also if you do a select all and then deselect 1 item, it doesnt switch to (pagesize -1), it instead does (total Systems -1)


With this change state is carried around properly, and ADVISOR-2388 can be worked on more easily as selected items are managed/updated properly. 
