### PR TITLE
fix(SystemAdvisor): show rules for satellite managed hosts

### DIFF
--- a/src/SmartComponents/SystemAdvisor/EmptyStates.js
+++ b/src/SmartComponents/SystemAdvisor/EmptyStates.js
@@ -2,8 +2,6 @@ import React from 'react';
 import {
   ChartSpikeIcon,
   CheckIcon,
-  ExternalLinkAltIcon,
-  PficonSatelliteIcon,
   TimesCircleIcon,
 } from '@patternfly/react-icons';
 import {
@@ -15,28 +13,6 @@ import {
 } from '@patternfly/react-core';
 import MessageState from '../../PresentationalComponents/MessageState/MessageState';
 import PropTypes from 'prop-types';
-
-export const HideResultsSatelliteManaged = () => (
-  <MessageState
-    icon={PficonSatelliteIcon}
-    title="Satellite managed system"
-    text={
-      <span key="satellite managed system">
-        Insights results can not be displayed for this host, as the &quot;Hide
-        Satellite Managed Systems&quot; setting has been enabled by an org
-        admin.
-        <br />
-        For more information on this setting and how to modify it,
-        <a href="https://access.redhat.com/solutions/4281761" rel="noopener">
-          {' '}
-          Please visit this Knowledgebase article &nbsp;
-          <ExternalLinkAltIcon />
-        </a>
-        .
-      </span>
-    }
-  />
-);
 
 export const NoMatchingRecommendations = () => (
   <Bullseye>

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -41,7 +41,6 @@ import { capitalize } from '../../PresentationalComponents/Common/Tables';
 import messages from '../../Messages';
 import { Provider } from 'react-redux';
 import {
-  HideResultsSatelliteManaged,
   NoMatchingRecommendations,
   NoRecommendations,
   InsightsNotEnabled,
@@ -58,9 +57,6 @@ const BaseSystemAdvisor = ({ entity }) => {
   const dispatch = useDispatch();
   const addNotification = (data) => dispatch(addNotificationAction(data));
 
-  const systemProfile = useSelector(({ systemProfileStore }) =>
-    systemProfileStore ? systemProfileStore.systemProfile : {}
-  );
   const routerData = useSelector(({ routerData }) => routerData);
 
   const [inventoryReportFetchStatus, setInventoryReportFetchStatus] =
@@ -70,15 +66,10 @@ const BaseSystemAdvisor = ({ entity }) => {
   const [kbaDetailsData, setKbaDetailsData] = useState([]);
   const [sortBy, setSortBy] = useState({});
   const [filters, setFilters] = useState({});
-  const [accountSettings, setAccountSettings] = useState({});
   const [searchValue, setSearchValue] = useState('');
   const [isSelected, setIsSelected] = useState(false);
   const [isAllExpanded, setIsAllExpanded] = useState(false);
 
-  const satelliteManaged =
-    (systemProfile && systemProfile.satellite_managed) || false; // system is managed by satellite
-  const satelliteShowHosts = accountSettings.show_satellite_hosts || false; // setting to show satellite managed systems
-  const hideResultsSatelliteManaged = !satelliteShowHosts && satelliteManaged;
   const getSelectedItems = (rows) => rows.filter((row) => row.selected);
   const selectedAnsibleRules = getSelectedItems(rows).filter(
     (r) => r.resolution?.has_playbook
@@ -654,20 +645,14 @@ const BaseSystemAdvisor = ({ entity }) => {
   useEffect(() => {
     const dataFetch = async () => {
       try {
-        const [settingsFetch, reportsFetch] = await Promise.all([
-          (
-            await Get(`${BASE_URL}/account_setting/`, {
-              credentials: 'include',
-            })
-          ).data,
-          (
-            await Get(`${BASE_URL}/system/${entity.id}/reports/`, {
-              credentials: 'include',
-            })
-          ).data,
-        ]);
+        const reportsFetch = await Get(
+          `${BASE_URL}/system/${entity.id}/reports/`,
+          {
+            credentials: 'include',
+          }
+        );
 
-        const activeRuleFirstReportsData = activeRuleFirst(reportsFetch);
+        const activeRuleFirstReportsData = activeRuleFirst(reportsFetch.data);
         fetchKbaDetails(activeRuleFirstReportsData);
 
         setRows(
@@ -682,7 +667,6 @@ const BaseSystemAdvisor = ({ entity }) => {
         );
         setInventoryReportFetchStatus('fulfilled');
         setActiveReports(activeRuleFirstReportsData);
-        setAccountSettings(settingsFetch);
       } catch (error) {
         setInventoryReportFetchStatus('failed');
       }
@@ -700,8 +684,6 @@ const BaseSystemAdvisor = ({ entity }) => {
   ) : (
     <div className="ins-c-inventory-insights__overrides">
       {inventoryReportFetchStatus === 'pending' ||
-      (inventoryReportFetchStatus === 'fulfilled' &&
-        hideResultsSatelliteManaged) ||
       entity.insights_id === null ? (
         <Fragment />
       ) : (
@@ -729,31 +711,26 @@ const BaseSystemAdvisor = ({ entity }) => {
           </CardBody>
         </Card>
       )}
-      {inventoryReportFetchStatus === 'fulfilled' &&
-        (hideResultsSatelliteManaged ? (
-          <HideResultsSatelliteManaged />
-        ) : (
-          <Fragment>
-            <Table
-              id={'system-advisor-report-table'}
-              aria-label={'report-table'}
-              onSelect={
-                !(rows.length === 1 && rows[0].heightAuto) && onRowSelect
-              }
-              onCollapse={handleOnCollapse}
-              rows={rows}
-              cells={cols}
-              sortBy={sortBy}
-              canSelectAll={false}
-              onSort={onSort}
-              variant={TableVariant.compact}
-              isStickyHeader
-            >
-              <TableHeader />
-              <TableBody />
-            </Table>
-          </Fragment>
-        ))}
+      {inventoryReportFetchStatus === 'fulfilled' && (
+        <Fragment>
+          <Table
+            id={'system-advisor-report-table'}
+            aria-label={'report-table'}
+            onSelect={!(rows.length === 1 && rows[0].heightAuto) && onRowSelect}
+            onCollapse={handleOnCollapse}
+            rows={rows}
+            cells={cols}
+            sortBy={sortBy}
+            canSelectAll={false}
+            onSort={onSort}
+            variant={TableVariant.compact}
+            isStickyHeader
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
+        </Fragment>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-3670.

This removes the checks for satellite managed systems and makes the system details page always show rule results.