### PR TITLE
fix(ADVIOSR-2957):Updating advisor to match inventory &fix pagination…

### DIFF
--- a/src/PresentationalComponents/Inventory/helpers.js
+++ b/src/PresentationalComponents/Inventory/helpers.js
@@ -95,7 +95,6 @@ export const getEntities =
     const results = await defaultGetEntities(
       fetchedSystems.data.map((system) => system.system_uuid),
       {
-        page,
         per_page,
         hasItems: true,
         fields: { system_profile: ['operating_system'] },

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -295,7 +295,6 @@ const SystemsTable = () => {
           const results = await defaultGetEntities(
             fetchedSystems.data.map((system) => system.system_uuid),
             {
-              page,
               per_page,
               hasItems: true,
               fields: { system_profile: ['operating_system'] },


### PR DESCRIPTION
In Advisor recommendations and systems table (inventory tables), when going to a new set a systems via pagination, the table breaks. This is because of the new commit in beta env [here](https://github.com/RedHatInsights/insights-inventory-frontend/commit/7999a28e9023c51f1646535f96c71853838f7d7a) 
# Description

Associated Jira ticket: # ([ADVIOSR-2957](https://issues.redhat.com/browse/ADVISOR-2957))

# How to test the PR
Go to recommendations, select one to go to the details (inventory page)
Go through pagination pages 
Verify that a system isnt showing up twice via control find

Please include steps to test your PR.

# Before the change
Inventory tables break

# After the change
Inventory table can flip through pages with no issues

# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
