### PR TITLE
feat(ghactions): improving the job script

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,9 @@
 name: cypress-test-run
-on: [push, pull_request]
+on:
+  push:
+    branches: ['master', 'master-stable', 'prod-beta', 'prod-stable']
+  pull_request:
+    branches: ['master']
 jobs:
   cypress-run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Easy PR, should remove the issue of tests running twice on merging to the master-stable and prod-stable
Screenshot of the issue 
![image](https://user-images.githubusercontent.com/62722417/203089760-a222d91f-e9fb-4bad-bb72-67a2010c7653.png)
