### PR TITLE
fix(SPUR): adjusting margin on reboot text after pf label update

### DIFF
--- a/src/PresentationalComponents/Common/_Common.scss
+++ b/src/PresentationalComponents/Common/_Common.scss
@@ -3,6 +3,7 @@
   align-items: baseline;
   .adv-c-text-system-reboot-message {
     position: relative;
+    margin-bottom: 0;
   }
   .adv-c-icon-reboot-required {
     align-self: center;


### PR DESCRIPTION
With recently merged pf dependencies, Labels and a few things have new css, this change is just to align the text with with the power icon in the reboot message. 
This message appears in beta env, in the pathways panel and in pathway details (click systems affected link or select a pathway)

Before this change:
![Screen Shot 2022-08-08 at 11 00 28 AM](https://user-images.githubusercontent.com/60629070/183448898-26b2fac0-7505-4d7b-926e-ae6e84c41975.png)
![Screen Shot 2022-08-08 at 11 03 04 AM](https://user-images.githubusercontent.com/60629070/183449458-7029c09a-1944-43b5-bde2-dbc323184935.png)




New Ui : 
![Screen Shot 2022-08-08 at 11 00 00 AM](https://user-images.githubusercontent.com/60629070/183448797-08abfac8-1ed7-4075-a222-227e3fb4193e.png)
![Screen Shot 2022-08-08 at 11 02 37 AM](https://user-images.githubusercontent.com/60629070/183449365-829d71b2-c435-4ee6-8a9b-3faad9278223.png)
