### PR TITLE
chore(Refactor): Reorganize RulesTable component

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -1,18 +1,13 @@
 import './_RulesTable.scss';
-
 import * as AppConstants from '../../AppConstants';
-
 import { DEBOUNCE_DELAY, FILTER_CATEGORIES as FC } from '../../AppConstants';
-import { Link, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import {
   Pagination,
   PaginationVariant,
 } from '@patternfly/react-core/dist/esm/components/Pagination/Pagination';
 import React, { useEffect, useState } from 'react';
-import {
-  Stack,
-  StackItem,
-} from '@patternfly/react-core/dist/esm/layouts/Stack/index';
+
 import {
   Table,
   TableBody,
@@ -22,53 +17,39 @@ import {
   fitContent,
   sortable,
 } from '@patternfly/react-table';
-import {
-  Tooltip,
-  TooltipPosition,
-} from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
+
 import {
   filterFetchBuilder,
   pruneFilters,
-  ruleResolutionRisk,
   urlBuilder,
   workloadQueryBuilder,
 } from '../Common/Tables';
 import { useDispatch, useSelector } from 'react-redux';
 
-import AnsibeTowerIcon from '@patternfly/react-icons/dist/esm/icons/ansibeTower-icon';
-import BellSlashIcon from '@patternfly/react-icons/dist/esm/icons/bell-slash-icon';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import CategoryLabel from '../Labels/CategoryLabel';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
-import { DeleteApi } from '../../Utilities/Api';
 import DisableRule from '../Modals/DisableRule';
 import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorState';
-import { InsightsLabel } from '@redhat-cloud-services/frontend-components/InsightsLabel';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
-import {
-  RuleDetails,
-  RuleDetailsMessagesKeys,
-  AdvisorProduct,
-} from '@redhat-cloud-services/frontend-components-advisor-components';
-import RuleLabels from '../Labels/RuleLabels';
 import ViewHostAcks from '../../PresentationalComponents/Modals/ViewHostAcks';
-import { addNotification as addNotificationAction } from '@redhat-cloud-services/frontend-components-notifications/';
 import debounce from '../../Utilities/Debounce';
 import downloadReport from '../Common/DownloadHelper';
 import messages from '../../Messages';
-import {
-  formatMessages,
-  mapContentToValues,
-  strong,
-} from '../../Utilities/intlHelper';
+
 import { updateRecFilters } from '../../Services/Filters';
 import { useGetRecsQuery } from '../../Services/Recs';
 import { useIntl } from 'react-intl';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import PropTypes from 'prop-types';
 
-import { emptyRows, urlFilterBuilder } from './helpers';
+import {
+  buildRows,
+  emptyRows,
+  filterConfigItems,
+  hideReports,
+  removeFilterParam,
+  toggleRulesDisabled,
+  urlFilterBuilder,
+} from './helpers';
 
 const RulesTable = ({ isTabActive }) => {
   const intl = useIntl();
@@ -124,7 +105,6 @@ const RulesTable = ({ isTabActive }) => {
   const [viewSystemsModalRule, setViewSystemsModalRule] = useState({});
   const [isAllExpanded, setIsAllExpanded] = useState(false);
 
-  const addNotification = (data) => dispatch(addNotificationAction(data));
   const setFilters = (filters) => dispatch(updateRecFilters(filters));
 
   let options = {};
@@ -173,58 +153,10 @@ const RulesTable = ({ isTabActive }) => {
     setFilters({ ...filters, offset: newOffset });
   };
 
-  const toggleRulesDisabled = (rule_status) => {
-    setFilters({
-      ...filters,
-      rule_status,
-      offset: 0,
-      ...(rule_status !== 'enabled' && { impacting: ['false'] }),
-    });
-  };
-
   const handleOnCollapse = (_e, rowId, isOpen) => {
     const collapseRows = [...rows];
     collapseRows[rowId] = { ...collapseRows[rowId], isOpen };
     setRows(collapseRows);
-  };
-
-  const hideReports = async (rowId) => {
-    const rule = rows[rowId].rule;
-
-    try {
-      if (rule.rule_status === 'enabled') {
-        setSelectedRule(rule);
-        setDisableRuleOpen(true);
-      } else {
-        try {
-          await DeleteApi(`${AppConstants.BASE_URL}/ack/${rule.rule_id}/`);
-          addNotification({
-            variant: 'success',
-            timeout: true,
-            dismissable: true,
-            title: intl.formatMessage(messages.recSuccessfullyEnabled),
-          });
-          refetch();
-        } catch (error) {
-          addNotification({
-            variant: 'danger',
-            dismissable: true,
-            title: intl.formatMessage(messages.error),
-            description: `${error}`,
-          });
-        }
-      }
-    } catch (error) {
-      addNotification({
-        variant: 'danger',
-        dismissable: true,
-        title:
-          rule.rule_status === 'enabled'
-            ? intl.formatMessage(messages.rulesTableHideReportsErrorDisabled)
-            : intl.formatMessage(messages.rulesTableHideReportsErrorEnabled),
-        description: `${error}`,
-      });
-    }
   };
 
   const actionResolver = (rowData, { rowIndex }) => {
@@ -237,13 +169,31 @@ const RulesTable = ({ isTabActive }) => {
       ? [
           {
             title: intl.formatMessage(messages.disableRule),
-            onClick: (_event, rowId) => hideReports(rowId),
+            onClick: (_event, rowId) =>
+              hideReports(
+                rowId,
+                rows,
+                setSelectedRule,
+                setDisableRuleOpen,
+                refetch,
+                dispatch,
+                intl
+              ),
           },
         ]
       : [
           {
             title: intl.formatMessage(messages.enableRule),
-            onClick: (_event, rowId) => hideReports(rowId),
+            onClick: (_event, rowId) =>
+              hideReports(
+                rowId,
+                rows,
+                setSelectedRule,
+                setDisableRuleOpen,
+                refetch,
+                dispatch,
+                intl
+              ),
           },
         ];
   };
@@ -284,161 +234,13 @@ const RulesTable = ({ isTabActive }) => {
       if (rules.data.length === 0) {
         setRows(emptyRows(filters, toggleRulesDisabled));
       } else {
-        const rows = rules.data.flatMap((value, key) => [
-          {
-            isOpen: isAllExpanded,
-            rule: value,
-            cells: [
-              {
-                title: (
-                  <span key={key}>
-                    <Link key={key} to={`/recommendations/${value.rule_id}`}>
-                      {' '}
-                      {value.description}{' '}
-                    </Link>
-                    <RuleLabels rule={value} isCompact />
-                  </span>
-                ),
-              },
-              {
-                title: (
-                  <DateFormat
-                    key={key}
-                    date={value.publish_date}
-                    variant="relative"
-                  />
-                ),
-              },
-              {
-                title: (
-                  <CategoryLabel
-                    key={key}
-                    labelList={[value.category]}
-                    isCompact
-                  />
-                ),
-              },
-              {
-                title: (
-                  <div key={key}>
-                    <Tooltip
-                      key={key}
-                      position={TooltipPosition.bottom}
-                      content={intl.formatMessage(
-                        messages.rulesDetailsTotalRiskBody,
-                        {
-                          risk:
-                            AppConstants.TOTAL_RISK_LABEL_LOWER[
-                              value.total_risk
-                            ] || intl.formatMessage(messages.undefined),
-                          strong: (str) => strong(str),
-                        }
-                      )}
-                    >
-                      <InsightsLabel value={value.total_risk} isCompact />
-                    </Tooltip>
-                  </div>
-                ),
-              },
-              {
-                title:
-                  value.rule_status === 'rhdisabled' ? (
-                    <Tooltip
-                      content={intl.formatMessage(messages.byEnabling, {
-                        systems: value.impacted_systems_count,
-                      })}
-                    >
-                      <span>{intl.formatMessage(messages.nA)}</span>
-                    </Tooltip>
-                  ) : (
-                    <div
-                      key={key}
-                    >{`${value.impacted_systems_count.toLocaleString()}`}</div>
-                  ),
-              },
-              {
-                title: (
-                  <div className="ins-c-center-text " key={key}>
-                    {value.playbook_count ? (
-                      <span>
-                        <AnsibeTowerIcon size="sm" />{' '}
-                        {intl.formatMessage(messages.playbook)}
-                      </span>
-                    ) : (
-                      intl.formatMessage(messages.manual)
-                    )}
-                  </div>
-                ),
-              },
-            ],
-          },
-          {
-            parent: key * 2,
-            fullWidth: true,
-            cells: [
-              {
-                title: (
-                  <section className="pf-c-page__main-section pf-m-light">
-                    <Stack hasGutter>
-                      {value.hosts_acked_count ? (
-                        <StackItem>
-                          <BellSlashIcon size="sm" />
-                          &nbsp;
-                          {value.hosts_acked_count &&
-                          !value.impacted_systems_count
-                            ? intl.formatMessage(
-                                messages.ruleIsDisabledForAllSystems
-                              )
-                            : intl.formatMessage(
-                                messages.ruleIsDisabledForSystemsBody,
-                                { systems: value.hosts_acked_count }
-                              )}
-                          &nbsp;{' '}
-                          <Button
-                            isInline
-                            variant="link"
-                            ouiaId="viewSystem"
-                            onClick={() => {
-                              setViewSystemsModalRule(value);
-                              setViewSystemsModalOpen(true);
-                            }}
-                          >
-                            {intl.formatMessage(messages.viewSystems)}
-                          </Button>
-                        </StackItem>
-                      ) : (
-                        <React.Fragment></React.Fragment>
-                      )}
-                      <RuleDetails
-                        messages={formatMessages(
-                          intl,
-                          RuleDetailsMessagesKeys,
-                          mapContentToValues(intl, value)
-                        )}
-                        product={AdvisorProduct.rhel}
-                        rule={value}
-                        resolutionRisk={ruleResolutionRisk(value)}
-                        resolutionRiskDesc={
-                          AppConstants.RISK_OF_CHANGE_DESC[
-                            ruleResolutionRisk(value)
-                          ]
-                        }
-                        isDetailsPage={false}
-                        showViewAffected
-                        linkComponent={Link}
-                        knowledgebaseUrl={
-                          value.node_id
-                            ? `https://access.redhat.com/node/${value.node_id}`
-                            : ''
-                        }
-                      />
-                    </Stack>
-                  </section>
-                ),
-              },
-            ],
-          },
-        ]);
+        const rows = buildRows(
+          rules,
+          isAllExpanded,
+          setViewSystemsModalRule,
+          setViewSystemsModalOpen,
+          intl
+        );
         setRows(rows);
       }
     }
@@ -454,159 +256,6 @@ const RulesTable = ({ isTabActive }) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedSearchText]);
-
-  const removeFilterParam = (param) => {
-    const filter = { ...filters, offset: 0 };
-    param === 'text' && setSearchText('');
-    delete filter[param];
-    setFilters(filter);
-  };
-
-  const addFilterParam = (param, values) => {
-    values.length > 0
-      ? setFilters({ ...filters, offset: 0, ...{ [param]: values } })
-      : removeFilterParam(param);
-  };
-
-  const filterConfigItems = [
-    {
-      label: intl.formatMessage(messages.name).toLowerCase(),
-      filterValues: {
-        key: 'text-filter',
-        onChange: (_event, value) => setSearchText(value),
-        value: searchText,
-        placeholder: intl.formatMessage(messages.filterBy),
-      },
-    },
-    {
-      label: FC.total_risk.title,
-      type: FC.total_risk.type,
-      id: FC.total_risk.urlParam,
-      value: `checkbox-${FC.total_risk.urlParam}`,
-      filterValues: {
-        key: `${FC.total_risk.urlParam}-filter`,
-        onChange: (_event, values) =>
-          addFilterParam(FC.total_risk.urlParam, values),
-        value: filters.total_risk,
-        items: FC.total_risk.values,
-      },
-    },
-    {
-      label: FC.res_risk.title,
-      type: FC.res_risk.type,
-      id: FC.res_risk.urlParam,
-      value: `checkbox-${FC.res_risk.urlParam}`,
-      filterValues: {
-        key: `${FC.res_risk.urlParam}-filter`,
-        onChange: (_event, values) =>
-          addFilterParam(FC.res_risk.urlParam, values),
-        value: filters.res_risk,
-        items: FC.res_risk.values,
-      },
-    },
-    {
-      label: FC.impact.title,
-      type: FC.impact.type,
-      id: FC.impact.urlParam,
-      value: `checkbox-${FC.impact.urlParam}`,
-      filterValues: {
-        key: `${FC.impact.urlParam}-filter`,
-        onChange: (_event, values) =>
-          addFilterParam(FC.impact.urlParam, values),
-        value: filters.impact,
-        items: FC.impact.values,
-      },
-    },
-    {
-      label: FC.likelihood.title,
-      type: FC.likelihood.type,
-      id: FC.likelihood.urlParam,
-      value: `checkbox-${FC.likelihood.urlParam}`,
-      filterValues: {
-        key: `${FC.likelihood.urlParam}-filter`,
-        onChange: (_event, values) =>
-          addFilterParam(FC.likelihood.urlParam, values),
-        value: filters.likelihood,
-        items: FC.likelihood.values,
-      },
-    },
-    {
-      label: FC.category.title,
-      type: FC.category.type,
-      id: FC.category.urlParam,
-      value: `checkbox-${FC.category.urlParam}`,
-      filterValues: {
-        key: `${FC.category.urlParam}-filter`,
-        onChange: (_event, values) =>
-          addFilterParam(FC.category.urlParam, values),
-        value: filters.category,
-        items: FC.category.values,
-      },
-    },
-    {
-      label: FC.incident.title,
-      type: FC.incident.type,
-      id: FC.incident.urlParam,
-      value: `checkbox-${FC.incident.urlParam}`,
-      filterValues: {
-        key: `${FC.incident.urlParam}-filter`,
-        onChange: (_event, values) =>
-          addFilterParam(FC.incident.urlParam, values),
-        value: filters.incident,
-        items: FC.incident.values,
-      },
-    },
-    {
-      label: FC.has_playbook.title,
-      type: FC.has_playbook.type,
-      id: FC.has_playbook.urlParam,
-      value: `checkbox-${FC.has_playbook.urlParam}`,
-      filterValues: {
-        key: `${FC.has_playbook.urlParam}-filter`,
-        onChange: (_event, values) =>
-          addFilterParam(FC.has_playbook.urlParam, values),
-        value: filters.has_playbook,
-        items: FC.has_playbook.values,
-      },
-    },
-    {
-      label: FC.reboot.title,
-      type: FC.reboot.type,
-      id: FC.reboot.urlParam,
-      value: `checkbox-${FC.reboot.urlParam}`,
-      filterValues: {
-        key: `${FC.reboot.urlParam}-filter`,
-        onChange: (_event, values) =>
-          addFilterParam(FC.reboot.urlParam, values),
-        value: filters.reboot,
-        items: FC.reboot.values,
-      },
-    },
-    {
-      label: FC.rule_status.title,
-      type: FC.rule_status.type,
-      id: FC.rule_status.urlParam,
-      value: `radio-${FC.rule_status.urlParam}`,
-      filterValues: {
-        key: `${FC.rule_status.urlParam}-filter`,
-        onChange: (_event, value) => toggleRulesDisabled(value),
-        value: `${filters.rule_status}`,
-        items: FC.rule_status.values,
-      },
-    },
-    {
-      label: FC.impacting.title,
-      type: FC.impacting.type,
-      id: FC.impacting.urlParam,
-      value: `checkbox-${FC.impacting.urlParam}`,
-      filterValues: {
-        key: `${FC.impacting.urlParam}-filter`,
-        onChange: (e, values) => addFilterParam(FC.impacting.urlParam, values),
-        value: filters.impacting,
-        items: FC.impacting.values,
-      },
-    },
-  ];
 
   const activeFiltersConfig = {
     deleteTitle: intl.formatMessage(messages.resetFilters),
@@ -634,14 +283,15 @@ const RulesTable = ({ isTabActive }) => {
           };
           newFilter[item.urlParam].length > 0
             ? setFilters({ ...filters, ...newFilter })
-            : removeFilterParam(item.urlParam);
+            : removeFilterParam(
+                item.urlParam,
+                filters,
+                setFilters,
+                setSearchText
+              );
         });
       }
     },
-  };
-
-  const afterViewSystemsFn = () => {
-    refetch();
   };
 
   const onExpandAllClick = (_e, isOpen) => {
@@ -664,7 +314,7 @@ const RulesTable = ({ isTabActive }) => {
             setViewSystemsModalOpen(toggleModal)
           }
           isModalOpen={viewSystemsModalOpen}
-          afterFn={afterViewSystemsFn}
+          afterFn={refetch}
           rule={viewSystemsModalRule}
         />
       )}
@@ -709,7 +359,15 @@ const RulesTable = ({ isTabActive }) => {
             ? intl.formatMessage(messages.exportData)
             : intl.formatMessage(messages.permsAction),
         }}
-        filterConfig={{ items: filterConfigItems }}
+        filterConfig={{
+          items: filterConfigItems(
+            filters,
+            setFilters,
+            searchText,
+            setSearchText,
+            intl
+          ),
+        }}
         activeFiltersConfig={activeFiltersConfig}
       />
       {isFetching ? (

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -47,7 +47,6 @@ import {
   filterConfigItems,
   hideReports,
   removeFilterParam,
-  toggleRulesDisabled,
   urlFilterBuilder,
 } from './helpers';
 
@@ -157,6 +156,14 @@ const RulesTable = ({ isTabActive }) => {
     const collapseRows = [...rows];
     collapseRows[rowId] = { ...collapseRows[rowId], isOpen };
     setRows(collapseRows);
+  };
+  const toggleRulesDisabled = (rule_status) => {
+    setFilters({
+      ...filters,
+      rule_status,
+      offset: 0,
+      ...(rule_status !== 'enabled' && { impacting: ['false'] }),
+    });
   };
 
   const actionResolver = (rowData, { rowIndex }) => {
@@ -365,6 +372,7 @@ const RulesTable = ({ isTabActive }) => {
             setFilters,
             searchText,
             setSearchText,
+            toggleRulesDisabled,
             intl
           ),
         }}

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -1,8 +1,41 @@
 import React from 'react';
-import { Text } from '@patternfly/react-core';
 import EmptyState from './Components/EmptyState';
 import { FormattedMessage } from 'react-intl';
 import { paramParser } from '../Common/Tables';
+import { DeleteApi } from '../../Utilities/Api';
+import { addNotification as addNotificationAction } from '@redhat-cloud-services/frontend-components-notifications/';
+import * as AppConstants from '../../AppConstants';
+import messages from '../../Messages';
+import { FILTER_CATEGORIES as FC } from '../../AppConstants';
+import { Link } from 'react-router-dom';
+import {
+  Stack,
+  StackItem,
+} from '@patternfly/react-core/dist/esm/layouts/Stack/index';
+import { Text } from '@patternfly/react-core';
+import {
+  Tooltip,
+  TooltipPosition,
+} from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
+import { InsightsLabel } from '@redhat-cloud-services/frontend-components/InsightsLabel';
+import AnsibeTowerIcon from '@patternfly/react-icons/dist/esm/icons/ansibeTower-icon';
+import BellSlashIcon from '@patternfly/react-icons/dist/esm/icons/bell-slash-icon';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import {
+  RuleDetails,
+  RuleDetailsMessagesKeys,
+  AdvisorProduct,
+} from '@redhat-cloud-services/frontend-components-advisor-components';
+import RuleLabels from '../Labels/RuleLabels';
+import CategoryLabel from '../Labels/CategoryLabel';
+
+import {
+  formatMessages,
+  mapContentToValues,
+  strong,
+} from '../../Utilities/intlHelper';
+import { ruleResolutionRisk } from '../Common/Tables';
 
 export const emptyRows = (filters, toggleRulesDisabled) => [
   {
@@ -106,4 +139,381 @@ export const urlFilterBuilder = (
     !Array.isArray(paramsObject.impacting) &&
     (paramsObject.impacting = [`${paramsObject.impacting}`]);
   setFilters({ ...filters, ...paramsObject });
+};
+
+export const hideReports = async (
+  rowId,
+  rows,
+  setSelectedRule,
+  setDisableRuleOpen,
+  refetch,
+  dispatch,
+  intl
+) => {
+  const rule = rows[rowId].rule;
+  const addNotification = (data) => dispatch(addNotificationAction(data));
+
+  try {
+    if (rule.rule_status === 'enabled') {
+      setSelectedRule(rule);
+      setDisableRuleOpen(true);
+    } else {
+      try {
+        await DeleteApi(`${AppConstants.BASE_URL}/ack/${rule.rule_id}/`);
+        addNotification({
+          variant: 'success',
+          timeout: true,
+          dismissable: true,
+          title: intl.formatMessage(messages.recSuccessfullyEnabled),
+        });
+        refetch();
+      } catch (error) {
+        addNotification({
+          variant: 'danger',
+          dismissable: true,
+          title: intl.formatMessage(messages.error),
+          description: `${error}`,
+        });
+      }
+    }
+  } catch (error) {
+    addNotification({
+      variant: 'danger',
+      dismissable: true,
+      title:
+        rule.rule_status === 'enabled'
+          ? intl.formatMessage(messages.rulesTableHideReportsErrorDisabled)
+          : intl.formatMessage(messages.rulesTableHideReportsErrorEnabled),
+      description: `${error}`,
+    });
+  }
+};
+export const removeFilterParam = (
+  param,
+  filters,
+  setFilters,
+  setSearchText
+) => {
+  const filter = { ...filters, offset: 0 };
+  param === 'text' && setSearchText('');
+  delete filter[param];
+  setFilters(filter);
+};
+
+export const toggleRulesDisabled = (rule_status, setFilters, filters) => {
+  setFilters({
+    ...filters,
+    rule_status,
+    offset: 0,
+    ...(rule_status !== 'enabled' && { impacting: ['false'] }),
+  });
+};
+export const filterConfigItems = (
+  filters,
+  setFilters,
+  searchText,
+  setSearchText,
+  intl
+) => {
+  const addFilterParam = (param, values) => {
+    values.length > 0
+      ? setFilters({ ...filters, offset: 0, ...{ [param]: values } })
+      : removeFilterParam(param);
+  };
+
+  return [
+    {
+      label: intl.formatMessage(messages.name).toLowerCase(),
+      filterValues: {
+        key: 'text-filter',
+        onChange: (_event, value) => setSearchText(value),
+        value: searchText,
+        placeholder: intl.formatMessage(messages.filterBy),
+      },
+    },
+    {
+      label: FC.total_risk.title,
+      type: FC.total_risk.type,
+      id: FC.total_risk.urlParam,
+      value: `checkbox-${FC.total_risk.urlParam}`,
+      filterValues: {
+        key: `${FC.total_risk.urlParam}-filter`,
+        onChange: (_event, values) =>
+          addFilterParam(FC.total_risk.urlParam, values),
+        value: filters.total_risk,
+        items: FC.total_risk.values,
+      },
+    },
+    {
+      label: FC.res_risk.title,
+      type: FC.res_risk.type,
+      id: FC.res_risk.urlParam,
+      value: `checkbox-${FC.res_risk.urlParam}`,
+      filterValues: {
+        key: `${FC.res_risk.urlParam}-filter`,
+        onChange: (_event, values) =>
+          addFilterParam(FC.res_risk.urlParam, values),
+        value: filters.res_risk,
+        items: FC.res_risk.values,
+      },
+    },
+    {
+      label: FC.impact.title,
+      type: FC.impact.type,
+      id: FC.impact.urlParam,
+      value: `checkbox-${FC.impact.urlParam}`,
+      filterValues: {
+        key: `${FC.impact.urlParam}-filter`,
+        onChange: (_event, values) =>
+          addFilterParam(FC.impact.urlParam, values),
+        value: filters.impact,
+        items: FC.impact.values,
+      },
+    },
+    {
+      label: FC.likelihood.title,
+      type: FC.likelihood.type,
+      id: FC.likelihood.urlParam,
+      value: `checkbox-${FC.likelihood.urlParam}`,
+      filterValues: {
+        key: `${FC.likelihood.urlParam}-filter`,
+        onChange: (_event, values) =>
+          addFilterParam(FC.likelihood.urlParam, values),
+        value: filters.likelihood,
+        items: FC.likelihood.values,
+      },
+    },
+    {
+      label: FC.category.title,
+      type: FC.category.type,
+      id: FC.category.urlParam,
+      value: `checkbox-${FC.category.urlParam}`,
+      filterValues: {
+        key: `${FC.category.urlParam}-filter`,
+        onChange: (_event, values) =>
+          addFilterParam(FC.category.urlParam, values),
+        value: filters.category,
+        items: FC.category.values,
+      },
+    },
+    {
+      label: FC.incident.title,
+      type: FC.incident.type,
+      id: FC.incident.urlParam,
+      value: `checkbox-${FC.incident.urlParam}`,
+      filterValues: {
+        key: `${FC.incident.urlParam}-filter`,
+        onChange: (_event, values) =>
+          addFilterParam(FC.incident.urlParam, values),
+        value: filters.incident,
+        items: FC.incident.values,
+      },
+    },
+    {
+      label: FC.has_playbook.title,
+      type: FC.has_playbook.type,
+      id: FC.has_playbook.urlParam,
+      value: `checkbox-${FC.has_playbook.urlParam}`,
+      filterValues: {
+        key: `${FC.has_playbook.urlParam}-filter`,
+        onChange: (_event, values) =>
+          addFilterParam(FC.has_playbook.urlParam, values),
+        value: filters.has_playbook,
+        items: FC.has_playbook.values,
+      },
+    },
+    {
+      label: FC.reboot.title,
+      type: FC.reboot.type,
+      id: FC.reboot.urlParam,
+      value: `checkbox-${FC.reboot.urlParam}`,
+      filterValues: {
+        key: `${FC.reboot.urlParam}-filter`,
+        onChange: (_event, values) =>
+          addFilterParam(FC.reboot.urlParam, values),
+        value: filters.reboot,
+        items: FC.reboot.values,
+      },
+    },
+    {
+      label: FC.rule_status.title,
+      type: FC.rule_status.type,
+      id: FC.rule_status.urlParam,
+      value: `radio-${FC.rule_status.urlParam}`,
+      filterValues: {
+        key: `${FC.rule_status.urlParam}-filter`,
+        onChange: (_event, value) => toggleRulesDisabled(value),
+        value: `${filters.rule_status}`,
+        items: FC.rule_status.values,
+      },
+    },
+    {
+      label: FC.impacting.title,
+      type: FC.impacting.type,
+      id: FC.impacting.urlParam,
+      value: `checkbox-${FC.impacting.urlParam}`,
+      filterValues: {
+        key: `${FC.impacting.urlParam}-filter`,
+        onChange: (e, values) => addFilterParam(FC.impacting.urlParam, values),
+        value: filters.impacting,
+        items: FC.impacting.values,
+      },
+    },
+  ];
+};
+
+export const buildRows = (
+  rules,
+  isAllExpanded,
+  setViewSystemsModalRule,
+  setViewSystemsModalOpen,
+  intl
+) => {
+  const rows = rules.data.flatMap((value, key) => [
+    {
+      isOpen: isAllExpanded,
+      rule: value,
+      cells: [
+        {
+          title: (
+            <span key={key}>
+              <Link key={key} to={`/recommendations/${value.rule_id}`}>
+                {' '}
+                {value.description}{' '}
+              </Link>
+              <RuleLabels rule={value} isCompact />
+            </span>
+          ),
+        },
+        {
+          title: (
+            <DateFormat
+              key={key}
+              date={value.publish_date}
+              variant="relative"
+            />
+          ),
+        },
+        {
+          title: (
+            <CategoryLabel key={key} labelList={[value.category]} isCompact />
+          ),
+        },
+        {
+          title: (
+            <div key={key}>
+              <Tooltip
+                key={key}
+                position={TooltipPosition.bottom}
+                content={intl.formatMessage(
+                  messages.rulesDetailsTotalRiskBody,
+                  {
+                    risk:
+                      AppConstants.TOTAL_RISK_LABEL_LOWER[value.total_risk] ||
+                      intl.formatMessage(messages.undefined),
+                    strong: (str) => strong(str),
+                  }
+                )}
+              >
+                <InsightsLabel value={value.total_risk} isCompact />
+              </Tooltip>
+            </div>
+          ),
+        },
+        {
+          title:
+            value.rule_status === 'rhdisabled' ? (
+              <Tooltip
+                content={intl.formatMessage(messages.byEnabling, {
+                  systems: value.impacted_systems_count,
+                })}
+              >
+                <span>{intl.formatMessage(messages.nA)}</span>
+              </Tooltip>
+            ) : (
+              <div
+                key={key}
+              >{`${value.impacted_systems_count.toLocaleString()}`}</div>
+            ),
+        },
+        {
+          title: (
+            <div className="ins-c-center-text " key={key}>
+              {value.playbook_count ? (
+                <span>
+                  <AnsibeTowerIcon size="sm" />{' '}
+                  {intl.formatMessage(messages.playbook)}
+                </span>
+              ) : (
+                intl.formatMessage(messages.manual)
+              )}
+            </div>
+          ),
+        },
+      ],
+    },
+    {
+      parent: key * 2,
+      fullWidth: true,
+      cells: [
+        {
+          title: (
+            <section className="pf-c-page__main-section pf-m-light">
+              <Stack hasGutter>
+                {value.hosts_acked_count ? (
+                  <StackItem>
+                    <BellSlashIcon size="sm" />
+                    &nbsp;
+                    {value.hosts_acked_count && !value.impacted_systems_count
+                      ? intl.formatMessage(messages.ruleIsDisabledForAllSystems)
+                      : intl.formatMessage(
+                          messages.ruleIsDisabledForSystemsBody,
+                          { systems: value.hosts_acked_count }
+                        )}
+                    &nbsp;{' '}
+                    <Button
+                      isInline
+                      variant="link"
+                      ouiaId="viewSystem"
+                      onClick={() => {
+                        setViewSystemsModalRule(value);
+                        setViewSystemsModalOpen(true);
+                      }}
+                    >
+                      {intl.formatMessage(messages.viewSystems)}
+                    </Button>
+                  </StackItem>
+                ) : (
+                  <React.Fragment></React.Fragment>
+                )}
+                <RuleDetails
+                  messages={formatMessages(
+                    intl,
+                    RuleDetailsMessagesKeys,
+                    mapContentToValues(intl, value)
+                  )}
+                  product={AdvisorProduct.rhel}
+                  rule={value}
+                  resolutionRisk={ruleResolutionRisk(value)}
+                  resolutionRiskDesc={
+                    AppConstants.RISK_OF_CHANGE_DESC[ruleResolutionRisk(value)]
+                  }
+                  isDetailsPage={false}
+                  showViewAffected
+                  linkComponent={Link}
+                  knowledgebaseUrl={
+                    value.node_id
+                      ? `https://access.redhat.com/node/${value.node_id}`
+                      : ''
+                  }
+                />
+              </Stack>
+            </section>
+          ),
+        },
+      ],
+    },
+  ]);
+
+  return rows;
 };

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -200,19 +200,12 @@ export const removeFilterParam = (
   setFilters(filter);
 };
 
-export const toggleRulesDisabled = (rule_status, setFilters, filters) => {
-  setFilters({
-    ...filters,
-    rule_status,
-    offset: 0,
-    ...(rule_status !== 'enabled' && { impacting: ['false'] }),
-  });
-};
 export const filterConfigItems = (
   filters,
   setFilters,
   searchText,
   setSearchText,
+  toggleRulesDisabled,
   intl
 ) => {
   const addFilterParam = (param, values) => {


### PR DESCRIPTION
Learning from my last large attempt at refactoring, This PR reorganizes just the RulesTable component. There should be no changes in functionality. This simply cleans up the RulesTable component so that its much easier to navigate. The file was 800+ lines of code and it caused of lot of jumping around when trying to debug the table. This PR cuts it in half and utilizes the helpers.js file

# Checklist:

- [ ] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
