### PR TITLE
fix(SystemTable): update the OS column sort key

### DIFF
--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -273,7 +273,7 @@ const SystemsTable = () => {
           } = config;
           const sort = `${orderDirection === 'ASC' ? '' : '-'}${
             (orderBy === 'updated' && 'last_seen') ||
-            (orderBy === 'system_profile' && 'rhel_version') ||
+            (orderBy === 'operating_system' && 'rhel_version') ||
             orderBy
           }`;
 


### PR DESCRIPTION
This updates the os column sort key after it has been changed on the Inventory side ([commit](https://github.com/RedHatInsights/insights-inventory-frontend/commit/ef34976e44fa0e9a7231579f981d537dfaab408d)). 