### PR TITLE
fix: ADVISOR-2569 - Handle empty KCS article node_id value

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -475,7 +475,11 @@ const RulesTable = () => {
                         isDetailsPage={false}
                         showViewAffected
                         linkComponent={Link}
-                        knowledgebaseUrl={`https://access.redhat.com/node/${value.node_id}`}
+                        knowledgebaseUrl={
+                          value.node_id
+                            ? `https://access.redhat.com/node/${value.node_id}`
+                            : ''
+                        }
                       />
                     </Stack>
                   </Main>

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -261,7 +261,11 @@ const OverviewDetails = () => {
                   { rule: ruleId, rating: calculatedRating }
                 );
               }}
-              knowledgebaseUrl={`https://access.redhat.com/node/${rule.node_id}`}
+              knowledgebaseUrl={
+                rule.node_id
+                  ? `https://access.redhat.com/node/${rule.node_id}`
+                  : ''
+              }
               linkComponent={Link}
             >
               <Flex>


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/ADVISOR-2569

A rule doesn't always have a KCS article associated with it, in which case node_id will be blank.  This PR handles that situation.