### PR TITLE
Fix Pathways systems table crash

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -284,18 +284,20 @@ const Inventory = ({
         ...displayName[0],
         transforms: [sortable, wrappable],
         props: { isStatic: true },
-        renderFunc: rule
-          ? (name, id) => {
-              return (
-                <Link
-                  className="pf-u-font-size-lg"
-                  to={`/recommendations/${rule.rule_id}/${id}?activeRule=true`}
-                >
-                  {name}
-                </Link>
-              );
+        ...(rule
+          ? {
+              renderFunc: (name, id) => {
+                return (
+                  <Link
+                    className="pf-u-font-size-lg"
+                    to={`/recommendations/${rule.rule_id}/${id}?activeRule=true`}
+                  >
+                    {name}
+                  </Link>
+                );
+              },
             }
-          : {},
+          : {}),
       };
 
       lastSeenColumn = {


### PR DESCRIPTION
When rule was `undefined` (always for Pathways systems table) `renderFunc` was set to `{}` which is not a valid function and was crashing the table. Fixed by only overriding `renderFunc` when rule wasn't `undefined`.