### PR TITLE
fix(RHCLOUD-23202): Do not re-create sotre on each render

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -3,21 +3,25 @@ import App from './App';
 import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations/';
 import { NotificationsPortal } from '@redhat-cloud-services/frontend-components-notifications/';
 import { Provider } from 'react-redux';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { getStore } from './Store';
 import messages from '../locales/translations.json';
 
-const AppEntry = () => (
-  <IntlProvider locale={navigator.language.slice(0, 2)} messages={messages}>
-    <Provider store={getStore()}>
-      <Router basename={getBaseName(window.location.pathname)}>
-        <NotificationsPortal />
-        <App />
-      </Router>
-    </Provider>
-  </IntlProvider>
-);
+const AppEntry = () => {
+  const store = useMemo(() => getStore(), []);
+
+  return (
+    <IntlProvider locale={navigator.language.slice(0, 2)} messages={messages}>
+      <Provider store={store}>
+        <Router basename={getBaseName(window.location.pathname)}>
+          <NotificationsPortal />
+          <App />
+        </Router>
+      </Provider>
+    </IntlProvider>
+  );
+};
 
 export default AppEntry;


### PR DESCRIPTION
# Description

Associated Jira ticket: #RHCLOUD-23202

There's an error with global filter tags not being applied when selecting. This is caused by re-creating store on each AppEntry render. The application can render multiple times (PF contexts, navigation, etc.) and that can invalidate data stored in the redux state. This PR fixes it by using `useMemo` to create the store only on initial render.


# How to test the PR

Run Advisor app locally and select tag from global filter.
