### PR TITLE
fix(ADVISOR-2830): Adds workload,SID, and GlobalTags to PathwayPanels

### DIFF
--- a/src/PresentationalComponents/PathwaysPanel/PathwaysPanel.js
+++ b/src/PresentationalComponents/PathwaysPanel/PathwaysPanel.js
@@ -18,6 +18,7 @@ import propTypes from 'prop-types';
 import { useGetPathwaysQuery } from '../../Services/Pathways';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
+import { workloadQueryBuilder } from '../Common/Tables';
 
 const PathwaysPanel = () => {
   const intl = useIntl();
@@ -25,10 +26,19 @@ const PathwaysPanel = () => {
   const [expanded, setExpanded] = useState(
     JSON.parse(localStorage.getItem('advisor_pathwayspanel_expanded') || 'true')
   );
+  const selectedTags = useSelector(({ filters }) => filters.selectedTags);
+  const workloads = useSelector(({ filters }) => filters.workloads);
+  const SID = useSelector(({ filters }) => filters.SID);
+
+  const options = {
+    ...(selectedTags?.length > 0 ? { tags: selectedTags.join(',') } : {}),
+    ...(workloads ? workloadQueryBuilder(workloads, SID) : {}),
+  };
   const { data, isLoading, isFetching, isError } = useGetPathwaysQuery({
     sort: '-recommendation_level',
     offset,
     limit: 3,
+    ...options,
   });
 
   return !isLoading ? (


### PR DESCRIPTION
Global filters and such were not added to pathway panels GET request. 
This causes situations like the one described in the ticket https://issues.redhat.com/browse/ADVISOR-2830 

It could also cause an issue that the pathway table show no pathways (because you add some global filter) but the pathway panels do.

To test, 
Navigate the /recommendations and select the pathways tab
Select global filters and verify that the pathway panel now also reloads when changing global filters. 
The results **should** be identical and in the same order **unless** you altered the sort/added additional filters to the table