### PR TITLE
ADVISOR-2113 recommendation sorting

### DIFF
--- a/src/PresentationalComponents/PathwaysTable/PathwaysTable.js
+++ b/src/PresentationalComponents/PathwaysTable/PathwaysTable.js
@@ -87,7 +87,7 @@ const PathwaysTable = () => {
     {
       title: intl.formatMessage(messages.reclvl),
       transforms: [
-        // sortable,
+        sortable,
         cellWidth(20),
         fitContent,
         info({
@@ -104,7 +104,7 @@ const PathwaysTable = () => {
     // 1: 'category',
     2: 'impacted_systems_count',
     // 3: 'reboot_required',
-    // 4: 'recommendation_level',
+    4: 'recommendation_level',
   };
   const [sortBy, setSortBy] = useState({});
   const [filterBuilding, setFilterBuilding] = useState(true);


### PR DESCRIPTION
Backend now supports sorting via recommendation, this PR implements that change on the front end.

To test, run advisor in beta env
 - head over to https://stage.foo.redhat.com:1337/beta/insights/advisor/recommendations/pathways
 - click recommendation level to see it sort for low to high
 - click again to see it sort from high to low
