### PR TITLE
fix: Add federated module wrapper for SystemAdvisor

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -65,10 +65,7 @@ plugins.push(
       root: resolve(__dirname, '../'),
       exposes: {
         './RootApp': resolve(__dirname, '../src/AppEntry'),
-        './SystemDetail': resolve(
-          __dirname,
-          '../src/SmartComponents/SystemAdvisor'
-        ),
+        './SystemDetail': resolve(__dirname, '../src/Modules/SystemDetail'),
       },
     }
   )

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -15,10 +15,7 @@ plugins.push(
       root: resolve(__dirname, '../'),
       exposes: {
         './RootApp': resolve(__dirname, '../src/AppEntry'),
-        './SystemDetail': resolve(
-          __dirname,
-          '../src/SmartComponents/SystemAdvisor'
-        ),
+        './SystemDetail': resolve(__dirname, '../src/Modules/SystemDetail'),
       },
     }
   )

--- a/src/Modules/SystemDetail.js
+++ b/src/Modules/SystemDetail.js
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import { IntlProvider } from 'react-intl';
+import { Provider } from 'react-redux';
+import messages from '../Messages';
+import SystemAdvisor from '../SmartComponents/SystemAdvisor/SystemAdvisor';
+
+const SystemDetail = ({ customItnl, intlProps, store, ...props }) => {
+  const Wrapper = customItnl ? IntlProvider : Fragment;
+  const ReduxProvider = store ? Provider : Fragment;
+
+  return (
+    <Wrapper
+      {...(customItnl && {
+        locale: navigator.language.slice(0, 2),
+        messages,
+        ...intlProps,
+      })}
+    >
+      <ReduxProvider store={store}>
+        <SystemAdvisor {...props} />
+      </ReduxProvider>
+    </Wrapper>
+  );
+};
+
+SystemDetail.propTypes = {
+  customItnl: PropTypes.bool,
+  intlProps: PropTypes.shape({
+    locale: PropTypes.string,
+    messages: PropTypes.array,
+  }),
+  store: PropTypes.object,
+};
+
+export default SystemDetail;

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -14,7 +14,7 @@ import {
   Tooltip,
   TooltipPosition,
 } from '@patternfly/react-core';
-import { IntlProvider, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import React, { Fragment, useEffect, useRef, useState } from 'react';
 import {
   SortByDirection,
@@ -39,7 +39,6 @@ import RuleLabels from '../../PresentationalComponents/Labels/RuleLabels';
 import { addNotification as addNotificationAction } from '@redhat-cloud-services/frontend-components-notifications/';
 import { capitalize } from '../../PresentationalComponents/Common/Tables';
 import messages from '../../Messages';
-import { Provider } from 'react-redux';
 import {
   HideResultsSatelliteManaged,
   NoMatchingRecommendations,
@@ -765,35 +764,11 @@ BaseSystemAdvisor.propTypes = {
   }),
 };
 
-const SystemAdvisor = ({ customItnl, intlProps, store, ...props }) => {
-  const Wrapper = customItnl ? IntlProvider : Fragment;
-  const ReduxProvider = store ? Provider : Fragment;
-
+const SystemAdvisor = ({ ...props }) => {
   const entity = useSelector(({ entityDetails }) => entityDetails.entity);
 
-  return (
-    <Wrapper
-      {...(customItnl && {
-        locale: navigator.language.slice(0, 2),
-        messages,
-        ...intlProps,
-      })}
-    >
-      <ReduxProvider store={store}>
-        <BaseSystemAdvisor {...props} entity={entity} />
-      </ReduxProvider>
-    </Wrapper>
-  );
+  return <BaseSystemAdvisor {...props} entity={entity} />;
 };
 
 export default SystemAdvisor;
 export { BaseSystemAdvisor };
-
-SystemAdvisor.propTypes = {
-  customItnl: PropTypes.bool,
-  intlProps: PropTypes.shape({
-    locale: PropTypes.string,
-    messages: PropTypes.array,
-  }),
-  store: PropTypes.object,
-};


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/RedHatInsights/insights-advisor-frontend/pull/1035.

## Description

This extracts `SystemDetail` federated module to an extra wrapper component. The previous implementation was leading to an error since the `useSelector` hook was trying to access the store before the redux provider was set up. We still require `BaseSystemAdvisor` not to request `entityDetails` via redux store for easier component testing.

## How to test

While deployed locally together with Inventory app (e.g., with test-inv.sh), check:
1) navigate to Advisor system details page and verify the rules table is rendered,
2) navigate to Inventory system details page, Advisor tab, and verify the rules table is rendered. 