### PR TITLE
enh(RHIF-178): load react-tokens only using absolute path

### DIFF
--- a/src/PresentationalComponents/Common/Common.js
+++ b/src/PresentationalComponents/Common/Common.js
@@ -14,7 +14,7 @@ import { createIntl, createIntlCache } from 'react-intl';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 import PowerOffIcon from '@patternfly/react-icons/dist/esm/icons/power-off-icon';
 import React from 'react';
-import { global_secondary_color_100 } from '@patternfly/react-tokens';
+import { global_secondary_color_100 } from '@patternfly/react-tokens/dist/js/global_secondary_color_100';
 import messages from '../../Messages';
 import { strong } from '../../Utilities/intlHelper';
 


### PR DESCRIPTION
# Description

Associated Jira ticket: # https://issues.redhat.com/browse/RHIF-178

Loads react-tokens using an absolute path. This enables us to reduce of the bundle by ~200kb.


# How to test the PR

Please include steps to test your PR.

# Before the change

![advisor-before-react-tokens](https://user-images.githubusercontent.com/59481011/220060710-2935aa9b-ccd3-45c6-973a-ef62415aafb1.png)


# After the change

![advisor-after-react-tokens](https://user-images.githubusercontent.com/59481011/219645690-e4078115-7925-4526-8040-8f316e68fbf9.png)

# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
