### PR TITLE
fix(SystemAdvisor): Request all kcs articles

### DIFF
--- a/cypress/fixtures/kcs.json
+++ b/cypress/fixtures/kcs.json
@@ -1,0 +1,59 @@
+[
+  {
+    "publishedTitle": "Scelerisque odio diam placerat semper pretium etiam, sollicitudin nisl enim risus lacinia.",
+    "id": "300533",
+    "view_uri": "http://foo.bar/articles/300533"
+  },
+  {
+    "publishedTitle": "Tristique cubilia diam sit tempus curae, lectus pellentesque amet.",
+    "id": "300821",
+    "view_uri": "http://foo.bar/articles/300821"
+  },
+  {
+    "publishedTitle": "Orci cursus sodales non molestie cras, mauris eros quisque blandit lacinia, non libero odio magna.",
+    "id": "300271",
+    "view_uri": "http://foo.bar/articles/300271"
+  },
+  {
+    "id": "300271",
+    "view_uri": "http://foo.bar/articles/additional/300271"
+  },
+  {
+    "id": "300271",
+    "view_uri": "http://foo.bar/articles/additional/300271/2"
+  },
+  {
+    "publishedTitle": "Luctus vitae cubilia eget quam sem, tincidunt pharetra laoreet.",
+    "id": "300247",
+    "view_uri": "http://foo.bar/articles/300247"
+  },
+  {
+    "publishedTitle": "Scelerisque dolor facilisis ut molestie libero litora amet nisl nunc, egestas nullam accumsan habitasse augue suscipit pulvinar.",
+    "id": "300579",
+    "view_uri": "http://foo.bar/articles/300579"
+  },
+  {
+    "publishedTitle": "Lorem quisque consectetur cras inceptos molestie hac quisque velit, magna consectetur eu dolor integer rutrum nisi.",
+    "id": "300877",
+    "view_uri": "http://foo.bar/articles/300877"
+  },
+  {
+    "publishedTitle": "Magna at curabitur sollicitudin inceptos eu, mollis per himenaeos leo, nec quis dui tristique.",
+    "id": "300464",
+    "view_uri": "http://foo.bar/articles/300464"
+  },
+  {
+    "id": "300464",
+    "view_uri": "http://foo.bar/articles/additional/300464"
+  },
+  {
+    "publishedTitle": "Eros tristique porttitor sit sollicitudin nisl, sit habitant nibh rutrum.",
+    "id": "300666",
+    "view_uri": "http://foo.bar/articles/300666"
+  },
+  {
+    "publishedTitle": "Condimentum commodo ornare nisl ac, ullamcorper habitant et.",
+    "id": "300538",
+    "view_uri": "http://foo.bar/articles/300538"
+  }
+]

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -489,9 +489,7 @@ const BaseSystemAdvisor = ({ entity }) => {
         await Get(
           `https://access.redhat.com/hydra/rest/search/kcs?q=id:(${kbaIds.join(
             ` OR `
-          )})&fl=view_uri,id,publishedTitle&rows=${
-            kbaIds.length
-          }&redhat_client=$ADVISOR`,
+          )})&fl=view_uri,id,publishedTitle&redhat_client=$ADVISOR`,
           {},
           { credentials: 'include' }
         )


### PR DESCRIPTION
# Description

Associated Jira ticket: https://issues.redhat.com/browse/ADVISOR-2948.

SystemAdvisor table renders so-called "Knowledgebase article" section where it also inserts a link to access.redhat.com with info relevant for particular rule. To learn the appropriate URL and publish title, it makes additional request to access.redhat.com API and provides all necessary rule (node) IDs. The issue is that we were providing this request also the parameter `rows` and it was set to the number of rule IDs. However, the API can return more results, and in some edge cases (see Jira), there can be some rules left out from the response, and the table was breaking. By removing `rows` parameter, we are making sure we receive kcs links for all node IDs.

# How to test the PR

The scenario is hard to simulate, but I checked the customer case and simulated the API fixtures that lead to this issue (check `fixturesKcs`) and wrote some cypress tests that have to pass. 

# Before the change

The table would break if it hasn't fetched all URLs and titles for all node ids.

# After the change

The response from API should contain all URLs for all node ids.

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
