### PR TITLE
Advisor 2388-3 CANT BE MERGED UNTILL 2472 IS ACCEPTED

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36659,7 +36659,9 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "ajv-keywords": {
           "version": "5.1.0",
@@ -36750,7 +36752,9 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36659,9 +36659,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",
@@ -36752,9 +36750,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -5,7 +5,7 @@ import {
   RULES_FETCH_URL,
   SYSTEMS_FETCH_URL,
 } from '../../AppConstants';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { TableVariant, sortable, wrappable } from '@patternfly/react-table';
 import {
   pruneFilters,
@@ -45,7 +45,6 @@ const Inventory = ({
   const store = useStore();
   const intl = useIntl();
   const dispatch = useDispatch();
-  const [selected, setSelected] = useState([]);
   const [filters, setFilters] = useState({
     limit: 20,
     offset: 0,
@@ -53,11 +52,12 @@ const Inventory = ({
     name: '',
   });
   const entities = useSelector(({ entities }) => entities || {});
-  const onSelectRows = (id, selected) =>
-    dispatch({ type: 'SELECT_ENTITY', payload: { id, selected } });
+  const selected = useSelector(({ entities }) => entities?.selected || []);
+
+  const onSelectRows = (id = false) =>
+    dispatch({ type: 'SELECT_ENTITY', payload: { id } });
   const addNotification = (data) => dispatch(notification(data));
   const [disableRuleModalOpen, setDisableRuleModalOpen] = useState(false);
-  const [bulkSelect, setBulkSelect] = useState();
 
   const remediationDataProvider = async () => {
     if (pathway) {
@@ -87,7 +87,7 @@ const Inventory = ({
   };
 
   const onRemediationCreated = (result) => {
-    onSelectRows(-1, false);
+    onSelectRows(-1);
     try {
       result.remediation && addNotification(result.getNotification());
     } catch (error) {
@@ -104,19 +104,13 @@ const Inventory = ({
     setDisableRuleModalOpen(disableRuleModalOpen);
   };
 
-  const bulkSelectfn = () => {
-    setBulkSelect(true);
-    onSelectRows(0, true);
+  const setPageAsSelected = () => {
+    let ids = [];
+    entities.rows.forEach((item) => {
+      ids.push(item.system_uuid);
+    });
+    onSelectRows(ids);
   };
-
-  const calculateSelectedItems = () =>
-    bulkSelect
-      ? setBulkSelect(false)
-      : setSelected(
-          entities?.rows
-            ?.filter((entity) => entity.selected === true)
-            .map((entity) => entity.id)
-        );
 
   const createColumns = (defaultColumns) => {
     let lastSeenColumn = defaultColumns.filter(({ key }) => key === 'updated');
@@ -245,11 +239,6 @@ const Inventory = ({
     },
   };
 
-  useEffect(() => {
-    entities?.rows?.length && calculateSelectedItems(entities.rows);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entities?.rows]);
-
   return (
     <React.Fragment>
       {disableRuleModalOpen && (
@@ -348,6 +337,11 @@ const Inventory = ({
             },
             showTags
           );
+          results.results.forEach((row) => {
+            if (selected.includes(row.id)) {
+              row.selected = true;
+            }
+          });
 
           return Promise.resolve({
             results: mergeArraysByDiffKeys(
@@ -385,7 +379,7 @@ const Inventory = ({
             {
               title: intl.formatMessage(messages.selectNone),
               onClick: () => {
-                onSelectRows(-1, false);
+                onSelectRows(-1);
               },
             },
             {
@@ -393,7 +387,7 @@ const Inventory = ({
                 items: entities?.rows?.length,
               }),
               onClick: () => {
-                onSelectRows(0, true);
+                setPageAsSelected();
               },
             },
             {
@@ -424,10 +418,11 @@ const Inventory = ({
                               { name: filters.name }
                             )
                           )?.data?.host_ids;
-
                       console.error(allSystems);
-                      setSelected(allSystems);
-                      bulkSelectfn();
+                      entities.rows.forEach((item) => {
+                        item.selected = true;
+                      });
+                      onSelectRows(allSystems);
                     },
                   }
                 : {}),
@@ -435,8 +430,7 @@ const Inventory = ({
           ],
           checked: checkedStatus(),
           onSelect: () => {
-            selected.length > 0 ? onSelectRows(-1, false) : bulkSelectfn();
-            calculateSelectedItems();
+            selected.length > 0 ? onSelectRows(-1) : setPageAsSelected();
           },
         }}
         fallback={Loading}

--- a/src/PresentationalComponents/Inventory/helpers.js
+++ b/src/PresentationalComponents/Inventory/helpers.js
@@ -1,0 +1,11 @@
+export const hasPlaybook = (pathwayRules = []) => {
+  let hasPlaybook = false;
+  if (pathwayRules.length > 0) {
+    for (let i = 0; i < pathwayRules.length; i++) {
+      if (pathwayRules[i].resolution_set[0].has_playbook) {
+        return (hasPlaybook = true);
+      }
+    }
+  }
+  return hasPlaybook;
+};

--- a/src/Store/AppReducer.js
+++ b/src/Store/AppReducer.js
@@ -11,11 +11,43 @@ export function systemReducer(cols, INVENTORY_ACTION_TYPES) {
       };
       return {
         ...state,
+        selected: state.selected || [],
         columns: cols.map((cell) => ({
           ...cell,
           ...state.columns.find(({ key }) => cell.key === key),
         })),
       };
+    },
+
+    [`${'SELECT_ENTITY'}`]: (state, action) => {
+      let newSelectedState;
+      let id = action.payload.id;
+      if (state?.selected) {
+        if (id === -1) {
+          newSelectedState = [];
+        } else if (Array.isArray(id)) {
+          newSelectedState = id;
+          state.rows.map((item) => {
+            item.selected = true;
+          });
+          return {
+            ...state,
+            selected: newSelectedState,
+          };
+        } else if (!state?.selected.includes(id)) {
+          newSelectedState = [...state.selected, id];
+        } else if (state?.selected.includes(id)) {
+          newSelectedState = [...state.selected.filter((item) => item !== id)];
+        }
+        return {
+          ...state,
+          selected: newSelectedState,
+        };
+      } else {
+        return {
+          state,
+        };
+      }
     },
   });
 }


### PR DESCRIPTION
The new redux bulk Select handeling is included in this PR, and therefor cannot be merged until changes for ADVISOR-2472 are approved.

This PR is in regard to ticket ADVISOR-2388, having the option to go through remediation process with systems that are not remediable (manual remediations). 
This see changes ,
- Run the app against prod DB (only prod has manual remediations_ with CHROME_ENV=prod-stable npm run start:proxy:beta
- navigate to recommendations, and then click pathways
- Click the Update Service Configuration pathway, this is the only known pathway with a manual remediation (if you find another on your account that works too)
- if you click any of the systems, the button will stay disabled as they cannot be remediated automatically.
- However, if you were to find a pathway that had both manual and automatic remediable systems, the button would be clickable as long as at least one of the selected systems can be remediated automatically.
