### PR TITLE
fix(ESSNTL-3781-2): Name Param changes if on systems page

### DIFF
--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -285,7 +285,8 @@ const SystemsTable = () => {
             filters,
             selectedTags,
             workloads,
-            SID
+            SID,
+            true
           );
           const fetchedSystems = (await Get(SYSTEMS_FETCH_URL, {}, options))
             ?.data;

--- a/src/PresentationalComponents/helper.js
+++ b/src/PresentationalComponents/helper.js
@@ -9,7 +9,8 @@ export const createOptions = (
   filters,
   selectedTags,
   workloads,
-  SID
+  SID,
+  systemsPage
 ) => {
   let options = {
     ...advisorFilters,
@@ -17,8 +18,14 @@ export const createOptions = (
     offset: page * per_page - per_page,
     sort: sort,
     ...(filters?.hostnameOrId &&
-      !pathway && {
+      !pathway &&
+      !systemsPage && {
         name: filters?.hostnameOrId,
+      }),
+    ...(filters?.hostnameOrId &&
+      !pathway &&
+      systemsPage && {
+        display_name: filters?.hostnameOrId,
       }),
     ...(filters.hostnameOrId &&
       pathway && {


### PR DESCRIPTION
Currently in production when sorting in the systems page, it will send the name param and not filter down the table. This PR changes that so that the correct param is sent for the correct table.


In the systems page it needs to send display_name.
In recommendations table in needs to send text.
in pathways table it also needs to send name
