### PR TITLE
fix(Shared dependencies): Align versions of redux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,9 @@
         "react-dom": "17.0.2",
         "react-intl": "^5.20.10",
         "react-markdown": "7.0.1",
-        "react-redux": "7.2.5",
+        "react-redux": "7.2.6",
         "react-router-dom": "5.3.0",
-        "redux": "4.1.1",
+        "redux": "4.1.2",
         "redux-logger": "3.0.6",
         "redux-promise-middleware": "6.1.2"
       },
@@ -4513,6 +4513,15 @@
         "react-dom": ">=16.14.0 || >=17.0.0"
       }
     },
+    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
     "node_modules/@redhat-cloud-services/frontend-components-pdf-generator": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-pdf-generator/-/frontend-components-pdf-generator-2.6.7.tgz",
@@ -4819,6 +4828,22 @@
         "react-redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "peerDependencies": {
+        "redux": "^4"
       }
     },
     "node_modules/@scalprum/core": {
@@ -5444,6 +5469,14 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
+      }
+    },
+    "node_modules/@types/react-redux/node_modules/redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/@types/retry": {
@@ -18700,16 +18733,16 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-redux": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.5.tgz",
-      "integrity": "sha512-Dt29bNyBsbQaysp6s/dN0gUodcq+dVKKER8Qv82UrpeygwYeX1raTtil7O/fftw/rFqzaf6gJhDZRkkZnn6bjg==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
+      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
       "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "@types/react-redux": "^7.1.16",
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
         "hoist-non-react-statics": "^3.3.2",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.7.2",
-        "react-is": "^16.13.1"
+        "react-is": "^17.0.2"
       },
       "peerDependencies": {
         "react": "^16.8.3 || ^17"
@@ -18722,6 +18755,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-router": {
       "version": "5.2.1",
@@ -18910,9 +18948,9 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
-      "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -18931,14 +18969,6 @@
       "integrity": "sha512-ZqZu/nnSzGgwTtNbGoGVontpk7LjTOv0kigtt3CcgXI9gpq+8WlfXTXRZD0WTD5yaohRq0q2nYmJXSTjwXs83Q==",
       "peerDependencies": {
         "redux": "^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
-    },
-    "node_modules/redux-thunk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
-      "peerDependencies": {
-        "redux": "^4"
       }
     },
     "node_modules/regenerate": {
@@ -26817,6 +26847,17 @@
         "react-redux": ">=5.0.7",
         "redux": ">=4.0.5",
         "redux-promise-middleware": "6.1.2"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+          "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+          "optional": true,
+          "requires": {
+            "@babel/runtime": "^7.9.2"
+          }
+        }
       }
     },
     "@redhat-cloud-services/frontend-components-pdf-generator": {
@@ -27051,6 +27092,22 @@
         "redux": "^4.1.0",
         "redux-thunk": "^2.3.0",
         "reselect": "^4.0.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+          "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+          "requires": {
+            "@babel/runtime": "^7.9.2"
+          }
+        },
+        "redux-thunk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+          "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+          "requires": {}
+        }
       }
     },
     "@scalprum/core": {
@@ -27627,6 +27684,16 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+          "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+          "requires": {
+            "@babel/runtime": "^7.9.2"
+          }
+        }
       }
     },
     "@types/retry": {
@@ -37551,16 +37618,23 @@
       }
     },
     "react-redux": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.5.tgz",
-      "integrity": "sha512-Dt29bNyBsbQaysp6s/dN0gUodcq+dVKKER8Qv82UrpeygwYeX1raTtil7O/fftw/rFqzaf6gJhDZRkkZnn6bjg==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
+      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
       "requires": {
-        "@babel/runtime": "^7.12.1",
-        "@types/react-redux": "^7.1.16",
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
         "hoist-non-react-statics": "^3.3.2",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.7.2",
-        "react-is": "^16.13.1"
+        "react-is": "^17.0.2"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        }
       }
     },
     "react-router": {
@@ -37716,9 +37790,9 @@
       }
     },
     "redux": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
-      "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
@@ -37735,12 +37809,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-6.1.2.tgz",
       "integrity": "sha512-ZqZu/nnSzGgwTtNbGoGVontpk7LjTOv0kigtt3CcgXI9gpq+8WlfXTXRZD0WTD5yaohRq0q2nYmJXSTjwXs83Q==",
-      "requires": {}
-    },
-    "redux-thunk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
       "requires": {}
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -88,9 +88,9 @@
     "react-dom": "17.0.2",
     "react-intl": "^5.20.10",
     "react-markdown": "7.0.1",
-    "react-redux": "7.2.5",
+    "react-redux": "7.2.6",
     "react-router-dom": "5.3.0",
-    "redux": "4.1.1",
+    "redux": "4.1.2",
     "redux-logger": "3.0.6",
     "redux-promise-middleware": "6.1.2"
   },


### PR DESCRIPTION
# Description

Associated Jira ticket: https://issues.redhat.com/browse/RHIF-111

This aligns the version of `redux` and `react-redux` libraries to the ones in insights-chrome.

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
