### PR TITLE
chore(RHIF-175): get rid of AppInfo with some code cleanup

### DIFF
--- a/src/PresentationalComponents/Inventory/InventoryDetails.js
+++ b/src/PresentationalComponents/Inventory/InventoryDetails.js
@@ -1,5 +1,4 @@
 import {
-  AppInfo,
   DetailWrapper,
   InventoryDetailHead,
 } from '@redhat-cloud-services/frontend-components/Inventory';
@@ -10,7 +9,6 @@ import {
 import React, { useEffect } from 'react';
 import { connect, useStore } from 'react-redux';
 import { Title } from '@patternfly/react-core/dist/js/components/Title/Title';
-
 import Breadcrumbs from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
 import { PageHeader } from '@redhat-cloud-services/frontend-components/PageHeader';
 import PropTypes from 'prop-types';
@@ -18,6 +16,7 @@ import { entitiesDetailsReducer } from '../../Store/AppReducer';
 import messages from '../../Messages';
 import { updateReducers } from '../../Store';
 import { useIntl } from 'react-intl';
+import SystemAdvisor from '../../SmartComponents/SystemAdvisor';
 
 const InventoryDetails = ({ entity }) => {
   const intl = useIntl();
@@ -46,14 +45,18 @@ const InventoryDetails = ({ entity }) => {
         <InventoryDetailHead hideBack fallback="" />
       </PageHeader>
       <section className="pf-l-page__main-section pf-c-page__main-section">
-        <Title className="pf-u-mb-lg" headingLevel="h3" size="2xl">
-          {intl.formatMessage(messages.recommendations)}
-        </Title>
-        <Grid hasGutter>
-          <GridItem span={12}>
-            <AppInfo fallback="" />
-          </GridItem>
-        </Grid>
+        {entity && (
+          <>
+            <Title className="pf-u-mb-lg" headingLevel="h3" size="2xl">
+              {intl.formatMessage(messages.recommendations)}
+            </Title>
+            <Grid hasGutter>
+              <GridItem span={12}>
+                <SystemAdvisor fallback="" />
+              </GridItem>
+            </Grid>
+          </>
+        )}
       </section>
     </DetailWrapper>
   );

--- a/src/PresentationalComponents/Inventory/InventoryDetails.js
+++ b/src/PresentationalComponents/Inventory/InventoryDetails.js
@@ -17,10 +17,12 @@ import messages from '../../Messages';
 import { updateReducers } from '../../Store';
 import { useIntl } from 'react-intl';
 import SystemAdvisor from '../../SmartComponents/SystemAdvisor';
+import { useParams } from 'react-router-dom';
 
 const InventoryDetails = ({ entity }) => {
   const intl = useIntl();
   const store = useStore();
+  const { inventoryId } = useParams();
   useEffect(() => {
     if (entity && (entity.display_name || entity.id)) {
       const subnav = `${entity.display_name || entity.id} - ${
@@ -45,18 +47,14 @@ const InventoryDetails = ({ entity }) => {
         <InventoryDetailHead hideBack fallback="" />
       </PageHeader>
       <section className="pf-l-page__main-section pf-c-page__main-section">
-        {entity && (
-          <>
-            <Title className="pf-u-mb-lg" headingLevel="h3" size="2xl">
-              {intl.formatMessage(messages.recommendations)}
-            </Title>
-            <Grid hasGutter>
-              <GridItem span={12}>
-                <SystemAdvisor fallback="" />
-              </GridItem>
-            </Grid>
-          </>
-        )}
+        <Title className="pf-u-mb-lg" headingLevel="h3" size="2xl">
+          {intl.formatMessage(messages.recommendations)}
+        </Title>
+        <Grid hasGutter>
+          <GridItem span={12}>
+            <SystemAdvisor fallback="" inventoryId={inventoryId} />
+          </GridItem>
+        </Grid>
       </section>
     </DetailWrapper>
   );

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.cy.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.cy.js
@@ -53,6 +53,7 @@ describe('system rules table', () => {
             id: SYSTEM_ID,
             insights_id: SYSTEM_INSIGHTS_ID,
           }}
+          inventoryId={SYSTEM_ID}
         />
       </Wrapper>
     );

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -29,7 +29,7 @@ import {
   useProcessRemediation,
 } from './SystemAdvisorAssets';
 
-const BaseSystemAdvisor = ({ entity }) => {
+const BaseSystemAdvisor = ({ entity, inventoryId }) => {
   const intl = useIntl();
   const systemAdvisorRef = useRef({
     rowCount: 0,
@@ -339,7 +339,7 @@ const BaseSystemAdvisor = ({ entity }) => {
     setRows(builtRows);
   };
 
-  const processRemediation = useProcessRemediation(entity);
+  const processRemediation = useProcessRemediation(inventoryId);
   const filterConfigItems = getFilters(
     filters,
     searchValue,
@@ -351,7 +351,7 @@ const BaseSystemAdvisor = ({ entity }) => {
     const dataFetch = async () => {
       try {
         const reportsFetch = await Get(
-          `${BASE_URL}/system/${entity.id}/reports/`,
+          `${BASE_URL}/system/${inventoryId}/reports/`,
           {
             credentials: 'include',
           }
@@ -380,7 +380,7 @@ const BaseSystemAdvisor = ({ entity }) => {
   }, []);
 
   return inventoryReportFetchStatus === 'fulfilled' &&
-    entity.insights_id === null ? (
+    entity?.insights_id === null ? (
     <NotConnected
       titleText={intl.formatMessage(messages.notConnectedTitle)}
       bodyText={intl.formatMessage(messages.notConnectedBody)}
@@ -389,7 +389,7 @@ const BaseSystemAdvisor = ({ entity }) => {
   ) : (
     <div className="ins-c-inventory-insights__overrides">
       {inventoryReportFetchStatus === 'pending' ||
-      entity.insights_id === null ? (
+      entity?.insights_id === null ? (
         <Fragment />
       ) : (
         <PrimaryToolbar
@@ -445,6 +445,7 @@ BaseSystemAdvisor.propTypes = {
     insights_id: PropTypes.string,
     id: PropTypes.string,
   }),
+  inventoryId: PropTypes.string.isRequired,
 };
 
 const SystemAdvisor = ({ ...props }) => {

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -1,19 +1,6 @@
 import './SystemAdvisor.scss';
-
-import { AnsibeTowerIcon } from '@patternfly/react-icons';
-import {
-  BASE_URL,
-  FILTER_CATEGORIES as FC,
-  IMPACT_LABEL,
-  LIKELIHOOD_LABEL,
-  RULE_CATEGORIES,
-} from '../../AppConstants';
-import {
-  Card,
-  CardBody,
-  Tooltip,
-  TooltipPosition,
-} from '@patternfly/react-core';
+import { BASE_URL, FILTER_CATEGORIES as FC } from '../../AppConstants';
+import { Card, CardBody } from '@patternfly/react-core';
 import { useIntl } from 'react-intl';
 import React, { Fragment, useEffect, useRef, useState } from 'react';
 import {
@@ -22,32 +9,25 @@ import {
   TableBody,
   TableHeader,
   TableVariant,
-  fitContent,
-  sortable,
 } from '@patternfly/react-table';
 import { useDispatch, useSelector } from 'react-redux';
 
-import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
 import { Get } from '../../Utilities/Api';
-import InsightsLabel from '@redhat-cloud-services/frontend-components/InsightsLabel';
 import { List } from 'react-content-loader';
 import PrimaryToolbar from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
 import PropTypes from 'prop-types';
 import RemediationButton from '@redhat-cloud-services/frontend-components-remediations/RemediationButton';
-import { ReportDetails } from '@redhat-cloud-services/frontend-components-advisor-components/ReportDetails';
-import RuleLabels from '../../PresentationalComponents/Labels/RuleLabels';
 import { addNotification as addNotificationAction } from '@redhat-cloud-services/frontend-components-notifications/';
 import { capitalize } from '../../PresentationalComponents/Common/Tables';
 import messages from '../../Messages';
-import {
-  NoMatchingRecommendations,
-  NoRecommendations,
-  InsightsNotEnabled,
-  InventoryReportFetchFailed,
-} from './EmptyStates';
 import NotConnected from '@redhat-cloud-services/frontend-components/NotConnected';
-import { useLocation } from 'react-router-dom';
 import get from 'lodash/get';
+import {
+  getColumns,
+  getFilters,
+  useBuildRows,
+  useProcessRemediation,
+} from './SystemAdvisorAssets';
 
 const BaseSystemAdvisor = ({ entity }) => {
   const intl = useIntl();
@@ -79,28 +59,7 @@ const BaseSystemAdvisor = ({ entity }) => {
     (r) => r.resolution?.has_playbook
   ).length;
 
-  const cols = [
-    {
-      title: intl.formatMessage(messages.topicAddEditDescription),
-      transforms: [sortable],
-    },
-    {
-      title: intl.formatMessage(messages.modified),
-      transforms: [sortable, fitContent],
-    },
-    {
-      title: intl.formatMessage(messages.firstImpacted),
-      transforms: [sortable, fitContent],
-    },
-    {
-      title: intl.formatMessage(messages.totalRisk),
-      transforms: [sortable, fitContent],
-    },
-    {
-      title: intl.formatMessage(messages.remediation),
-      transforms: [sortable, fitContent],
-    },
-  ];
+  const cols = getColumns(intl);
 
   const onExpandAllClick = (_e, isOpen) => {
     setIsAllExpanded(isOpen);
@@ -160,214 +119,13 @@ const BaseSystemAdvisor = ({ entity }) => {
     collapseRows[rowId] = { ...collapseRows[rowId], isOpen };
     setRows(collapseRows);
   };
-  const location = useLocation().pathname?.split('/');
 
-  const buildRows = (
-    activeReports,
-    kbaDetails,
-    filters,
-    rows,
-    searchValue = '',
-    kbaLoading = false,
-    isFirstLoad = false
-  ) => {
-    const url = window.location.href;
-    let newActiveReportsList = activeReports;
-    let isRulePresent = url.indexOf('activeRule') > -1 ? true : false;
-    if (isRulePresent && isFirstLoad) {
-      let activeRule = location[2];
-      //sorts activeReportsList by making the activeRecommendation ruleId having a higher priority when sorting, or by total_risk
-      newActiveReportsList.sort((x, y) =>
-        x.rule.rule_id === activeRule
-          ? -1
-          : y.rule.rule_id === activeRule
-          ? 1
-          : 0
-      );
-    } else if (isFirstLoad) {
-      newActiveReportsList.sort((x, y) =>
-        x.rule.total_risk > y.rule.total_risk
-          ? -1
-          : y.rule.total_risk > x.rule.total_risk
-          ? 1
-          : 0
-      );
-    }
-
-    const builtRows = newActiveReportsList.flatMap((value, key) => {
-      const rule = value.rule;
-      const resolution = value.resolution;
-      const kbaDetail = Object.keys(kbaDetails).length
-        ? kbaDetails.filter((article) => article.id === value.rule.node_id)[0]
-        : {};
-      const match = rows.find((row) => row?.rule?.rule_id === rule.rule_id);
-      const selected = match?.selected;
-      const isOpen =
-        match?.isOpen || (isRulePresent && isFirstLoad && key === 0);
-
-      const reportRow = [
-        {
-          rule,
-          resolution,
-          //make arrow button disappear when there is no resolution
-          isOpen: resolution ? isOpen : undefined,
-          selected,
-          disableSelection: resolution ? !resolution.has_playbook : true,
-          cells: [
-            {
-              title: (
-                <span>
-                  {rule.description} <RuleLabels rule={rule} />
-                </span>
-              ),
-            },
-            {
-              title: (
-                <span>
-                  <DateFormat
-                    date={rule.publish_date}
-                    type="relative"
-                    tooltipProps={{ position: TooltipPosition.bottom }}
-                  />
-                </span>
-              ),
-            },
-            {
-              title: (
-                <div key={key}>
-                  <DateFormat
-                    date={value.impacted_date}
-                    type="relative"
-                    tooltipProps={{ position: TooltipPosition.bottom }}
-                  />
-                </div>
-              ),
-            },
-            {
-              title: (
-                <div key={key} style={{ verticalAlign: 'top' }}>
-                  <Tooltip
-                    key={key}
-                    position={TooltipPosition.bottom}
-                    content={
-                      <span>
-                        The <strong>likelihood</strong> that this will be a
-                        problem is {LIKELIHOOD_LABEL[rule.likelihood]}. The{' '}
-                        <strong>impact</strong> of the problem would be &nbsp;
-                        {IMPACT_LABEL[rule.impact.impact]} if it occurred.
-                      </span>
-                    }
-                  >
-                    <InsightsLabel value={rule.total_risk} isCompact />
-                  </Tooltip>
-                </div>
-              ),
-            },
-            {
-              title: (
-                <div className="ins-c-center-text" key={key}>
-                  {resolution === null ? (
-                    intl.formatMessage(messages.notAvailable)
-                  ) : resolution?.has_playbook ? (
-                    <span>
-                      <AnsibeTowerIcon size="sm" />{' '}
-                      {intl.formatMessage(messages.playbook)}
-                    </span>
-                  ) : (
-                    intl.formatMessage(messages.manual)
-                  )}
-                </div>
-              ),
-            },
-          ],
-        },
-        resolution && {
-          parent: key,
-          fullWidth: true,
-          cells: [
-            {
-              title: (
-                <ReportDetails
-                  key={`child-${key}`}
-                  report={{
-                    ...value,
-                    resolution: value.resolution.resolution,
-                  }}
-                  kbaDetail={kbaDetail}
-                  kbaLoading={kbaLoading}
-                />
-              ),
-            },
-          ],
-        },
-      ];
-      const isValidSearchValue =
-        searchValue.length === 0 ||
-        rule.description.toLowerCase().includes(searchValue.toLowerCase());
-      const isValidFilterValue =
-        Object.keys(filters).length === 0 ||
-        Object.keys(filters)
-          .map((key) => {
-            const filterValues = filters[key];
-            const rowValue = {
-              has_playbook: value.resolution?.has_playbook,
-              publish_date: rule.publish_date,
-              total_risk: rule.total_risk,
-              category: RULE_CATEGORIES[rule.category.name.toLowerCase()],
-            };
-            return filterValues.find(
-              (value) => String(value) === String(rowValue[key])
-            );
-          })
-          .every((x) => x);
-
-      return isValidSearchValue && isValidFilterValue
-        ? reportRow.filter((row) => row !== null)
-        : [];
-    });
-    //must recalculate parent for expandable table content whenever the array size changes
-    builtRows.forEach((row, index) =>
-      row.parent ? (row.parent = index - 1) : null
-    );
-
-    systemAdvisorRef.current.rowCount = activeReports.length;
-
-    if (activeReports.length < 1 || builtRows.length < 1) {
-      let EmptyState =
-        (builtRows.length === 0 && NoMatchingRecommendations) ||
-        (entity.insights_id && NoRecommendations) ||
-        InsightsNotEnabled;
-
-      return [
-        {
-          heightAuto: true,
-          cells: [
-            {
-              props: { colSpan: 5 },
-              title: <EmptyState />,
-            },
-          ],
-        },
-      ];
-    }
-
-    if (inventoryReportFetchStatus === 'failed') {
-      return [
-        {
-          heightAuto: true,
-          cells: [
-            {
-              props: { colSpan: 5 },
-              title: <InventoryReportFetchFailed entity={entity} />,
-            },
-          ],
-        },
-      ];
-    }
-
-    return builtRows;
-  };
-
+  const buildRows = useBuildRows(
+    intl,
+    systemAdvisorRef,
+    entity,
+    inventoryReportFetchStatus
+  );
   const onRowSelect = (_e, isSelected, rowId) =>
     setRows(
       buildRows(
@@ -581,65 +339,13 @@ const BaseSystemAdvisor = ({ entity }) => {
     setRows(builtRows);
   };
 
-  const processRemediation = (selectedAnsibleRules) => {
-    const playbookRows = selectedAnsibleRules.filter(
-      (r) => r.resolution?.has_playbook
-    );
-    const issues = playbookRows.map((r) => ({
-      id: `advisor:${r.rule.rule_id}`,
-      description: r.rule.description,
-    }));
-    return issues.length ? { issues, systems: [entity.id] } : false;
-  };
-
-  const filterConfigItems = [
-    {
-      label: 'description',
-      filterValues: {
-        key: 'text-filter',
-        onChange: (_e, value) => onInputChange(value),
-        value: searchValue,
-      },
-    },
-    {
-      label: FC.total_risk.title,
-      type: FC.total_risk.type,
-      id: FC.total_risk.urlParam,
-      value: `checkbox-${FC.total_risk.urlParam}`,
-      filterValues: {
-        key: `${FC.total_risk.urlParam}-filter`,
-        onChange: (_e, values) =>
-          onFilterChange(FC.total_risk.urlParam, values),
-        value: filters.total_risk,
-        items: FC.total_risk.values,
-      },
-    },
-    {
-      label: FC.category.title,
-      type: FC.category.type,
-      id: FC.category.urlParam,
-      value: `checkbox-${FC.category.urlParam}`,
-      filterValues: {
-        key: `${FC.category.urlParam}-filter`,
-        onChange: (_e, values) => onFilterChange(FC.category.urlParam, values),
-        value: filters.category,
-        items: FC.category.values,
-      },
-    },
-    {
-      label: FC.has_playbook.title,
-      type: FC.has_playbook.type,
-      id: FC.has_playbook.urlParam,
-      value: `checkbox-${FC.has_playbook.urlParam}`,
-      filterValues: {
-        key: `${FC.has_playbook.urlParam}-filter`,
-        onChange: (_e, values) =>
-          onFilterChange(FC.has_playbook.urlParam, values),
-        value: filters.has_playbook,
-        items: FC.has_playbook.values,
-      },
-    },
-  ];
+  const processRemediation = useProcessRemediation(entity);
+  const filterConfigItems = getFilters(
+    filters,
+    searchValue,
+    onInputChange,
+    onFilterChange
+  );
 
   useEffect(() => {
     const dataFetch = async () => {

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisorAssets.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisorAssets.js
@@ -99,7 +99,7 @@ export const getFilters = (
   },
 ];
 
-export const useProcessRemediation = (entity) =>
+export const useProcessRemediation = (inventoryId) =>
   useCallback(
     (selectedAnsibleRules) => {
       const playbookRows = selectedAnsibleRules.filter(
@@ -109,9 +109,9 @@ export const useProcessRemediation = (entity) =>
         id: `advisor:${r.rule.rule_id}`,
         description: r.rule.description,
       }));
-      return issues.length ? { issues, systems: [entity.id] } : false;
+      return issues.length ? { issues, systems: [inventoryId] } : false;
     },
-    [entity]
+    [inventoryId]
   );
 
 export const useBuildRows = (
@@ -295,7 +295,7 @@ export const useBuildRows = (
       if (activeReports.length < 1 || builtRows.length < 1) {
         let EmptyState =
           (builtRows.length === 0 && NoMatchingRecommendations) ||
-          (entity.insights_id && NoRecommendations) ||
+          (entity?.insights_id && NoRecommendations) ||
           InsightsNotEnabled;
 
         return [

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisorAssets.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisorAssets.js
@@ -1,0 +1,332 @@
+import './SystemAdvisor.scss';
+import React, { useCallback } from 'react';
+import { fitContent, sortable } from '@patternfly/react-table';
+import { Tooltip, TooltipPosition } from '@patternfly/react-core';
+import AnsibeTowerIcon from '@patternfly/react-icons/dist/esm/icons/ansibeTower-icon';
+import InsightsLabel from '@redhat-cloud-services/frontend-components/InsightsLabel';
+import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
+import RuleLabels from '../../PresentationalComponents/Labels/RuleLabels';
+import { ReportDetails } from '@redhat-cloud-services/frontend-components-advisor-components/ReportDetails';
+import {
+  FILTER_CATEGORIES as FC,
+  IMPACT_LABEL,
+  LIKELIHOOD_LABEL,
+  RULE_CATEGORIES,
+} from '../../AppConstants';
+import {
+  NoMatchingRecommendations,
+  NoRecommendations,
+  InsightsNotEnabled,
+  InventoryReportFetchFailed,
+} from './EmptyStates';
+import { useLocation } from 'react-router-dom';
+
+import messages from '../../Messages';
+
+export const getColumns = (intl) => [
+  {
+    title: intl.formatMessage(messages.topicAddEditDescription),
+    transforms: [sortable],
+  },
+  {
+    title: intl.formatMessage(messages.modified),
+    transforms: [sortable, fitContent],
+  },
+  {
+    title: intl.formatMessage(messages.firstImpacted),
+    transforms: [sortable, fitContent],
+  },
+  {
+    title: intl.formatMessage(messages.totalRisk),
+    transforms: [sortable, fitContent],
+  },
+  {
+    title: intl.formatMessage(messages.remediation),
+    transforms: [sortable, fitContent],
+  },
+];
+
+export const getFilters = (
+  filters,
+  searchValue,
+  onInputChange,
+  onFilterChange
+) => [
+  {
+    label: 'description',
+    filterValues: {
+      key: 'text-filter',
+      onChange: (_e, value) => onInputChange(value),
+      value: searchValue,
+    },
+  },
+  {
+    label: FC.total_risk.title,
+    type: FC.total_risk.type,
+    id: FC.total_risk.urlParam,
+    value: `checkbox-${FC.total_risk.urlParam}`,
+    filterValues: {
+      key: `${FC.total_risk.urlParam}-filter`,
+      onChange: (_e, values) => onFilterChange(FC.total_risk.urlParam, values),
+      value: filters.total_risk,
+      items: FC.total_risk.values,
+    },
+  },
+  {
+    label: FC.category.title,
+    type: FC.category.type,
+    id: FC.category.urlParam,
+    value: `checkbox-${FC.category.urlParam}`,
+    filterValues: {
+      key: `${FC.category.urlParam}-filter`,
+      onChange: (_e, values) => onFilterChange(FC.category.urlParam, values),
+      value: filters.category,
+      items: FC.category.values,
+    },
+  },
+  {
+    label: FC.has_playbook.title,
+    type: FC.has_playbook.type,
+    id: FC.has_playbook.urlParam,
+    value: `checkbox-${FC.has_playbook.urlParam}`,
+    filterValues: {
+      key: `${FC.has_playbook.urlParam}-filter`,
+      onChange: (_e, values) =>
+        onFilterChange(FC.has_playbook.urlParam, values),
+      value: filters.has_playbook,
+      items: FC.has_playbook.values,
+    },
+  },
+];
+
+export const useProcessRemediation = (entity) =>
+  useCallback(
+    (selectedAnsibleRules) => {
+      const playbookRows = selectedAnsibleRules.filter(
+        (r) => r.resolution?.has_playbook
+      );
+      const issues = playbookRows.map((r) => ({
+        id: `advisor:${r.rule.rule_id}`,
+        description: r.rule.description,
+      }));
+      return issues.length ? { issues, systems: [entity.id] } : false;
+    },
+    [entity]
+  );
+
+export const useBuildRows = (
+  intl,
+  systemAdvisorRef,
+  entity,
+  inventoryReportFetchStatus
+) => {
+  const location = useLocation().pathname?.split('/');
+  return useCallback(
+    (
+      activeReports,
+      kbaDetails,
+      filters,
+      rows,
+      searchValue = '',
+      kbaLoading = false,
+      isFirstLoad = false
+    ) => {
+      const url = window.location.href;
+      let newActiveReportsList = activeReports;
+      let isRulePresent = url.indexOf('activeRule') > -1 ? true : false;
+      if (isRulePresent && isFirstLoad) {
+        let activeRule = location[2];
+        //sorts activeReportsList by making the activeRecommendation ruleId having a higher priority when sorting, or by total_risk
+        newActiveReportsList.sort((x, y) =>
+          x.rule.rule_id === activeRule
+            ? -1
+            : y.rule.rule_id === activeRule
+            ? 1
+            : 0
+        );
+      } else if (isFirstLoad) {
+        newActiveReportsList.sort((x, y) =>
+          x.rule.total_risk > y.rule.total_risk
+            ? -1
+            : y.rule.total_risk > x.rule.total_risk
+            ? 1
+            : 0
+        );
+      }
+
+      const builtRows = newActiveReportsList.flatMap((value, key) => {
+        const rule = value.rule;
+        const resolution = value.resolution;
+        const kbaDetail = Object.keys(kbaDetails).length
+          ? kbaDetails.filter((article) => article.id === value.rule.node_id)[0]
+          : {};
+        const match = rows.find((row) => row?.rule?.rule_id === rule.rule_id);
+        const selected = match?.selected;
+        const isOpen =
+          match?.isOpen || (isRulePresent && isFirstLoad && key === 0);
+
+        const reportRow = [
+          {
+            rule,
+            resolution,
+            //make arrow button disappear when there is no resolution
+            isOpen: resolution ? isOpen : undefined,
+            selected,
+            disableSelection: resolution ? !resolution.has_playbook : true,
+            cells: [
+              {
+                title: (
+                  <span>
+                    {rule.description} <RuleLabels rule={rule} />
+                  </span>
+                ),
+              },
+              {
+                title: (
+                  <span>
+                    <DateFormat
+                      date={rule.publish_date}
+                      type="relative"
+                      tooltipProps={{ position: TooltipPosition.bottom }}
+                    />
+                  </span>
+                ),
+              },
+              {
+                title: (
+                  <div key={key}>
+                    <DateFormat
+                      date={value.impacted_date}
+                      type="relative"
+                      tooltipProps={{ position: TooltipPosition.bottom }}
+                    />
+                  </div>
+                ),
+              },
+              {
+                title: (
+                  <div key={key} style={{ verticalAlign: 'top' }}>
+                    <Tooltip
+                      key={key}
+                      position={TooltipPosition.bottom}
+                      content={
+                        <span>
+                          The <strong>likelihood</strong> that this will be a
+                          problem is {LIKELIHOOD_LABEL[rule.likelihood]}. The{' '}
+                          <strong>impact</strong> of the problem would be &nbsp;
+                          {IMPACT_LABEL[rule.impact.impact]} if it occurred.
+                        </span>
+                      }
+                    >
+                      <InsightsLabel value={rule.total_risk} isCompact />
+                    </Tooltip>
+                  </div>
+                ),
+              },
+              {
+                title: (
+                  <div className="ins-c-center-text" key={key}>
+                    {resolution === null ? (
+                      intl.formatMessage(messages.notAvailable)
+                    ) : resolution?.has_playbook ? (
+                      <span>
+                        <AnsibeTowerIcon size="sm" />{' '}
+                        {intl.formatMessage(messages.playbook)}
+                      </span>
+                    ) : (
+                      intl.formatMessage(messages.manual)
+                    )}
+                  </div>
+                ),
+              },
+            ],
+          },
+          resolution && {
+            parent: key,
+            fullWidth: true,
+            cells: [
+              {
+                title: (
+                  <ReportDetails
+                    key={`child-${key}`}
+                    report={{
+                      ...value,
+                      resolution: value.resolution.resolution,
+                    }}
+                    kbaDetail={kbaDetail}
+                    kbaLoading={kbaLoading}
+                  />
+                ),
+              },
+            ],
+          },
+        ];
+        const isValidSearchValue =
+          searchValue.length === 0 ||
+          rule.description.toLowerCase().includes(searchValue.toLowerCase());
+        const isValidFilterValue =
+          Object.keys(filters).length === 0 ||
+          Object.keys(filters)
+            .map((key) => {
+              const filterValues = filters[key];
+              const rowValue = {
+                has_playbook: value.resolution?.has_playbook,
+                publish_date: rule.publish_date,
+                total_risk: rule.total_risk,
+                category: RULE_CATEGORIES[rule.category.name.toLowerCase()],
+              };
+              return filterValues.find(
+                (value) => String(value) === String(rowValue[key])
+              );
+            })
+            .every((x) => x);
+
+        return isValidSearchValue && isValidFilterValue
+          ? reportRow.filter((row) => row !== null)
+          : [];
+      });
+      //must recalculate parent for expandable table content whenever the array size changes
+      builtRows.forEach((row, index) =>
+        row.parent ? (row.parent = index - 1) : null
+      );
+
+      systemAdvisorRef.current.rowCount = activeReports.length;
+
+      if (activeReports.length < 1 || builtRows.length < 1) {
+        let EmptyState =
+          (builtRows.length === 0 && NoMatchingRecommendations) ||
+          (entity.insights_id && NoRecommendations) ||
+          InsightsNotEnabled;
+
+        return [
+          {
+            heightAuto: true,
+            cells: [
+              {
+                props: { colSpan: 5 },
+                title: <EmptyState />,
+              },
+            ],
+          },
+        ];
+      }
+
+      if (inventoryReportFetchStatus === 'failed') {
+        return [
+          {
+            heightAuto: true,
+            cells: [
+              {
+                props: { colSpan: 5 },
+                title: <InventoryReportFetchFailed entity={entity} />,
+              },
+            ],
+          },
+        ];
+      }
+
+      return builtRows;
+    },
+    [entity, inventoryReportFetchStatus]
+  );
+};

--- a/src/Store/AppReducer.js
+++ b/src/Store/AppReducer.js
@@ -1,4 +1,3 @@
-import Advisor from '../SmartComponents/SystemAdvisor';
 import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
 
 export function systemReducer() {
@@ -23,7 +22,6 @@ function enableApplications(state) {
   return {
     ...state,
     loaded: true,
-    activeApps: [{ title: 'Insights', name: 'insights', component: Advisor }],
   };
 }
 


### PR DESCRIPTION
# Description

Associated Jira ticket: # [RHIF-175](https://issues.redhat.com/browse/RHIF-175)

Removes AppInfo component usage and introduces some code cleanup to SystemAdvisories.

- Moves all easy to extract constants and functions into the assets file
- Wrapps some functions into `useCallback` hook

The next step should be to improve & simplify the functions extracted.

# How to test the PR

Functionality of the app should not change

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
