### PR TITLE
fix(ADVISOR-3030): Fix broken page

### DIFF
--- a/src/PresentationalComponents/PathwaysTable/PathwaysTable.js
+++ b/src/PresentationalComponents/PathwaysTable/PathwaysTable.js
@@ -315,7 +315,8 @@ const PathwaysTable = ({ isTabActive }) => {
         ? setSearchText('')
         : setSearchText(paramsObject.text);
       paramsObject.sort =
-        paramsObject.sort === undefined
+        paramsObject.sort === undefined ||
+        !Object.values(sortIndices).includes(paramsObject?.sort[0])
           ? '-impacted_systems_count'
           : paramsObject.sort[0];
       paramsObject.offset === undefined


### PR DESCRIPTION
# Description

Associated Jira ticket: # (ADVISOR-3030)
When selected a pathway and going to pathway details, sometimes when going back, the page breaks. This is because the sort params on rules table dont coincide with pathway table. 

# How to test the PR
Go to pathway details, then go back a page. The page should not break regardless if the sort in url is -total_risk. 
Also paste in the url : https://stage.foo.redhat.com:1337/beta/insights/advisor/recommendations/pathways?sort=-total_risk&limit=20&offset=0&impacting=true&rule_status=enabled#SIDs=&tags= and see if it breaks
# Before the change
Page breaks

# After the change
Page does not break

# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
