### PR TITLE
Refactor(ADVISOR-2673): PathwaysPanel is sorted by rec lvl, independent of PathwaysTable 

### DIFF
--- a/src/PresentationalComponents/PathwaysPanel/PathwaysPanel.js
+++ b/src/PresentationalComponents/PathwaysPanel/PathwaysPanel.js
@@ -21,14 +21,12 @@ import { useSelector } from 'react-redux';
 
 const PathwaysPanel = () => {
   const intl = useIntl();
-  const { sort, offset } = useSelector(
-    ({ filters: { pathState } }) => pathState
-  );
+  const { offset } = useSelector(({ filters: { pathState } }) => pathState);
   const [expanded, setExpanded] = useState(
     JSON.parse(localStorage.getItem('advisor_pathwayspanel_expanded') || 'true')
   );
   const { data, isLoading, isFetching, isError } = useGetPathwaysQuery({
-    sort,
+    sort: '-recommendation_level',
     offset,
     limit: 3,
   });


### PR DESCRIPTION
This refactors PathwayPanel so that it is independent of the sort on pathwaysTable. It will always be sorted via recommendation level.