### PR TITLE
fix(ADVISOR-2942): fix enable all recs button

### DIFF
--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -207,7 +207,12 @@ const OverviewDetails = () => {
                       isInline
                       variant="link"
                       onClick={() =>
-                        bulkHostActions(refetch, addNotification, intl, rule)
+                        bulkHostActions({
+                          refetch,
+                          addNotification,
+                          intl,
+                          rule,
+                        })
                       }
                       ouiaId="bulkHost"
                     >


### PR DESCRIPTION
# Description

Associated Jira ticket: # [(ADVISOR-2942)](https://issues.redhat.com/browse/ADVISOR-2942)

Fixes 'Enabling recommendation for all systems' by correctly passing function parameters. 


# How to test the PR

1. Visit Advisor recommendations tab.
2. Open any recommendation systems page.
3. Select a few systems
4. From actions in the table toolbar, click on 'Disable recommendation for selected systems'
5. click on new appeared 'Enable this recommendation for all systems' button to re-enable
6. Observer that page does not break

# Before the change


# After the change


# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
