### PR TITLE
Dynamic OS filter values in the Systems and Affected systems tables

### DIFF
--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -49,6 +49,9 @@ const SystemsTable = () => {
   const workloads = useSelector(({ filters }) => filters.workloads);
   const SID = useSelector(({ filters }) => filters.SID);
   const filters = useSelector(({ filters }) => filters.sysState);
+  const operatingSystems = useSelector(
+    ({ entities }) => entities?.operatingSystems || []
+  );
   const setFilters = (filters) => dispatch(updateSysFilters(filters));
   const permsExport = usePermissions('advisor', PERMS.export).hasAccess;
   const [filterBuilding, setFilterBuilding] = useState(true);
@@ -107,14 +110,17 @@ const SystemsTable = () => {
     },
     ...(buildOSFilterConfig
       ? [
-          buildOSFilterConfig({
-            label: SFC.rhel_version.title.toLowerCase(),
-            type: SFC.rhel_version.type,
-            id: SFC.rhel_version.urlParam,
-            value: toGroupSelectionValue(filters.rhel_version || []),
-            onChange: (_e, value) =>
-              addFilterParam(SFC.rhel_version.urlParam, value),
-          }),
+          buildOSFilterConfig(
+            {
+              label: SFC.rhel_version.title.toLowerCase(),
+              type: SFC.rhel_version.type,
+              id: SFC.rhel_version.urlParam,
+              value: toGroupSelectionValue(filters.rhel_version || []),
+              onChange: (_e, value) =>
+                addFilterParam(SFC.rhel_version.urlParam, value),
+            },
+            operatingSystems
+          ),
         ]
       : []),
   ];


### PR DESCRIPTION
This follows up on and has to be merged first before https://github.com/RedHatInsights/insights-inventory-frontend/pull/1621.

In order to work correctly with the updated Inventory's OS filter, Advisor has to provide the available OS values to `buildOSFilterConfig` (which is imported from Inventory). It also replaces the static filter values in the Affected systems table and builds the filter config the same way done in the Systems.

### How to test

1. Locally, in the Inventory app, checkout to https://github.com/RedHatInsights/insights-inventory-frontend/pull/1621.
2. In Advisor app folder, run `PROXY=true BETA=true npx webpack serve --config config/dev.webpack.config.js --port 8004`.
3. In Inventory app folder, run `LOCAL_API=advisor:8004~https PROXY=true BETA=true npx webpack serve --config config/dev.webpack.config.js`.
4. Verify the changes on https://stage.foo.redhat.com:1337/beta/insights/advisor/systems.
5. Verify the changes on any recommendation details page, affected systems table.
6. You can also checkout Inventory app to the upstream `master` branch and check whether these Advisor changes will work together before Inventory patch is released.

![image](https://user-images.githubusercontent.com/31385370/188596098-28c51d4d-a971-49a5-ba8f-dfa86217d3cf.png)
![image](https://user-images.githubusercontent.com/31385370/188596180-28306ad1-f9c6-4aab-b9ef-089a3d7c47ef.png)

