### PR TITLE
fix(RHINENG-956): Fix broken links in rule content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@patternfly/react-tokens": "^4.94.6",
         "@react-pdf/renderer": "2.0.19",
         "@redhat-cloud-services/frontend-components": "^3.9.35",
-        "@redhat-cloud-services/frontend-components-advisor-components": "^1.0.13",
+        "@redhat-cloud-services/frontend-components-advisor-components": "^1.0.14",
         "@redhat-cloud-services/frontend-components-charts": "3.2.5",
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.5",
         "@redhat-cloud-services/frontend-components-pdf-generator": "^2.6.19",
@@ -4238,9 +4238,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-advisor-components": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-advisor-components/-/frontend-components-advisor-components-1.0.13.tgz",
-      "integrity": "sha512-CRWqi54jaPutoXtXguDvlKR/wDuKpiXMQSxfcmwi3SpxQek4B8zGmlt5xXbFYwFhEvS8ZrZLoBJgESDmL4ngpw==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-advisor-components/-/frontend-components-advisor-components-1.0.14.tgz",
+      "integrity": "sha512-JDjRD3ZBNtp2Trwt4OHD+DTkSJidbOty3bnpQbqXmP10evkGr07SV22moQq0wrTiQrgMIjrOjFFPgv+uEzcGyg==",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^3.9.12",
         "dot": "^1.1.3",
@@ -27989,9 +27989,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-advisor-components": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-advisor-components/-/frontend-components-advisor-components-1.0.13.tgz",
-      "integrity": "sha512-CRWqi54jaPutoXtXguDvlKR/wDuKpiXMQSxfcmwi3SpxQek4B8zGmlt5xXbFYwFhEvS8ZrZLoBJgESDmL4ngpw==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-advisor-components/-/frontend-components-advisor-components-1.0.14.tgz",
+      "integrity": "sha512-JDjRD3ZBNtp2Trwt4OHD+DTkSJidbOty3bnpQbqXmP10evkGr07SV22moQq0wrTiQrgMIjrOjFFPgv+uEzcGyg==",
       "requires": {
         "@redhat-cloud-services/frontend-components": "^3.9.12",
         "dot": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@patternfly/react-tokens": "^4.94.6",
     "@react-pdf/renderer": "2.0.19",
     "@redhat-cloud-services/frontend-components": "^3.9.35",
-    "@redhat-cloud-services/frontend-components-advisor-components": "^1.0.13",
+    "@redhat-cloud-services/frontend-components-advisor-components": "^1.0.14",
     "@redhat-cloud-services/frontend-components-charts": "3.2.5",
     "@redhat-cloud-services/frontend-components-notifications": "^3.2.5",
     "@redhat-cloud-services/frontend-components-pdf-generator": "^2.6.19",

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -396,6 +396,7 @@ const RulesTable = ({ isTabActive }) => {
           rows={rows}
           areActionsDisabled={() => !permsDisableRec}
           isStickyHeader
+          expandId="expand-button"
         >
           <TableHeader />
           <TableBody className="pf-m-width-100" />


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHINENG-956.

On the /recommendations page, when one expands the content, the "View affected ..." links must lead to /recommendations/%rule_id page.

## How to test

1. Navigate to /recommendations
2. Expand any rule that has at least 1 system impacted
3. Click on the "View affected ... systems" and make sure you are navigated to the rule details page.