### PR TITLE
fix(travis):remove test step from travis and update nyc

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "translations:compile": "npx formatjs compile ./build/messages/src/Messages.json --out-file ./locales/translations.json",
     "translations:datafile": "node scripts/createDataJson.js",
     "travis:build": "NODE_ENV=production webpack --config config/prod.webpack.config.js",
-    "travis:verify": "npm-run-all travis:build lint test",
+    "travis:verify": "npm-run-all travis:build lint",
     "verify": "npm-run-all build lint test",
     "coverage:clean": "rm -rf .nyc_output coverage reports",
     "coverage": "bash coverage.sh && npm run coverage:clean"
@@ -150,12 +150,7 @@
   "nyc": {
     "report-dir": "cypress-coverage",
     "include": [
-      "src/Modules",
-      "src/PresentationalComponents",
-      "src/Services",
-      "src/SmartComponents",
-      "src/Store",
-      "src/Utilities"
+      "src/**/*"
     ],
     "exclude": [
       "src/**/*.spec.ct.js",


### PR DESCRIPTION
# Description
When I was moving deploy back to Travis I added a test step back as well
This PR removes this test step from Travis because it's already present in the GitHub actions
Also, I updated nyc settings to read from any folder under src



# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
