### PR TITLE
ADVISOR-2472 : bulk Selector refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.8",
         "@reduxjs/toolkit": "1.6.1",
         "@scalprum/react-core": "^0.1.9",
+        "@testing-library/react-hooks": "^8.0.0",
         "classnames": "2.3.1",
         "dot": "1.1.3",
         "marked": "4.0.10",
@@ -4449,6 +4450,35 @@
         "postcss-syntax": ">=0.36.2"
       }
     },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.0.tgz",
+      "integrity": "sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
+        "react-test-renderer": "^16.9.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -4777,9 +4807,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.0.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.12.tgz",
-      "integrity": "sha512-duF1OTASSBQtcigUvhuiTB1Ya3OvSy+xORCiEf20H0P0lzx+/KeVsA99U5UjLXSbyo1DRJDlLKqTeM1ngosqtg==",
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.45.tgz",
+      "integrity": "sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -16425,6 +16455,21 @@
         "react": ">=0.14.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-fast-compare": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
@@ -16484,16 +16529,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-intl/node_modules/@types/react": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.45.tgz",
-      "integrity": "sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/react-is": {
@@ -24081,6 +24116,15 @@
         "unist-util-find-all-after": "^3.0.2"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.0.tgz",
+      "integrity": "sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
+      }
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -24406,9 +24450,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.0.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.12.tgz",
-      "integrity": "sha512-duF1OTASSBQtcigUvhuiTB1Ya3OvSy+xORCiEf20H0P0lzx+/KeVsA99U5UjLXSbyo1DRJDlLKqTeM1ngosqtg==",
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.45.tgz",
+      "integrity": "sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -33149,6 +33193,14 @@
         "prop-types-extra": "^1.1.0"
       }
     },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "react-fast-compare": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
@@ -33185,18 +33237,6 @@
         "hoist-non-react-statics": "^3.3.2",
         "intl-messageformat": "9.9.1",
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@types/react": {
-          "version": "17.0.45",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.45.tgz",
-          "integrity": "sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==",
-          "requires": {
-            "@types/prop-types": "*",
-            "@types/scheduler": "*",
-            "csstype": "^3.0.2"
-          }
-        }
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   "dependencies": {
     "@babel/runtime": "7.15.4",
     "@patternfly/patternfly": "4.183.1",
-    "@patternfly/react-core": "^4.221.3",
     "@patternfly/react-charts": "6.14.17",
+    "@patternfly/react-core": "^4.221.3",
     "@patternfly/react-icons": "^4.72.3",
     "@patternfly/react-table": "^4.90.3",
     "@patternfly/react-tokens": "^4.73.3",
@@ -72,6 +72,7 @@
     "@redhat-cloud-services/frontend-components-utilities": "^3.2.8",
     "@reduxjs/toolkit": "1.6.1",
     "@scalprum/react-core": "^0.1.9",
+    "@testing-library/react-hooks": "^8.0.0",
     "classnames": "2.3.1",
     "dot": "1.1.3",
     "marked": "4.0.10",

--- a/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/__snapshots__/useBulkSelect.test.js.snap
+++ b/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/__snapshots__/useBulkSelect.test.js.snap
@@ -1,0 +1,246 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useBulkSelect returns a bulk select configuration 1`] = `
+Object {
+  "all": Array [
+    Object {
+      "selectNone": [Function],
+      "selectedIds": Array [],
+      "tableProps": Object {
+        "canSelectAll": false,
+        "onSelect": undefined,
+      },
+      "toolbarProps": Object {
+        "bulkSelect": Object {
+          "checked": false,
+          "isDisabled": true,
+          "items": Array [
+            Object {
+              "onClick": [Function],
+              "props": Object {
+                "isDisabled": true,
+              },
+              "title": "Select none",
+            },
+            Object {
+              "onClick": [Function],
+              "title": "Select page (0 items)",
+            },
+            Object {
+              "onClick": [Function],
+              "title": "Unselect all (0 items)",
+            },
+          ],
+          "onSelect": undefined,
+          "toggleProps": Object {
+            "children": Array [
+              "0 selected",
+            ],
+          },
+        },
+      },
+    },
+    Object {
+      "selectNone": [Function],
+      "selectedIds": undefined,
+      "tableProps": Object {
+        "canSelectAll": false,
+        "onSelect": undefined,
+      },
+      "toolbarProps": Object {
+        "bulkSelect": Object {
+          "checked": false,
+          "isDisabled": true,
+          "items": Array [
+            Object {
+              "onClick": [Function],
+              "props": Object {
+                "isDisabled": true,
+              },
+              "title": "Select none",
+            },
+            Object {
+              "onClick": [Function],
+              "title": "Select page (0 items)",
+            },
+            Object {
+              "onClick": [Function],
+              "title": "Unselect all (0 items)",
+            },
+          ],
+          "onSelect": undefined,
+          "toggleProps": Object {
+            "children": Array [
+              "0 selected",
+            ],
+          },
+        },
+      },
+    },
+  ],
+  "current": Object {
+    "selectNone": [Function],
+    "selectedIds": undefined,
+    "tableProps": Object {
+      "canSelectAll": false,
+      "onSelect": undefined,
+    },
+    "toolbarProps": Object {
+      "bulkSelect": Object {
+        "checked": false,
+        "isDisabled": true,
+        "items": Array [
+          Object {
+            "onClick": [Function],
+            "props": Object {
+              "isDisabled": true,
+            },
+            "title": "Select none",
+          },
+          Object {
+            "onClick": [Function],
+            "title": "Select page (0 items)",
+          },
+          Object {
+            "onClick": [Function],
+            "title": "Unselect all (0 items)",
+          },
+        ],
+        "onSelect": undefined,
+        "toggleProps": Object {
+          "children": Array [
+            "0 selected",
+          ],
+        },
+      },
+    },
+  },
+  "error": undefined,
+}
+`;
+
+exports[`useBulkSelect returns a bulk select configuration with the correct options 1`] = `
+Object {
+  "selectNone": [Function],
+  "selectedIds": Array [
+    "ID",
+  ],
+  "tableProps": Object {
+    "canSelectAll": false,
+    "onSelect": [Function],
+  },
+  "toolbarProps": Object {
+    "bulkSelect": Object {
+      "checked": null,
+      "isDisabled": false,
+      "items": Array [
+        Object {
+          "onClick": [Function],
+          "props": Object {
+            "isDisabled": false,
+          },
+          "title": "Select none",
+        },
+        Object {
+          "onClick": [Function],
+          "title": "Select page (2 items)",
+        },
+        Object {
+          "onClick": [Function],
+          "title": "Select all (2 items)",
+        },
+      ],
+      "onSelect": [Function],
+      "toggleProps": Object {
+        "children": Array [
+          "1 selected",
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`useBulkSelect returns a bulk select configuration with the correct options 2`] = `
+Object {
+  "selectNone": [Function],
+  "selectedIds": Array [
+    "ID",
+  ],
+  "tableProps": Object {
+    "canSelectAll": false,
+    "onSelect": [Function],
+  },
+  "toolbarProps": Object {
+    "bulkSelect": Object {
+      "checked": null,
+      "isDisabled": false,
+      "items": Array [
+        Object {
+          "onClick": [Function],
+          "props": Object {
+            "isDisabled": false,
+          },
+          "title": "Select none",
+        },
+        Object {
+          "onClick": [Function],
+          "title": "Select page (2 items)",
+        },
+        Object {
+          "onClick": [Function],
+          "title": "Select all (2 items)",
+        },
+      ],
+      "onSelect": [Function],
+      "toggleProps": Object {
+        "children": Array [
+          "1 selected",
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`useBulkSelect returns a bulk select configuration with the correct options 3`] = `
+Object {
+  "selectNone": [Function],
+  "selectedIds": Array [
+    "ID",
+  ],
+  "tableProps": Object {
+    "canSelectAll": false,
+    "onSelect": [Function],
+  },
+  "toolbarProps": Object {
+    "bulkSelect": Object {
+      "checked": null,
+      "isDisabled": false,
+      "items": Array [
+        Object {
+          "onClick": [Function],
+          "props": Object {
+            "isDisabled": false,
+          },
+          "title": "Select none",
+        },
+        Object {
+          "onClick": [Function],
+          "title": "Unselect page (1 items)",
+        },
+        Object {
+          "onClick": [Function],
+          "title": "Select all (2 items)",
+        },
+      ],
+      "onSelect": [Function],
+      "toggleProps": Object {
+        "children": Array [
+          "1 selected",
+        ],
+      },
+    },
+  },
+}
+`;

--- a/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/helpers.js
+++ b/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/helpers.js
@@ -1,0 +1,42 @@
+export const compileTitle = (itemsTotal, titleOption) => {
+  if (typeof titleOption === 'string') {
+    return titleOption;
+  } else if (typeof titleOption === 'function') {
+    return titleOption(itemsTotal);
+  } else {
+    return `${itemsTotal} selected`;
+  }
+};
+
+export const checkboxState = (selectedItemsTotal, itemsTotal) => {
+  if (selectedItemsTotal === 0) {
+    return false;
+  } else if (selectedItemsTotal === itemsTotal) {
+    return true;
+  } else {
+    return null;
+  }
+};
+
+export const selectOrUnselect = (selected) =>
+  selected ? 'Unselect' : 'Select';
+
+const allItemsIncluded = (items = [], selection = []) =>
+  items?.filter((item) => selection.includes(item)).length === items.length;
+
+export const checkCurrentPageSelected = (items = [], selectedItems = []) => {
+  if (selectedItems.length === 0) {
+    return false;
+  } else {
+    return allItemsIncluded(items, selectedItems);
+  }
+};
+
+export const itemIds = (items) => items.map(({ itemId }) => itemId);
+
+export const selectItemTransformer = (item, selectedIds = []) => ({
+  ...item,
+  rowProps: {
+    selected: selectedIds.includes(item.itemId),
+  },
+});

--- a/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/index.js
+++ b/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/index.js
@@ -1,0 +1,1 @@
+export { default } from './useBulkSelect';

--- a/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/useBulkSelect.js
+++ b/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/useBulkSelect.js
@@ -1,0 +1,126 @@
+import { useEffect } from 'react';
+import useSelectionManager from '../useSelectionManager';
+import {
+  compileTitle,
+  checkboxState,
+  selectOrUnselect,
+  checkCurrentPageSelected,
+} from './helpers';
+
+/**
+ * Provides properties for a Pattternfly (based) Table and Toolbar component to implement bulk selection
+ *
+ * @param {number} [total] Number to show as total count
+ * @param {Function} [onSelect] function to call when a selection is made
+ * @param {Array} [preselected] Array of itemIds selected when initialising
+ * @param {Function} [itemIdsInTable] async function that returns an array of all item ids
+ * @param {Function} [itemIdsOnPage] async function that returns an array of item ids visible on the page
+ * @param {string} [identifies] Prop of the row containing the item ID
+ * @returns {{ selectedIds , selectNone, tableProps }}
+ */
+const useBulkSelect = ({
+  total = 0,
+  onSelect,
+  preselected,
+  itemIdsInTable,
+  itemIdsOnPage,
+  identifier = 'id',
+}) => {
+  const enableBulkSelect = !!onSelect;
+  const {
+    selection: selectedIds,
+    set,
+    select,
+    deselect,
+    clear,
+  } = useSelectionManager(preselected || []);
+  const selectedIdsTotal = (selectedIds || []).length;
+  const idsOnPage = itemIdsOnPage();
+  const paginatedTotal = idsOnPage.length || total;
+  const allSelected = selectedIdsTotal === total;
+  const noneSelected = selectedIdsTotal === 0;
+  const currentPageSelected = checkCurrentPageSelected(idsOnPage, selectedIds);
+
+  const isDisabled = total === 0;
+  const checked = checkboxState(selectedIdsTotal, total);
+  const title = compileTitle(selectedIdsTotal);
+
+  const mergeArraysUniqly = (arrayA, arrayB) =>
+    Array.from(new Set([...arrayA, ...arrayB]));
+
+  const selectOne = (_, selected, _key, row) =>
+    selected ? select(row[identifier]) : deselect(row[identifier]);
+
+  const selectPage = () => {
+    let selectedItems =
+      selectedIds?.length > 0
+        ? mergeArraysUniqly(selectedIds, idsOnPage)
+        : idsOnPage;
+    currentPageSelected
+      ? deselect(idsOnPage)
+      : select(selectedItems, undefined, true);
+  };
+
+  const selectAll = async () => {
+    const items = await itemIdsInTable();
+    if (allSelected) {
+      clear();
+    } else {
+      set(items);
+    }
+  };
+
+  useEffect(() => {
+    set(preselected);
+  }, [JSON.stringify(preselected)]);
+
+  return enableBulkSelect
+    ? {
+        selectedIds,
+        selectNone: () => clear(),
+        tableProps: {
+          onSelect: total > 0 ? selectOne : undefined,
+          canSelectAll: false,
+        },
+        toolbarProps: {
+          bulkSelect: {
+            toggleProps: { children: [title] },
+            isDisabled,
+            items: [
+              {
+                title: 'Select none',
+                onClick: () => clear(),
+                props: {
+                  isDisabled: noneSelected,
+                },
+              },
+              ...(itemIdsOnPage
+                ? [
+                    {
+                      title: `${selectOrUnselect(
+                        currentPageSelected
+                      )} page (${paginatedTotal} items)`,
+                      onClick: selectPage,
+                    },
+                  ]
+                : []),
+              ...(itemIdsInTable
+                ? [
+                    {
+                      title: `${selectOrUnselect(
+                        allSelected
+                      )} all (${total} items)`,
+                      onClick: selectAll,
+                    },
+                  ]
+                : []),
+            ],
+            checked,
+            onSelect: !isDisabled ? selectPage : undefined,
+          },
+        },
+      }
+    : {};
+};
+
+export default useBulkSelect;

--- a/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/useBulkSelect.test.js
+++ b/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/useBulkSelect.test.js
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useBulkSelect from './useBulkSelect';
+
+describe('useBulkSelect', () => {
+  const defaultOptions = {
+    total: 0,
+    onSelect: () => ({}),
+    itemIdsInTable: () => [],
+    itemIdsOnPage: () => [],
+  };
+
+  it('returns a bulk select configuration', () => {
+    const { result } = renderHook(() => useBulkSelect(defaultOptions));
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('returns a bulk select configuration with the correct options', () => {
+    const { result } = renderHook(() =>
+      useBulkSelect({
+        ...defaultOptions,
+        total: 2,
+        preselected: ['ID'],
+        itemIdsInTable: () => {
+          return ['ID', 'ID1'];
+        },
+        itemIdsOnPage: () => ['ID', 'ID1'],
+      })
+    );
+
+    expect(result.current).toMatchSnapshot();
+  });
+
+  it('returns a bulk select configuration with the correct options', () => {
+    const { result } = renderHook(() =>
+      useBulkSelect({
+        ...defaultOptions,
+        total: 2,
+        preselected: ['ID'],
+        itemIdsInTable: () => ['ID', 'ID2'],
+        itemIdsOnPage: () => ['ID', 'ID2'],
+      })
+    );
+
+    expect(result.current).toMatchSnapshot();
+  });
+
+  it('returns a bulk select configuration with the correct options', () => {
+    const { result } = renderHook(() =>
+      useBulkSelect({
+        ...defaultOptions,
+        total: 2,
+        preselected: ['ID'],
+        itemIdsInTable: () => ['ID', 'ID2'],
+        itemIdsOnPage: () => ['ID'],
+      })
+    );
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/src/PresentationalComponents/Inventory/Hooks/useSelectionManager/__snapshots__/useSelectionManager.test.js.snap
+++ b/src/PresentationalComponents/Inventory/Hooks/useSelectionManager/__snapshots__/useSelectionManager.test.js.snap
@@ -1,0 +1,197 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useSelectionManager returns an object with function to manage selections 1`] = `
+Object {
+  "all": Array [
+    Object {
+      "clear": [Function],
+      "deselect": [Function],
+      "reset": [Function],
+      "select": [Function],
+      "selection": Array [],
+      "set": [Function],
+      "toggle": [Function],
+    },
+  ],
+  "current": Object {
+    "clear": [Function],
+    "deselect": [Function],
+    "reset": [Function],
+    "select": [Function],
+    "selection": Array [],
+    "set": [Function],
+    "toggle": [Function],
+  },
+  "error": undefined,
+}
+`;
+
+exports[`useSelectionManager withGroups true adds an item from the selection when calling select 1`] = `
+Object {
+  "clear": [Function],
+  "deselect": [Function],
+  "reset": [Function],
+  "select": [Function],
+  "selection": Object {
+    "group1": Array [
+      1,
+      2,
+      3,
+      4,
+    ],
+    "group2": Array [
+      42,
+      12,
+      23,
+      34,
+      45,
+    ],
+  },
+  "set": [Function],
+  "toggle": [Function],
+}
+`;
+
+exports[`useSelectionManager withGroups true removes an item from the selection when calling deselect 1`] = `
+Object {
+  "clear": [Function],
+  "deselect": [Function],
+  "reset": [Function],
+  "select": [Function],
+  "selection": Object {
+    "group1": Array [
+      1,
+      3,
+      4,
+    ],
+    "group2": Array [
+      12,
+      23,
+      34,
+      45,
+    ],
+  },
+  "set": [Function],
+  "toggle": [Function],
+}
+`;
+
+exports[`useSelectionManager withGroups true returns an object with function to manage selections with groups 1`] = `
+Object {
+  "clear": [Function],
+  "deselect": [Function],
+  "reset": [Function],
+  "select": [Function],
+  "selection": Object {
+    "group1": Array [
+      1,
+      2,
+      3,
+      4,
+    ],
+    "group2": Array [
+      12,
+      23,
+      34,
+      45,
+    ],
+  },
+  "set": [Function],
+  "toggle": [Function],
+}
+`;
+
+exports[`useSelectionManager withGroups true sets items for a selection when calling set 1`] = `
+Object {
+  "clear": [Function],
+  "deselect": [Function],
+  "reset": [Function],
+  "select": [Function],
+  "selection": Object {
+    "group1": Array [
+      0,
+      9,
+      8,
+      45,
+      3,
+    ],
+    "group2": Array [
+      12,
+      23,
+      34,
+      45,
+    ],
+  },
+  "set": [Function],
+  "toggle": [Function],
+}
+`;
+
+exports[`useSelectionManager withGroups: false adds an item from the selection when calling select 1`] = `
+Object {
+  "clear": [Function],
+  "deselect": [Function],
+  "reset": [Function],
+  "select": [Function],
+  "selection": Array [
+    42,
+    1,
+    2,
+    3,
+    4,
+  ],
+  "set": [Function],
+  "toggle": [Function],
+}
+`;
+
+exports[`useSelectionManager withGroups: false removes an item from the selection when calling deselect 1`] = `
+Object {
+  "clear": [Function],
+  "deselect": [Function],
+  "reset": [Function],
+  "select": [Function],
+  "selection": Array [
+    1,
+    2,
+    4,
+  ],
+  "set": [Function],
+  "toggle": [Function],
+}
+`;
+
+exports[`useSelectionManager withGroups: false returns an object with function to manage selections wihtout groups 1`] = `
+Object {
+  "clear": [Function],
+  "deselect": [Function],
+  "reset": [Function],
+  "select": [Function],
+  "selection": Array [
+    1,
+    2,
+    3,
+    4,
+  ],
+  "set": [Function],
+  "toggle": [Function],
+}
+`;
+
+exports[`useSelectionManager withGroups: false sets items for a selection when calling set 1`] = `
+Object {
+  "clear": [Function],
+  "deselect": [Function],
+  "reset": [Function],
+  "select": [Function],
+  "selection": Array [
+    0,
+    9,
+    8,
+    45,
+    3,
+  ],
+  "set": [Function],
+  "toggle": [Function],
+}
+`;

--- a/src/PresentationalComponents/Inventory/Hooks/useSelectionManager/index.js
+++ b/src/PresentationalComponents/Inventory/Hooks/useSelectionManager/index.js
@@ -1,0 +1,1 @@
+export { default } from './useSelectionManager';

--- a/src/PresentationalComponents/Inventory/Hooks/useSelectionManager/reducer.js
+++ b/src/PresentationalComponents/Inventory/Hooks/useSelectionManager/reducer.js
@@ -1,0 +1,72 @@
+import isObject from 'lodash/isObject';
+import uniq from 'lodash/uniq';
+
+const selectionGroup = (action) => action.group || 'default';
+
+export const init = (withGroups) => (preselected) =>
+  withGroups ? preselected || {} : { default: preselected || [] };
+
+const cleanEmpty = (state) => {
+  const newState = state;
+  Object.entries(state).forEach(([key, value]) => {
+    if (value === undefined) {
+      delete newState[key];
+    }
+  });
+  return newState;
+};
+
+const set = (state = {}, action) => {
+  const group = selectionGroup(action);
+  return cleanEmpty({
+    ...state,
+    [group]:
+      action.items?.length > 0 || isObject(action.items)
+        ? action.items
+        : undefined,
+  });
+};
+
+const select = (state = {}, action) => {
+  const group = selectionGroup(action);
+  return cleanEmpty({
+    ...state,
+    [group]: action.reset
+      ? action?.items
+      : uniq([action?.item, ...(state[group] || [])]),
+  });
+};
+
+const deselect = (state = {}, action) => {
+  const group = selectionGroup(action);
+  const items = (state[group] || []).filter(
+    (selectedItem) => !action.item.includes(selectedItem)
+  );
+  return cleanEmpty({
+    ...state,
+    [group]: items.length === 0 ? undefined : items,
+  });
+};
+
+const toggle = (state, action) => {
+  const group = selectionGroup(action);
+  // eslint-disable-next-line prettier/prettier
+  return (state[group] || []).includes(action.item) ? deselect(state, action) : select(state, action);
+};
+
+const reset = (state, action) =>
+  init(Object.prototype.hasOwnProperty.call(!state, 'default'))(
+    action?.preselected
+  );
+const clear = (state) =>
+  init(Object.prototype.hasOwnProperty.call(!state, 'default'))();
+
+export default (state, action) =>
+  ({
+    set,
+    select,
+    deselect,
+    toggle,
+    reset,
+    clear,
+  }[action.type](state, action));

--- a/src/PresentationalComponents/Inventory/Hooks/useSelectionManager/useSelectionManager.js
+++ b/src/PresentationalComponents/Inventory/Hooks/useSelectionManager/useSelectionManager.js
@@ -1,0 +1,43 @@
+import { useReducer } from 'react';
+import reducer, { init as initReducer } from './reducer';
+
+/**
+ * Provides a generic API to manage selection stats of one (default) or multiple groups of selections.
+ *
+ * @param {Array} preselected Array of items initially selected
+ * @param {Object} [options] function to call when a selection is made
+ */
+const useSelectionManager = (preselected, options = {}) => {
+  const { withGroups = false } = options;
+  const [selection, dispatch] = useReducer(
+    reducer,
+    preselected,
+    initReducer(withGroups)
+  );
+
+  const set = (items, group) => dispatch({ type: 'set', group, items });
+
+  const select = (item, group, useSet = false) =>
+    useSet ? set(item, group) : dispatch({ type: 'select', group, item });
+
+  const deselect = (item, group, useSet = false) =>
+    useSet ? set(item, group) : dispatch({ type: 'deselect', group, item });
+
+  const toggle = (item, group) => dispatch({ type: 'toggle', group, item });
+
+  const reset = () => dispatch({ type: 'reset', preselected });
+
+  const clear = () => dispatch({ type: 'clear' });
+
+  return {
+    set,
+    select,
+    deselect,
+    toggle,
+    reset,
+    clear,
+    selection: withGroups ? selection : selection.default,
+  };
+};
+
+export default useSelectionManager;

--- a/src/PresentationalComponents/Inventory/Hooks/useSelectionManager/useSelectionManager.test.js
+++ b/src/PresentationalComponents/Inventory/Hooks/useSelectionManager/useSelectionManager.test.js
@@ -1,0 +1,106 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import useSelectionManager from './useSelectionManager';
+
+describe('useSelectionManager', () => {
+  it('returns an object with function to manage selections', () => {
+    const { result } = renderHook(() => useSelectionManager());
+    expect(result).toMatchSnapshot();
+  });
+
+  describe('withGroups: false', () => {
+    const defaultArguments = [[1, 2, 3, 4]];
+
+    it('returns an object with function to manage selections wihtout groups', () => {
+      const { result } = renderHook(() =>
+        useSelectionManager(...defaultArguments)
+      );
+      expect(result.current.selection).toEqual(defaultArguments[0]);
+      expect(result.current).toMatchSnapshot();
+    });
+
+    it('adds an item from the selection when calling select', () => {
+      const { result } = renderHook(() =>
+        useSelectionManager(...defaultArguments)
+      );
+
+      act(() => {
+        result.current.select(42);
+      });
+
+      expect(result.current).toMatchSnapshot();
+    });
+
+    it('removes an item from the selection when calling deselect', () => {
+      const { result } = renderHook(() =>
+        useSelectionManager(...defaultArguments)
+      );
+
+      act(() => {
+        result.current.deselect([3]);
+      });
+
+      expect(result.current).toMatchSnapshot();
+    });
+
+    it('sets items for a selection when calling set', () => {
+      const { result } = renderHook(() =>
+        useSelectionManager(...defaultArguments)
+      );
+
+      act(() => {
+        result.current.set([0, 9, 8, 45, 3]);
+      });
+
+      expect(result.current).toMatchSnapshot();
+    });
+  });
+
+  describe('withGroups true', () => {
+    const defaultArguments = [
+      { group1: [1, 2, 3, 4], group2: [12, 23, 34, 45] },
+      { withGroups: true },
+    ];
+
+    it('returns an object with function to manage selections with groups', () => {
+      const { result } = renderHook(() =>
+        useSelectionManager(...defaultArguments)
+      );
+      expect(result.current).toMatchSnapshot();
+    });
+
+    it('adds an item from the selection when calling select', () => {
+      const { result } = renderHook(() =>
+        useSelectionManager(...defaultArguments)
+      );
+
+      act(() => {
+        result.current.select(42, 'group2');
+      });
+
+      expect(result.current).toMatchSnapshot();
+    });
+
+    it('removes an item from the selection when calling deselect', () => {
+      const { result } = renderHook(() =>
+        useSelectionManager(...defaultArguments)
+      );
+      act(() => {
+        result.current.deselect([2], 'group1');
+      });
+
+      expect(result.current).toMatchSnapshot();
+    });
+
+    it('sets items for a selection when calling set', () => {
+      const { result } = renderHook(() =>
+        useSelectionManager(...defaultArguments)
+      );
+
+      act(() => {
+        result.current.set([0, 9, 8, 45, 3], 'group1');
+      });
+
+      expect(result.current).toMatchSnapshot();
+    });
+  });
+});

--- a/src/Store/AppReducer.js
+++ b/src/Store/AppReducer.js
@@ -17,6 +17,10 @@ export function systemReducer(cols, INVENTORY_ACTION_TYPES) {
         })),
       };
     },
+    ['SELECT_ENTITIES']: (state, { payload: { selected } }) => ({
+      ...state,
+      rows: selectRows(state.rows, selected),
+    }),
   });
 }
 
@@ -36,3 +40,9 @@ function enableApplications(state) {
     activeApps: [{ title: 'Insights', name: 'insights', component: Advisor }],
   };
 }
+
+const selectRows = (rows, selected = []) =>
+  (rows || []).map((row) => ({
+    ...row,
+    selected: selected.includes(row.id),
+  }));


### PR DESCRIPTION
This change fixes the issues regarding the bulk selector in advisor pathway details page.
Right now, when trying to view more systems, all selected items are cleared. To replicate

Click recommendations in the left menu,
Selected pathways tab
Select a pathway
Click systems tab
Select a system or two
Press a new page (look at the pagination button, select the '>' button the view items 20-40 as opposed to 1-20.
Old Behavior: selected is clear

New Behavior: When moving pages , state is carried across. Also if you do a select all and then deselect 1 item, it doesnt switch to (pagesize -1), it instead does (total Systems -1)

With this change state is carried around properly, and ADVISOR-2388 can be worked on more easily as selected items are managed/updated properly.