### PR TITLE
fix(ADVISOR-2965): adds check against url

### DIFF
--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -73,11 +73,15 @@ export const urlFilterBuilder = (
   let sortingValues = Object.values(sortIndices);
   const paramsObject = paramParser();
   delete paramsObject.tags;
-  if (
-    !sortingValues?.includes(paramsObject.sort) ||
-    !sortingValues?.includes(paramsObject.sort[0]) ||
-    !sortingValues?.includes(`-${paramsObject.sort[0]}`)
-  ) {
+
+  if (Array.isArray(paramsObject.sort)) {
+    if (
+      !sortingValues?.includes(paramsObject.sort[0]) ||
+      !sortingValues?.includes(`-${paramsObject.sort[0]}`)
+    ) {
+      paramsObject.sort = '-total_risk';
+    }
+  } else if (!sortingValues?.includes(paramsObject.sort)) {
     paramsObject.sort = '-total_risk';
   }
   paramsObject.text === undefined


### PR DESCRIPTION
Bandaid fix for advisors sorting issue on page load. Sometimes the value is an array and others a string. This adds conditions to that check. 
Still investigating the real issue at hand but I wanted to send this up as its listed other major incidents. 

Associated Jira ticket: # (issue)

Please include a summary of the change, what this fixes/creates/improves.


# How to test the PR

go to Recommendations page
apply a filter (NOT name filter)
copy the URL
navigate to the URL in a new tab

# Before the change
breaks on sort in url

# After the change
Does not break

# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
