### PR TITLE
Fix resolution bug

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -74,6 +74,11 @@ export default defineMessages({
     description: 'Maunal table cell text',
     defaultMessage: 'Manual',
   },
+  notAvailable: {
+    id: 'notAvailable',
+    description: 'Not availabl table cell text',
+    defaultMessage: 'N/A',
+  },
   rulesTableHideReportsErrorEnabled: {
     id: 'rulestable.hidereports.errorenabling',
     description:

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -82,11 +82,11 @@ const BaseSystemAdvisor = () => {
   const hideResultsSatelliteManaged = !satelliteShowHosts && satelliteManaged;
   const getSelectedItems = (rows) => rows.filter((entity) => entity.selected);
   const selectedAnsibleRules = getSelectedItems(rows).filter(
-    (r) => r.resolution && r.resolution.has_playbook
+    (r) => r.resolution && r.resolution?.has_playbook
   );
   const selectedItemsLength = getSelectedItems(rows).length;
   const selectableItemsLength = rows.filter(
-    (r) => r.resolution && r.resolution.has_playbook
+    (r) => r.resolution && r.resolution?.has_playbook
   ).length;
 
   const cols = [
@@ -185,14 +185,14 @@ const BaseSystemAdvisor = () => {
       const match = rows.find((row) => row?.rule?.rule_id === rule.rule_id);
       const selected = match?.selected;
       const isOpen = match?.isOpen || false;
-
       const reportRow = [
         {
           rule,
           resolution,
-          isOpen,
+          //make arrow button disappear when there is no resolution
+          isOpen: resolution ? isOpen : undefined,
           selected,
-          disableSelection: !resolution.has_playbook,
+          disableSelection: resolution ? !resolution.has_playbook : true,
           cells: [
             {
               title: (
@@ -235,7 +235,9 @@ const BaseSystemAdvisor = () => {
             {
               title: (
                 <div className="ins-c-center-text" key={key}>
-                  {resolution.has_playbook ? (
+                  {resolution === null ? (
+                    intl.formatMessage(messages.notAvailable)
+                  ) : resolution?.has_playbook ? (
                     <span>
                       <AnsibeTowerIcon size="sm" />{' '}
                       {intl.formatMessage(messages.playbook)}
@@ -248,7 +250,7 @@ const BaseSystemAdvisor = () => {
             },
           ],
         },
-        {
+        resolution && {
           parent: key,
           fullWidth: true,
           cells: [
@@ -277,7 +279,7 @@ const BaseSystemAdvisor = () => {
           .map((key) => {
             const filterValues = filters[key];
             const rowValue = {
-              has_playbook: value.resolution.has_playbook,
+              has_playbook: value.resolution?.has_playbook,
               publish_date: rule.publish_date,
               total_risk: rule.total_risk,
               category: RULE_CATEGORIES[rule.category.name.toLowerCase()],
@@ -288,14 +290,16 @@ const BaseSystemAdvisor = () => {
           })
           .every((x) => x);
 
-      return isValidSearchValue && isValidFilterValue ? reportRow : [];
+      return isValidSearchValue && isValidFilterValue
+        ? reportRow.filter((row) => row !== null)
+        : [];
     });
     //must recalculate parent for expandable table content whenever the array size changes
     builtRows.forEach((row, index) =>
       row.parent ? (row.parent = index - 1) : null
     );
 
-    systemAdvisorRef.current.rowCount = builtRows.length / 2;
+    systemAdvisorRef.current.rowCount = activeReports.length;
 
     if (activeReports.length < 1 || builtRows.length < 1) {
       let EmptyState =

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -82,11 +82,11 @@ const BaseSystemAdvisor = () => {
   const hideResultsSatelliteManaged = !satelliteShowHosts && satelliteManaged;
   const getSelectedItems = (rows) => rows.filter((entity) => entity.selected);
   const selectedAnsibleRules = getSelectedItems(rows).filter(
-    (r) => r.resolution && r.resolution?.has_playbook
+    (r) => r.resolution?.has_playbook
   );
   const selectedItemsLength = getSelectedItems(rows).length;
   const selectableItemsLength = rows.filter(
-    (r) => r.resolution && r.resolution?.has_playbook
+    (r) => r.resolution?.has_playbook
   ).length;
 
   const cols = [
@@ -545,7 +545,7 @@ const BaseSystemAdvisor = () => {
 
   const processRemediation = (selectedAnsibleRules) => {
     const playbookRows = selectedAnsibleRules.filter(
-      (r) => r.resolution && r.resolution.has_playbook
+      (r) => r.resolution?.has_playbook
     );
     const issues = playbookRows.map((r) => ({
       id: `advisor:${r.rule.rule_id}`,


### PR DESCRIPTION
This fixes the invisible recommendations bug on prod-stable. The issue was due to some of the recommendations had resultion: null in the api response and all [lines](https://github.com/RedHatInsights/insights-advisor-frontend/blob/master/src/SmartComponents/SystemAdvisor/SystemAdvisor.js#L195) in which resolution is used to access a property caused type error. With this commit, all lines dealing with resolution are modified to handle resolution: null nicely.

To test:

- There is a temp commit with the API result from the customer. 
- Please import results object from **apiResponseInTheCase** file.
- provide the results object to [activeRuleFirst](https://github.com/RedHatInsights/insights-advisor-frontend/blob/master/src/SmartComponents/SystemAdvisor/SystemAdvisor.js#L618) function so that the api mock data is used to build the table.
- Verify that the page does not break.
- Verify that Remediation column has 'N/A' for the recommendation with resolution:null
- Verify that rows for recommendations with no resolution can not be expanded

Once the ticket is verified, I will remove the temp commit before it PR gets merged.