### PR TITLE
fix(ADVISOR-2915): Updates filters check for RulesTable

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.cy.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.cy.js
@@ -392,3 +392,42 @@ describe('Sorting', () => {
     });
   });
 });
+
+const urlParamsList = [
+  'impacting=true&rule_status=enabled&sort=-total_risk&limit=20&offset=0#SIDs=&tags=',
+  'impacting=false&rule_status=enabled&sort=-recommendation_level&limit=20&offset=0#SIDs=&tags=',
+];
+
+urlParamsList.forEach((urlParams, index) => {
+  describe(`pre-filled url search parameters ${index}`, () => {
+    beforeEach(() => {
+      cy.intercept('*', {
+        statusCode: 201,
+        body: {
+          ...fixtures,
+        },
+      }).as('call');
+
+      cy.mount(
+        <MemoryRouter
+          initialEntries={[`/recommendations?${urlParams}`]}
+          initialIndex={0}
+        >
+          <IntlProvider
+            locale={navigator.language.slice(0, 2)}
+            messages={messages}
+          >
+            <Provider store={getStore()}>
+              <RulesTable />
+            </Provider>
+          </IntlProvider>
+        </MemoryRouter>
+      );
+    });
+
+    it('Sorts properly even if url doesnt match params for table', () => {
+      const column = 'Total risk';
+      tableIsSortedBy(column);
+    });
+  });
+});

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -266,11 +266,15 @@ const RulesTable = ({ isTabActive }) => {
       const paramsObject = paramParser();
       delete paramsObject.tags;
 
+      if (
+        paramsObject.sort[0] === '-recommendation_level' ||
+        paramsObject.sort === undefined
+      ) {
+        paramsObject.sort = '-total_risk';
+      }
       paramsObject.text === undefined
         ? setSearchText('')
         : setSearchText(paramsObject.text);
-      paramsObject.sort =
-        paramsObject.sort === undefined ? '-total_risk' : paramsObject.sort[0];
       paramsObject.has_playbook !== undefined &&
         !Array.isArray(paramsObject.has_playbook) &&
         (paramsObject.has_playbook = [`${paramsObject.has_playbook}`]);

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -28,7 +28,6 @@ import {
 } from '@patternfly/react-core/dist/js/components/Tooltip/Tooltip';
 import {
   filterFetchBuilder,
-  paramParser,
   pruneFilters,
   ruleResolutionRisk,
   urlBuilder,
@@ -70,7 +69,7 @@ import { useIntl } from 'react-intl';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import PropTypes from 'prop-types';
 
-import { emptyRows } from './helpers';
+import { emptyRows, urlFilterBuilder } from './helpers';
 
 const RulesTable = ({ isTabActive }) => {
   const intl = useIntl();
@@ -263,37 +262,7 @@ const RulesTable = ({ isTabActive }) => {
   // Builds table filters from url params
   useEffect(() => {
     if (isTabActive && search && filterBuilding) {
-      const paramsObject = paramParser();
-      delete paramsObject.tags;
-
-      if (
-        paramsObject.sort[0] === '-recommendation_level' ||
-        paramsObject.sort === undefined
-      ) {
-        paramsObject.sort = '-total_risk';
-      }
-      paramsObject.text === undefined
-        ? setSearchText('')
-        : setSearchText(paramsObject.text);
-      paramsObject.has_playbook !== undefined &&
-        !Array.isArray(paramsObject.has_playbook) &&
-        (paramsObject.has_playbook = [`${paramsObject.has_playbook}`]);
-      paramsObject.incident !== undefined &&
-        !Array.isArray(paramsObject.incident) &&
-        (paramsObject.incident = [`${paramsObject.incident}`]);
-      paramsObject.offset === undefined
-        ? (paramsObject.offset = 0)
-        : (paramsObject.offset = Number(paramsObject.offset[0]));
-      paramsObject.limit === undefined
-        ? (paramsObject.limit = 20)
-        : (paramsObject.limit = Number(paramsObject.limit[0]));
-      paramsObject.reboot !== undefined &&
-        !Array.isArray(paramsObject.reboot) &&
-        (paramsObject.reboot = [`${paramsObject.reboot}`]);
-      paramsObject.impacting !== undefined &&
-        !Array.isArray(paramsObject.impacting) &&
-        (paramsObject.impacting = [`${paramsObject.impacting}`]);
-      setFilters({ ...filters, ...paramsObject });
+      urlFilterBuilder(sortIndices, setSearchText, setFilters, filters);
     }
 
     setFilterBuilding(false);

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Text } from '@patternfly/react-core';
 import EmptyState from './Components/EmptyState';
 import { FormattedMessage } from 'react-intl';
+import { paramParser } from '../Common/Tables';
 
 export const emptyRows = (filters, toggleRulesDisabled) => [
   {
@@ -61,4 +62,43 @@ export const messageMapping = () => {
       ),
     },
   };
+};
+
+export const urlFilterBuilder = (
+  sortIndices,
+  setSearchText,
+  setFilters,
+  filters
+) => {
+  let sortingValues = Object.values(sortIndices);
+  const paramsObject = paramParser();
+  delete paramsObject.tags;
+  if (
+    !sortingValues?.includes(paramsObject.sort[0]) ||
+    !sortingValues?.includes(`-${paramsObject.sort[0]}`)
+  ) {
+    paramsObject.sort = '-total_risk';
+  }
+  paramsObject.text === undefined
+    ? setSearchText('')
+    : setSearchText(paramsObject.text);
+  paramsObject.has_playbook !== undefined &&
+    !Array.isArray(paramsObject.has_playbook) &&
+    (paramsObject.has_playbook = [`${paramsObject.has_playbook}`]);
+  paramsObject.incident !== undefined &&
+    !Array.isArray(paramsObject.incident) &&
+    (paramsObject.incident = [`${paramsObject.incident}`]);
+  paramsObject.offset === undefined
+    ? (paramsObject.offset = 0)
+    : (paramsObject.offset = Number(paramsObject.offset[0]));
+  paramsObject.limit === undefined
+    ? (paramsObject.limit = 20)
+    : (paramsObject.limit = Number(paramsObject.limit[0]));
+  paramsObject.reboot !== undefined &&
+    !Array.isArray(paramsObject.reboot) &&
+    (paramsObject.reboot = [`${paramsObject.reboot}`]);
+  paramsObject.impacting !== undefined &&
+    !Array.isArray(paramsObject.impacting) &&
+    (paramsObject.impacting = [`${paramsObject.impacting}`]);
+  setFilters({ ...filters, ...paramsObject });
 };


### PR DESCRIPTION
# Description

Associated Jira ticket: # ([ADVISOR-2915](https://issues.redhat.com/browse/ADVISOR-2915))
It seems Advisor rules table was originally built to update filters based off urls on page load. Different tables take in differing parameter values in advisor (this is a known issue).


# How to test the PR

Run advisor against prod env via :
CHROME_ENV=prod-stable npm run start:proxy
Access https://console.redhat.com/insights/dashboard
In the menu select Advisor > Recommendations
In the global filter select "Microsoft SQL"
Select a recommendation to show the affected systems
Click on the "Go back" button in the browser

# Before the change
The table would break, in the network tab it would yell about an incorrect sorting param passed in

# After the change
It passes, making the default '-total_risk'

Notes: In the refactor PR I will try and optimize this page further.

# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
