### PR TITLE
fix: Don't override onError for IntlProvider wrapper component

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -10,11 +10,7 @@ import { getStore } from './Store';
 import messages from '../locales/data.json';
 
 const AppEntry = () => (
-  <IntlProvider
-    locale={navigator.language.slice(0, 2)}
-    messages={messages}
-    onError={console.log}
-  >
+  <IntlProvider locale={navigator.language.slice(0, 2)} messages={messages}>
     <Provider store={getStore()}>
       <Router basename={getBaseName(window.location.pathname)}>
         <NotificationsPortal />


### PR DESCRIPTION
If the format.js translations were not found, Advisor would log errors in production. Removing the line sets the behavior to default: https://formatjs.io/docs/react-intl/components/#onerror and will make errors appear only if `NODE_ENV` is not set to `production`.