### PR TITLE
fix for advisor tags on systems page

### DIFF
--- a/src/Services/Filters.js
+++ b/src/Services/Filters.js
@@ -14,7 +14,7 @@ const filtersInitialState = {
     offset: 0,
   },
   sysState: { sort: '-last_seen', limit: 20, offset: 0 },
-  selectedTags: null,
+  selectedTags: [],
   workloads: {},
   SID: [],
 };


### PR DESCRIPTION
On page load for Systems tab in advisor, the tags were sent as an empty object and the api was getting angry. The tags were set to null at first. This fixes selectedTags and now you can add/remove tag filters and you can load the systems page in advisor. Currently a problem in stage env. 