### PR TITLE
Advisor-2673 - Refactor(api): matching GET req params in pathwaysTables with Pathways…

### DIFF
--- a/src/PresentationalComponents/PathwaysPanel/PathwaysPanel.js
+++ b/src/PresentationalComponents/PathwaysPanel/PathwaysPanel.js
@@ -17,13 +17,19 @@ import messages from '../../Messages';
 import propTypes from 'prop-types';
 import { useGetPathwaysQuery } from '../../Services/Pathways';
 import { useIntl } from 'react-intl';
+import { useSelector } from 'react-redux';
 
 const PathwaysPanel = () => {
   const intl = useIntl();
+  const { sort, offset } = useSelector(
+    ({ filters: { pathState } }) => pathState
+  );
   const [expanded, setExpanded] = useState(
     JSON.parse(localStorage.getItem('advisor_pathwayspanel_expanded') || 'true')
   );
   const { data, isLoading, isFetching, isError } = useGetPathwaysQuery({
+    sort,
+    offset,
     limit: 3,
   });
 

--- a/src/Services/Filters.js
+++ b/src/Services/Filters.js
@@ -9,7 +9,7 @@ const filtersInitialState = {
     offset: 0,
   },
   pathState: {
-    sort: '-impacted_systems_count',
+    sort: '-recommendation_level',
     limit: 20,
     offset: 0,
   },


### PR DESCRIPTION
This makes the order of pathways in pathways panel match the order in pathways table and sorts via recommendation level as opposed to impacted systems. In the attached pictures you can see in the old UI, the ordering in panels doesnt match. With the passed in params, the order now matches.

Old UI: 
![Screen Shot 2022-08-09 at 12 35 22 PM](https://user-images.githubusercontent.com/60629070/183707978-ce61d4f5-c7f0-4093-83cb-017ce71bb2fd.png)


New UI: 
![Screen Shot 2022-08-09 at 12 34 37 PM](https://user-images.githubusercontent.com/60629070/183707841-02998827-6ecd-45e2-9323-2960bf8f74c3.png)
 