### PR TITLE
fix(ghactions): fixing release in gh actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,12 +8,13 @@ jobs:
   CICD:
     runs-on: ubuntu-latest
     env:
-      BRANCH: "${{ github.ref_name }}:-${{ github.head_ref }}"
-      TRAVIS_PULL_REQUEST_BRANCH: ${{ github.ref_name }}
-      TRAVIS_BRANCH: ${{ github.head_ref }}
+      BRANCH: "${{ github.head_ref }}"
+      TRAVIS_BRANCH: ${{ github.base_ref }}
       REPO: "git@github.com:RedHatInsights/insights-advisor-frontend-build"
       REPO_DIR: "insights-advisor-frontend-build"
     steps:
+      - name: "Name target branch"
+        run: echo "$TRAVIS_BRANCH"
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install dependencies


### PR DESCRIPTION
# Description
Fixing the release bug
The issue was - instead of using the target of the pull request as TRAVIS_BRANCH variable I was using the current branch

Source
https://stackoverflow.com/questions/62331829/how-to-get-the-target-branch-of-the-github-pull-request-from-an-actions
# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
