### PR TITLE
ADVISOR-2289 Refresh Bug 

### DIFF
--- a/src/SmartComponents/Recs/DetailsPathways.js
+++ b/src/SmartComponents/Recs/DetailsPathways.js
@@ -170,8 +170,6 @@ const PathwayDetails = () => {
       <Main>
         <Tabs
           className="adv__background--global-100"
-          mountOnEnter
-          unmountOnExit
           activeKey={activeTab}
           onSelect={(_e, tab) => setActiveTab(tab)}
         >

--- a/src/SmartComponents/Recs/List.js
+++ b/src/SmartComponents/Recs/List.js
@@ -79,8 +79,6 @@ const List = () => {
             </Suspense>
             <Tabs
               className="adv__background--global-100"
-              mountOnEnter
-              unmountOnExit
               activeKey={activeTab}
               onSelect={(_e, tab) => changeTab(tab)}
             >

--- a/src/SmartComponents/Recs/Recs.js
+++ b/src/SmartComponents/Recs/Recs.js
@@ -19,54 +19,92 @@ const ClassicRedirect = lazy(() =>
   import(/* webpackChunkName: "ClassicRedirect" */ '../Common/ClassicRedirect')
 );
 
-const suspenseHelper = (component) => (
-  <Suspense fallback={<Loading />}>{component}</Suspense>
+// eslint-disable-next-line react/prop-types
+const SuspenseHelper = ({ children }) => (
+  <Suspense fallback={<Loading />}>{children}</Suspense>
 );
+
 const Recs = () => (
   <React.Fragment>
     <Switch>
       <Route
         exact
         path="/recommendations"
-        component={() => suspenseHelper(<List />)}
+        component={() => (
+          <SuspenseHelper>
+            <List />
+          </SuspenseHelper>
+        )}
       />
       <Route
         exact
         path="/recommendations/by_id/:id"
-        component={() => suspenseHelper(<List />)}
+        component={() => (
+          <SuspenseHelper>
+            <List />
+          </SuspenseHelper>
+        )}
       />
       <Route
         exact
         path="/recommendations/pathways"
-        component={() => suspenseHelper(<List />)}
+        component={() => (
+          <SuspenseHelper>
+            <List />
+          </SuspenseHelper>
+        )}
       />
       <Route
         exact
         path="/recommendations/pathways/:id"
-        component={() => suspenseHelper(<DetailsPathways />)}
+        component={() => (
+          <SuspenseHelper>
+            <DetailsPathways />
+          </SuspenseHelper>
+        )}
       />
       <Route
         exact
         path="/recommendations/pathways/systems/:id"
-        component={() => suspenseHelper(<DetailsPathways />)}
+        component={() => (
+          <SuspenseHelper>
+            <DetailsPathways />
+          </SuspenseHelper>
+        )}
       />
       <Route
         exact
         path="/recommendations/:id"
-        component={() => suspenseHelper(<Details />)}
+        component={() => (
+          <SuspenseHelper>
+            <Details />
+          </SuspenseHelper>
+        )}
       />
       <Route
         exact
         path="/recommendations/classic/:id/:classicId/"
-        component={() => suspenseHelper(<ClassicRedirect />)}
+        component={() => (
+          <SuspenseHelper>
+            <ClassicRedirect />
+          </SuspenseHelper>
+        )}
       />
       <Route
         path="/recommendations/by_id/:id/:inventoryId/"
-        component={() => suspenseHelper(<InventoryDetails />)}
+        component={() => (
+          <SuspenseHelper>
+            <InventoryDetails />
+          </SuspenseHelper>
+        )}
       />
       <Route
         path="/recommendations/:id/:inventoryId/"
-        component={() => suspenseHelper(<InventoryDetails />)}
+        component={() => (
+          <SuspenseHelper>
+            <InventoryDetails />{' '}
+          </SuspenseHelper>
+        )}
       />
       <Redirect path="*" to="/recommendations" push />
     </Switch>


### PR DESCRIPTION
These changes are to make headway against the refresh bug. It seems to be having a different result on some set ups so I want to test with more people. To test this PR

- run advisor with npm run start:proxy:beta
- Select the systems affected link (or click a pathway, and then hit the systems tab)
- select systems
- select the remediate button
- type something inside the input 'create a playbook'

Monitor to see if the data gets refresh/wiped. Ideally with this PR the data is never wiped and the 'removeQueryResult' redux call is never called