### PR TITLE
fix(ADVISOR-2861): Sends global tags up in inventory and systems table

### DIFF
--- a/src/PresentationalComponents/Inventory/helpers.js
+++ b/src/PresentationalComponents/Inventory/helpers.js
@@ -13,6 +13,7 @@ export const paginatedRequestHelper = async ({
   SID,
   pathway,
   rule,
+  selectedTags,
 }) => {
   let options = {
     ...advisorFilters,
@@ -31,10 +32,9 @@ export const paginatedRequestHelper = async ({
       rhel_version: advisorFilters.rhel_version?.join(','),
     }),
     ...(filters.tagFilters?.length && buildTagFilter(filters.tagFilters)),
+    ...(workloads ? workloadQueryBuilder(workloads, SID) : {}),
+    ...(selectedTags?.length > 0 ? { tags: selectedTags.join(',') } : {}),
   };
-
-  workloads &&
-    (options = { ...options, ...workloadQueryBuilder(workloads, SID) });
 
   return pathway
     ? (
@@ -97,10 +97,11 @@ export const getEntities =
         rhel_version: advisorFilters.rhel_version?.join(','),
       }),
       ...(filters.tagFilters?.length && buildTagFilter(filters.tagFilters)),
+      ...(config.selectedTags?.length > 0
+        ? { tags: config.selectedTags.join(',') }
+        : {}),
+      ...(workloads ? workloadQueryBuilder(workloads, SID) : {}),
     };
-
-    workloads &&
-      (options = { ...options, ...workloadQueryBuilder(workloads, SID) });
 
     handleRefresh(options);
     const allDetails = { ...config, pathway, handleRefresh, rule };

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -293,10 +293,11 @@ const SystemsTable = () => {
             }),
             ...(filters.tagFilters?.length &&
               buildTagFilter(filters.tagFilters)),
+            ...(selectedTags?.length > 0
+              ? { tags: selectedTags.join(',') }
+              : {}),
+            ...(workloads ? workloadQueryBuilder(workloads, SID) : {}),
           };
-
-          workloads &&
-            (options = { ...options, ...workloadQueryBuilder(workloads, SID) });
 
           const fetchedSystems = (await Get(SYSTEMS_FETCH_URL, {}, options))
             ?.data;


### PR DESCRIPTION
https://issues.redhat.com/browse/ADVISOR-2861

Global Tags were not being sent in Get request causing unrelated systems to show up in certain scenarios.
To test head to recommendations
Add a global filter tag 
Look at the results in the table, specifically the affected systems number of the recommendation you're going to select
Selected the recommendation
It should have the same amount of systems as it said it was going to have 