### PR TITLE
fix: Remove intl on error redirect to console

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -10,8 +10,6 @@ const cache = createIntlCache();
 const locale = navigator.language.slice(0, 2);
 const intl = createIntl(
   {
-    // eslint-disable-next-line no-console
-    onError: console.log,
     locale,
   },
   cache

--- a/src/PresentationalComponents/Common/Common.js
+++ b/src/PresentationalComponents/Common/Common.js
@@ -22,8 +22,6 @@ const cache = createIntlCache();
 const locale = navigator.language.slice(0, 2);
 const intl = createIntl(
   {
-    // eslint-disable-next-line no-console
-    onError: console.log,
     locale,
   },
   cache

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -727,7 +727,6 @@ const SystemAdvisor = ({ customItnl, intlProps, store, ...props }) => {
       {...(customItnl && {
         locale: navigator.language.slice(0, 2),
         messages,
-        onError: console.log,
         ...intlProps,
       })}
     >
@@ -745,7 +744,6 @@ SystemAdvisor.propTypes = {
   intlProps: PropTypes.shape({
     locale: PropTypes.string,
     messages: PropTypes.array,
-    onError: PropTypes.func,
   }),
   store: PropTypes.object,
 };


### PR DESCRIPTION
Removes the redirects to console log for Intl on error, which can lock up the browser. 