### PR TITLE
[RHCLOUD-19380] Update template to use chrome path

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -16,7 +16,7 @@ objects:
           - v1
       frontend:
         paths:
-          - /insights/advisor
+          - /apps/advisor
       image: ${IMAGE}:${IMAGE_TAG}
       navItems:
         - title: "Advisor"


### PR DESCRIPTION
The template should be using `apps/` for chrome to correctly handle routing. `/insights/*`  is handled via the `routes` in the module field.