### PR TITLE
fix(ADVISOR-2791): Fixes sorting in Inventory table

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -95,7 +95,8 @@ const Inventory = ({
     selectedIds,
     setFullFilters,
     fullFilters,
-    rule
+    rule,
+    setFilters
   );
 
   const grabPageIds = () => {
@@ -317,6 +318,7 @@ const Inventory = ({
 
       systemProfile = {
         ...systemProfile[0],
+        sortKey: 'rhel_version',
         transforms: [wrappable],
       };
 

--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -318,8 +318,8 @@ const Inventory = ({
 
       systemProfile = {
         ...systemProfile[0],
-        sortKey: 'rhel_version',
         transforms: [wrappable],
+        props: { isStatic: true },
       };
 
       tags = {

--- a/src/PresentationalComponents/Inventory/helpers.js
+++ b/src/PresentationalComponents/Inventory/helpers.js
@@ -11,7 +11,6 @@ export const paginatedRequestHelper = async ({
   filters,
   workloads,
   SID,
-  sort,
   pathway,
   rule,
 }) => {
@@ -19,7 +18,7 @@ export const paginatedRequestHelper = async ({
     ...advisorFilters,
     limit: per_page,
     offset: page * per_page - per_page,
-    sort,
+    sort: advisorFilters.sort,
     ...(filters?.hostnameOrId &&
       !pathway && {
         name: filters?.hostnameOrId,
@@ -63,7 +62,8 @@ export const getEntities =
     selectedIds,
     setFullFilters,
     fullFilters,
-    rule
+    rule,
+    setFilters
   ) =>
   async (_items, config, showTags, defaultGetEntities) => {
     const {
@@ -105,6 +105,7 @@ export const getEntities =
     handleRefresh(options);
     const allDetails = { ...config, pathway, handleRefresh, rule };
     setFullFilters(allDetails);
+    setFilters({ ...filters, sort: sort });
     const fetchedSystems = await paginatedRequestHelper(allDetails);
     const results = await defaultGetEntities(
       fetchedSystems.data.map((system) => system.system_uuid),


### PR DESCRIPTION
This fixes sorting in the Inventory table, while also disabling sorting for columns that are not supported by the backend.
Tickets for columns [Impacted_date, rhel_version(OS)] have been made and the backend team is aware. Once backend supports these, we can enable sorting on the frontend. 

To test navigate to recommendations - select a recommendation > try sorting on the table there with the available options.

P.S I will squash the commits. I didn't mean to grab all of these.