### PR TITLE
fix(ADVISOR-3032)Update empty state when rule is not found

### DIFF
--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -107,41 +107,40 @@ const OverviewDetails = () => {
 
   return (
     <React.Fragment>
-      {viewSystemsModalOpen && !isError && (
-        <ViewHostAcks
-          handleModalToggle={(toggleModal) =>
-            setViewSystemsModalOpen(toggleModal)
-          }
-          isModalOpen={viewSystemsModalOpen}
-          afterFn={() => refetch()}
-          rule={rule}
-        />
-      )}
-      {disableRuleModalOpen && !isError && (
-        <DisableRule
-          handleModalToggle={handleModalToggle}
-          isModalOpen={disableRuleModalOpen}
-          rule={rule}
-          afterFn={afterDisableFn}
-          host={host}
-        />
-      )}
-      {!isFetching && !isError && !topicIsFetching && (
-        <DetailsRules
-          rule={rule}
-          topics={topics}
-          permsDisableRec={permsDisableRec}
-          setActionsDropdownOpen={setActionsDropdownOpen}
-          actionsDropdownOpen={actionsDropdownOpen}
-          addNotification={addNotification}
-          handleModalToggle={handleModalToggle}
-          refetch={refetch}
-        />
-      )}
-      {isFetching && <Loading />}
-      <section className="pf-l-page__main-section pf-c-page__main-section">
-        {!isFetching && !isError ? (
-          <React.Fragment>
+      {!isFetching && !isError ? (
+        <React.Fragment>
+          {viewSystemsModalOpen && (
+            <ViewHostAcks
+              handleModalToggle={(toggleModal) =>
+                setViewSystemsModalOpen(toggleModal)
+              }
+              isModalOpen={viewSystemsModalOpen}
+              afterFn={() => refetch()}
+              rule={rule}
+            />
+          )}
+          {disableRuleModalOpen && (
+            <DisableRule
+              handleModalToggle={handleModalToggle}
+              isModalOpen={disableRuleModalOpen}
+              rule={rule}
+              afterFn={afterDisableFn}
+              host={host}
+            />
+          )}
+          {!isFetching && !topicIsFetching && (
+            <DetailsRules
+              rule={rule}
+              topics={topics}
+              permsDisableRec={permsDisableRec}
+              setActionsDropdownOpen={setActionsDropdownOpen}
+              actionsDropdownOpen={actionsDropdownOpen}
+              addNotification={addNotification}
+              handleModalToggle={handleModalToggle}
+              refetch={refetch}
+            />
+          )}
+          <section className="pf-l-page__main-section pf-c-page__main-section">
             {(rule.hosts_acked_count > 0 || rule.rule_status !== 'enabled') && (
               <Card className="adv-c-card-details">
                 <CardHeader>
@@ -280,13 +279,13 @@ const OverviewDetails = () => {
                 }
               />
             )}
-          </React.Fragment>
-        ) : isError ? (
-          <InvalidObject />
-        ) : (
-          <Loading />
-        )}
-      </section>
+          </section>
+        </React.Fragment>
+      ) : isError ? (
+        <InvalidObject />
+      ) : (
+        <Loading />
+      )}
     </React.Fragment>
   );
 };

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -18,7 +18,7 @@ import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
 
-import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorState';
+import { InvalidObject } from '@redhat-cloud-services/frontend-components/InvalidObject';
 import Inventory from '../../PresentationalComponents/Inventory/Inventory';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import MessageState from '../../PresentationalComponents/MessageState/MessageState';
@@ -107,7 +107,7 @@ const OverviewDetails = () => {
 
   return (
     <React.Fragment>
-      {viewSystemsModalOpen && (
+      {viewSystemsModalOpen && !isError && (
         <ViewHostAcks
           handleModalToggle={(toggleModal) =>
             setViewSystemsModalOpen(toggleModal)
@@ -117,7 +117,7 @@ const OverviewDetails = () => {
           rule={rule}
         />
       )}
-      {disableRuleModalOpen && (
+      {disableRuleModalOpen && !isError && (
         <DisableRule
           handleModalToggle={handleModalToggle}
           isModalOpen={disableRuleModalOpen}
@@ -126,7 +126,7 @@ const OverviewDetails = () => {
           host={host}
         />
       )}
-      {!isFetching && !topicIsFetching && (
+      {!isFetching && !isError && !topicIsFetching && (
         <DetailsRules
           rule={rule}
           topics={topics}
@@ -140,7 +140,7 @@ const OverviewDetails = () => {
       )}
       {isFetching && <Loading />}
       <section className="pf-l-page__main-section pf-c-page__main-section">
-        {!isFetching ? (
+        {!isFetching && !isError ? (
           <React.Fragment>
             {(rule.hosts_acked_count > 0 || rule.rule_status !== 'enabled') && (
               <Card className="adv-c-card-details">
@@ -282,7 +282,7 @@ const OverviewDetails = () => {
             )}
           </React.Fragment>
         ) : isError ? (
-          <ErrorState />
+          <InvalidObject />
         ) : (
           <Loading />
         )}


### PR DESCRIPTION
# Description
Updates empty state behavior so that when a user goes to a bookmark of a rule that no longer exist, they are greeted with the correct page. 

Associated Jira ticket: # (ADVISOR-3032)
# How to test the PR
Head to https://stage.foo.redhat.com:1337/beta/insights/advisor/recommendations/whatever#SIDs=&tags= 
Observe that the page does not error out but instead shows this image
![Screen Shot 2023-04-06 at 5 04 49 PM](https://user-images.githubusercontent.com/60629070/230493756-b6a96223-c9d3-4ef8-aa5a-8931c9df6169.png)
# Before the change
The page would crash and get  "Something went wrong". 

# After the change
Page does not crash anymore.

# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
