### PR TITLE
Run cypress in PRs, and use npm script instead

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,5 @@
 name: cypress-test-run
-on: [push]
+on: [push, pull_request]
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
@@ -8,8 +8,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: npm install
-      - name: Cypress run
-        uses: cypress-io/github-action@v4
-        with:
-          component: true
-          spec: src/**/*.cy.js
+      - name: Component tests
+        run: npm run test:ct


### PR DESCRIPTION
This PR modifies the cypress workflow config so that the tests are also run in pull requests. Also, it makes the check use the cypress binaries right from `node_modules` instead of using a GH action (which led to flaky behavior sometimes).