### PR TITLE
 Refactor(advisor): System Advisor sorts by total risk on first load when coming from systems route

### DIFF
--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -180,14 +180,22 @@ const BaseSystemAdvisor = () => {
   ) => {
     const url = window.location.href;
     let newActiveReportsList = activeReports;
-    let isRulePresent = url.indexOf('activeRule') ? true : false;
+    let isRulePresent = url.indexOf('activeRule') > -1 ? true : false;
     if (isRulePresent) {
       let activeRule = location[2];
-      //sorts activeReportsList by making the activeRecommendation ruleId having a higher priority when sorting
+      //sorts activeReportsList by making the activeRecommendation ruleId having a higher priority when sorting, or by total_risk
       newActiveReportsList.sort((x, y) =>
         x.rule.rule_id === activeRule
           ? -1
           : y.rule.rule_id === activeRule
+          ? 1
+          : 0
+      );
+    } else if (isFirstLoad) {
+      newActiveReportsList.sort((x, y) =>
+        x.rule.total_risk > y.rule.total_risk
+          ? -1
+          : y.rule.total_risk > x.rule.total_risk
           ? 1
           : 0
       );


### PR DESCRIPTION
Per pm, this introduces sorting by total_risk when coming from any route other than recommendations tab. 
These are the two routes to verify 

- Advisor recommendations -> recom details -> Affected system: first in the table should be the recommendation in question, expanded.
- Advisor systems -> system details: all recommendations are collapsed, sorted by total risk.


