### PR TITLE
BulkSelector Refactor completion

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -1,19 +1,11 @@
 import './_Inventory.scss';
 
-import {
-  BASE_URL,
-  RULES_FETCH_URL,
-  SYSTEMS_FETCH_URL,
-} from '../../AppConstants';
+import { BASE_URL } from '../../AppConstants';
 import React, { useEffect, useState } from 'react';
 import { TableVariant, sortable, wrappable } from '@patternfly/react-table';
-import {
-  pruneFilters,
-  urlBuilder,
-  workloadQueryBuilder,
-  buildTagFilter,
-} from '../Common/Tables';
+import { pruneFilters, urlBuilder } from '../Common/Tables';
 import { useDispatch, useSelector, useStore } from 'react-redux';
+import { getEntities, allCurrentSystemIds } from './helper';
 
 import DisableRule from '../../PresentationalComponents/Modals/DisableRule';
 import { Get } from '../../Utilities/Api';
@@ -22,7 +14,6 @@ import Loading from '../Loading/Loading';
 import PropTypes from 'prop-types';
 import RemediationButton from '@redhat-cloud-services/frontend-components-remediations/RemediationButton';
 import { SYSTEM_FILTER_CATEGORIES as SFC } from '../../AppConstants';
-import { mergeArraysByDiffKeys } from '../Common/Tables';
 import messages from '../../Messages';
 import { addNotification as notification } from '@redhat-cloud-services/frontend-components-notifications/';
 import { systemReducer } from '../../Store/AppReducer';
@@ -52,8 +43,10 @@ const Inventory = ({
     sort: '-last_seen',
     name: '',
   });
+  const [fullFilters, setFullFilters] = useState();
   const [total, setTotal] = useState(0);
   const entities = useSelector(({ entities }) => entities || {});
+
   const addNotification = (data) => dispatch(notification(data));
   const [disableRuleModalOpen, setDisableRuleModalOpen] = useState(false);
   const [curPageIds, setCurPageIds] = useState([]);
@@ -64,26 +57,21 @@ const Inventory = ({
   const [isRemediationButtonDisabled, setIsRemediationButtonDisabled] =
     useState(true);
 
-  const fetchAllSystems = async () => {
-    const allSystems = pathway
-      ? (
-          await Get(
-            `${SYSTEMS_FETCH_URL}`,
-            {},
-            {
-              pathway: pathway.slug,
-              limit: pathway.impacted_systems_count,
-            }
-          )
-        )?.data?.data?.map((system) => system.system_uuid)
-      : (
-          await Get(
-            `${RULES_FETCH_URL}${encodeURI(rule.rule_id)}/systems/`,
-            {},
-            { name: filters.name }
-          )
-        )?.data?.host_ids;
-    return allSystems;
+  const handleRefresh = (options) => {
+    /* Rec table doesn't use the same sorting params as sys table, switching between the two results in the rec table blowing up cuz its trying to
+    read the endpoint with incorrect sorting params, if we hold of on updating the sysable url params when using the this component in pathways, it
+    solves this issue for the time being*/
+    const { name, display_name } = options;
+    const refreshedFilters = {
+      ...options,
+      ...(name && {
+        name,
+      }),
+      ...(display_name && {
+        display_name,
+      }),
+    };
+    !pathway && urlBuilder(refreshedFilters, selectedTags);
   };
 
   const grabPageIds = () => {
@@ -98,10 +86,20 @@ const Inventory = ({
   } = useBulkSelect({
     total,
     onSelect: () => {},
-    itemIdsInTable: fetchAllSystems,
+    itemIdsInTable: allCurrentSystemIds(fullFilters, total, rule),
     itemIdsOnPage: grabPageIds,
     identitfier: 'system_uuid',
   });
+
+  const fetchSystems = getEntities(
+    handleRefresh,
+    pathway,
+    setCurPageIds,
+    setTotal,
+    selectedIds,
+    setFullFilters,
+    fullFilters
+  );
 
   // Ensures rows are marked as selected
   useEffect(() => {
@@ -276,22 +274,6 @@ const Inventory = ({
     return [displayName, tags, systemProfile, lastSeenColumn];
   };
 
-  const handleRefresh = (options) => {
-    /* Rec table doesn't use the same sorting params as sys table, switching between the two results in the rec table blowing up cuz its trying to
-    read the endpoint with incorrect sorting params, if we hold of on updating the sysable url params when using the this component in pathways, it
-    solves this issue for the time being*/
-    const { name, display_name } = options;
-    const refreshedFilters = {
-      ...options,
-      ...(name && {
-        name,
-      }),
-      ...(display_name && {
-        display_name,
-      }),
-    };
-    !pathway && urlBuilder(refreshedFilters, selectedTags);
-  };
   const removeFilterParam = (param) => {
     const filter = { ...filters, offset: 0 };
     delete filter[param];
@@ -387,90 +369,7 @@ const Inventory = ({
           SID,
         }}
         showTags={showTags}
-        getEntities={async (_items, config, showTags, defaultGetEntities) => {
-          const {
-            per_page,
-            page,
-            orderBy,
-            orderDirection,
-            advisorFilters,
-            filters,
-            workloads,
-            SID,
-          } = config;
-          const sort = `${orderDirection === 'ASC' ? '' : '-'}${
-            orderBy === 'updated' ? 'last_seen' : orderBy
-          }`;
-          let options = {
-            ...advisorFilters,
-            limit: per_page,
-            offset: page * per_page - per_page,
-            sort,
-            ...(config.filters.hostnameOrId &&
-              !pathway && {
-                name: config?.filters?.hostnameOrId,
-              }),
-            ...(config.filters.hostnameOrId &&
-              pathway && {
-                display_name: config?.filters?.hostnameOrId,
-              }),
-            ...(Array.isArray(advisorFilters.rhel_version) && {
-              rhel_version: advisorFilters.rhel_version?.join(','),
-            }),
-            ...(filters.tagFilters?.length &&
-              buildTagFilter(filters.tagFilters)),
-          };
-
-          workloads &&
-            (options = { ...options, ...workloadQueryBuilder(workloads, SID) });
-
-          handleRefresh(options);
-
-          const fetchedSystems = pathway
-            ? (
-                await Get(
-                  `${SYSTEMS_FETCH_URL}`,
-                  {},
-                  { ...options, pathway: pathway.slug }
-                )
-              )?.data
-            : (
-                await Get(
-                  `${RULES_FETCH_URL}${encodeURI(
-                    rule.rule_id
-                  )}/systems_detail/`,
-                  {},
-                  options
-                )
-              )?.data;
-
-          const results = await defaultGetEntities(
-            fetchedSystems.data.map((system) => system.system_uuid),
-            {
-              page,
-              per_page,
-              hasItems: true,
-              fields: { system_profile: ['operating_system'] },
-            },
-            showTags
-          );
-          setCurPageIds(
-            fetchedSystems.data.map((system) => system.system_uuid)
-          );
-          setTotal(fetchedSystems.meta.count);
-          return Promise.resolve({
-            results: mergeArraysByDiffKeys(
-              fetchedSystems.data,
-              results.results
-            ).map((item) => {
-              return {
-                ...item,
-                selected: selectedIds?.includes(item.id),
-              };
-            }),
-            total: fetchedSystems.meta.count,
-          });
-        }}
+        getEntities={fetchSystems}
         dedicatedAction={
           <RemediationButton
             key="remediation-button"

--- a/src/PresentationalComponents/Inventory/helper.js
+++ b/src/PresentationalComponents/Inventory/helper.js
@@ -1,0 +1,149 @@
+import { workloadQueryBuilder, buildTagFilter } from '../Common/Tables';
+import { Get } from '../../Utilities/Api';
+import { mergeArraysByDiffKeys } from '../Common/Tables';
+
+import { RULES_FETCH_URL, SYSTEMS_FETCH_URL } from '../../AppConstants';
+
+/*This functions purpose is to grab the currently set filters, and return all associated systems for it.*/
+export const paginatedRequestHelper = async ({
+  per_page,
+  page,
+  advisorFilters,
+  filters,
+  workloads,
+  SID,
+  sort,
+  pathway,
+  rule,
+}) => {
+  let options = {
+    ...advisorFilters,
+    limit: per_page,
+    offset: page * per_page - per_page,
+    sort,
+    ...(filters?.hostnameOrId &&
+      !pathway && {
+        name: filters?.hostnameOrId,
+      }),
+    ...(filters.hostnameOrId &&
+      pathway && {
+        display_name: filters?.hostnameOrId,
+      }),
+    ...(Array.isArray(advisorFilters.rhel_version) && {
+      rhel_version: advisorFilters.rhel_version?.join(','),
+    }),
+    ...(filters.tagFilters?.length && buildTagFilter(filters.tagFilters)),
+  };
+
+  workloads &&
+    (options = { ...options, ...workloadQueryBuilder(workloads, SID) });
+
+  return pathway
+    ? (
+        await Get(
+          `${SYSTEMS_FETCH_URL}`,
+          {},
+          { ...options, pathway: pathway.slug }
+        )
+      )?.data
+    : (
+        await Get(
+          `${RULES_FETCH_URL}${encodeURI(rule.rule_id)}/systems_detail/`,
+          {},
+          options
+        )
+      )?.data;
+};
+
+export const getEntities =
+  (
+    handleRefresh,
+    pathway,
+    setCurPageIds,
+    setTotal,
+    selectedIds,
+    setFullFilters
+  ) =>
+  async (_items, config, showTags, defaultGetEntities) => {
+    const {
+      per_page,
+      page,
+      orderBy,
+      orderDirection,
+      advisorFilters,
+      filters,
+      workloads,
+      SID,
+    } = config;
+    const sort = `${orderDirection === 'ASC' ? '' : '-'}${
+      orderBy === 'updated' ? 'last_seen' : orderBy
+    }`;
+    let options = {
+      ...advisorFilters,
+      limit: per_page,
+      offset: page * per_page - per_page,
+      sort,
+      ...(config?.filters?.hostnameOrId &&
+        !pathway && {
+          name: config?.filters?.hostnameOrId,
+        }),
+      ...(config.filters.hostnameOrId &&
+        pathway && {
+          display_name: config?.filters?.hostnameOrId,
+        }),
+      ...(Array.isArray(advisorFilters.rhel_version) && {
+        rhel_version: advisorFilters.rhel_version?.join(','),
+      }),
+      ...(filters.tagFilters?.length && buildTagFilter(filters.tagFilters)),
+    };
+
+    workloads &&
+      (options = { ...options, ...workloadQueryBuilder(workloads, SID) });
+
+    handleRefresh(options);
+    const allDetails = { ...config, pathway, handleRefresh };
+    setFullFilters(allDetails);
+    const fetchedSystems = await paginatedRequestHelper(allDetails);
+    const results = await defaultGetEntities(
+      fetchedSystems.data.map((system) => system.system_uuid),
+      {
+        page,
+        per_page,
+        hasItems: true,
+        fields: { system_profile: ['operating_system'] },
+      },
+      showTags
+    );
+    setCurPageIds(fetchedSystems.data.map((system) => system.system_uuid));
+    setTotal(fetchedSystems.meta.count);
+    return Promise.resolve({
+      results: mergeArraysByDiffKeys(fetchedSystems.data, results.results).map(
+        (item) => {
+          return {
+            ...item,
+            selected: selectedIds?.includes(item.id),
+          };
+        }
+      ),
+      total: fetchedSystems.meta.count,
+    });
+  };
+
+/*Takes in the current filters, and keeps sending get request until there are no pages left*/
+const fetchBatched = (fetchFunction, total, filter, batchSize = 100, rule) => {
+  const pages = Math.ceil(total / batchSize) || 1;
+  return Promise.all(
+    [...new Array(pages)].map((_, pageIdx) =>
+      fetchFunction({ ...filter, page: pageIdx + 1, per_page: batchSize, rule })
+    )
+  );
+};
+/*Grabs all systemIds and maniupaltes the data into one large array of systems*/
+export const allCurrentSystemIds = (fullFilters, total, rule) => async () => {
+  const results = await (
+    await fetchBatched(paginatedRequestHelper, total, fullFilters, 100, rule)
+  ).map((item) => item.data);
+
+  const merged = [].concat.apply([], results).map((item) => item.system_uuid);
+  return merged;
+};


### PR DESCRIPTION
With this PR bulk selector refactor is completed. When pressing the 'Select All' option in the dropdown, it will select all systems associated with the currently set filters. So if you were to filter down to 400 systems (starting with lets say 2,000), when pressing selectAll, it will making paginated calls to the api and select the 400 systems as opposed to the 2,000.

To test

Navigate to advisor recommendations in Beta Env,

Select a pathway with alot of systems (you can click the systems affected link)

With the systems tab selected, press select all in the bulk selector and it will select every system - old behavior was it selected 1000

Then deselect all

Filter down the total systems (type in 'rhiq' and it should filter out something like 50 systems if testing in Insights-qa account)

Press selectAll in bulk Selector

All filtered down results are selected as opposed to all systems associated with the pathway