### PR TITLE
fix(ADVISOR-3029): Fix Pathway details styling

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -378,7 +378,7 @@ const RulesTable = ({ isTabActive }) => {
             cells: [
               {
                 title: (
-                  <section className="pf-l-page__main-section pf-c-page__main-section">
+                  <section className="pf-c-page__main-section pf-m-light">
                     <Stack hasGutter>
                       {value.hosts_acked_count ? (
                         <StackItem>
@@ -732,7 +732,7 @@ const RulesTable = ({ isTabActive }) => {
           isStickyHeader
         >
           <TableHeader />
-          <TableBody />
+          <TableBody className="pf-m-width-100" />
         </Table>
       )}
       <Pagination

--- a/src/SmartComponents/Recs/DetailsPathways.js
+++ b/src/SmartComponents/Recs/DetailsPathways.js
@@ -151,7 +151,7 @@ const PathwayDetails = () => {
             </p>
             <p className="pf-u-mb-lg">{pathway.description}</p>
           </PageHeader>
-          <section className="pf-u-pb-0">
+          <section className="pf-u-p-lg">
             <Grid hasGutter>
               <GridItem sm={12} md={6}>
                 <TotalRiskCard {...pathway} />
@@ -164,7 +164,7 @@ const PathwayDetails = () => {
         </React.Fragment>
       )}
       {isFetching && <Loading />}
-      <section>
+      <section className="pf-u-px-lg pf-u-pb-lg">
         <Tabs
           className="adv__background--global-100"
           activeKey={activeTab}


### PR DESCRIPTION
# Description

Associated Jira ticket: # (ADVISOR-3029)
This PR reverts some styling issues that snuck-in in the removal of that Main component in this [PR](https://github.com/RedHatInsights/insights-advisor-frontend/pull/1066) 

# How to test the PR
Ensure the padding and colors look the same in a pathway details table as they do in other tables. 
Here is a picture before that PR for reference. 
<img width="1112" alt="Screen Shot 2023-04-07 at 5 05 32 PM" src="https://user-images.githubusercontent.com/60629070/230678852-3247ef7f-a2d9-4c29-9c62-cd09065a57e4.png">


# Before the change
![Screen Shot 2023-04-07 at 5 05 50 PM](https://user-images.githubusercontent.com/60629070/230678877-706dc38f-05e2-4458-8e46-a3c548e07a79.png)



# After the change
![Screen Shot 2023-04-07 at 5 06 12 PM](https://user-images.githubusercontent.com/60629070/230678919-ace11cfd-f30f-4bd5-9768-057df550ec5c.png)
![Screen Shot 2023-04-11 at 5 38 51 PM](https://user-images.githubusercontent.com/60629070/231293979-2754ba9c-cc94-429b-a56f-510a8c334b27.png)


# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
