### PR TITLE
fix(RHIF-262): adopt chrome updateDocumentTitle hook

### DIFF
--- a/src/PresentationalComponents/Inventory/InventoryDetails.js
+++ b/src/PresentationalComponents/Inventory/InventoryDetails.js
@@ -18,19 +18,23 @@ import { updateReducers } from '../../Store';
 import { useIntl } from 'react-intl';
 import SystemAdvisor from '../../SmartComponents/SystemAdvisor';
 import { useParams } from 'react-router-dom';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 const InventoryDetails = ({ entity }) => {
   const intl = useIntl();
   const store = useStore();
   const { inventoryId } = useParams();
+  const chrome = useChrome();
   useEffect(() => {
     if (entity && (entity.display_name || entity.id)) {
       const subnav = `${entity.display_name || entity.id} - ${
         messages.systems.defaultMessage
       }`;
-      document.title = intl.formatMessage(messages.documentTitle, { subnav });
+      chrome.updateDocumentTitle(
+        intl.formatMessage(messages.documentTitle, { subnav })
+      );
     }
-  }, [entity, intl]);
+  }, [entity, intl, chrome]);
 
   return (
     <DetailWrapper

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -34,6 +34,8 @@ import { useGetRecQuery } from '../../Services/Recs';
 import { useGetTopicsQuery } from '../../Services/Topics';
 import { enableRule, bulkHostActions } from './helpers';
 import { DetailsRules } from './DetailsRules';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+
 const OverviewDetails = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
@@ -44,6 +46,7 @@ const OverviewDetails = () => {
   const ruleId = useParams().id;
   const addNotification = (data) => dispatch(notification(data));
   const permsExport = usePermissions('advisor', PERMS.export).hasAccess;
+  const chrome = useChrome();
 
   const {
     data: rule = {},
@@ -99,11 +102,11 @@ const OverviewDetails = () => {
 
     if (rule?.description) {
       const subnav = `${rule.description} - ${messages.recommendations.defaultMessage}`;
-      document.title = intl.formatMessage(messages.documentTitle, { subnav });
+      chrome.updateDocumentTitle(
+        intl.formatMessage(messages.documentTitle, { subnav })
+      );
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [chrome, intl, rule.description, ruleId]);
 
   return (
     <React.Fragment>

--- a/src/SmartComponents/Recs/DetailsPathways.js
+++ b/src/SmartComponents/Recs/DetailsPathways.js
@@ -31,6 +31,7 @@ import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import { workloadQueryBuilder } from '../../PresentationalComponents/Common/Tables';
 import { useLocation } from 'react-router-dom';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 const RulesTable = lazy(() =>
   import(
@@ -66,6 +67,16 @@ const PathwayDetails = () => {
   const [activeTab, setActiveTab] = useState(
     pathname.includes('/recommendations/pathways/systems/') ? 1 : 0
   );
+  const chrome = useChrome();
+  useEffect(() => {
+    pathway &&
+      !isFetching &&
+      chrome.updateDocumentTitle(
+        intl.formatMessage(messages.documentTitle, {
+          subnav: `${pathway.name} - ${messages.pathways.defaultMessage}`,
+        })
+      );
+  }, [chrome, intl, pathway, pathname, isFetching]);
 
   const waitForElm = (selector) => {
     return new Promise((resolve) => {

--- a/src/SmartComponents/Recs/List.js
+++ b/src/SmartComponents/Recs/List.js
@@ -2,7 +2,7 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-import React, { Suspense, lazy, useState } from 'react';
+import React, { Suspense, lazy, useEffect, useState } from 'react';
 import {
   Tab,
   TabTitleText,
@@ -20,6 +20,7 @@ import { useIntl } from 'react-intl';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import PathwaysPanel from '../../PresentationalComponents/PathwaysPanel/PathwaysPanel';
 import RulesTable from '../../PresentationalComponents/RulesTable/RulesTable';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 const PathwaysTable = lazy(() =>
   import(
@@ -32,9 +33,16 @@ const List = () => {
   const { pathname } = useLocation();
   const history = useHistory();
   const permsExport = usePermissions('advisor', PERMS.export);
-  document.title = intl.formatMessage(messages.documentTitle, {
-    subnav: messages.recommendations.defaultMessage,
-  });
+  const chrome = useChrome();
+
+  useEffect(() => {
+    chrome.updateDocumentTitle(
+      intl.formatMessage(messages.documentTitle, {
+        subnav: messages.recommendations.defaultMessage,
+      })
+    );
+  }, [chrome, intl]);
+
   const [activeTab, setActiveTab] = useState(
     pathname === '/recommendations/pathways' ? 1 : 0
   );

--- a/src/SmartComponents/Systems/List.js
+++ b/src/SmartComponents/Systems/List.js
@@ -2,17 +2,22 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-import React from 'react';
+import React, { useEffect } from 'react';
 import SystemsTable from '../../PresentationalComponents/SystemsTable/SystemsTable';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 const List = () => {
   const intl = useIntl();
-
-  document.title = intl.formatMessage(messages.documentTitle, {
-    subnav: messages.systems.defaultMessage,
-  });
+  const chrome = useChrome();
+  useEffect(() => {
+    chrome.updateDocumentTitle(
+      intl.formatMessage(messages.documentTitle, {
+        subnav: messages.systems.defaultMessage,
+      })
+    );
+  }, [chrome, intl]);
 
   return (
     <React.Fragment>

--- a/src/SmartComponents/Topics/Details.js
+++ b/src/SmartComponents/Topics/Details.js
@@ -25,6 +25,7 @@ import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { workloadQueryBuilder } from '../../PresentationalComponents/Common/Tables';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 const Details = () => {
   const intl = useIntl();
@@ -62,14 +63,16 @@ const Details = () => {
     return () => dispatch(updateRecFilters(initiaRecFilters));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  const chrome = useChrome();
 
   useEffect(() => {
     if (topic && topic.name) {
       const subnav = `${topic.name} - ${messages.topics.defaultMessage}`;
-      document.title = intl.formatMessage(messages.documentTitle, { subnav });
+      chrome.updateDocumentTitle(
+        intl.formatMessage(messages.documentTitle, { subnav })
+      );
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [topic]);
+  }, [chrome, intl, topic]);
 
   return (
     <React.Fragment>

--- a/src/SmartComponents/Topics/List.js
+++ b/src/SmartComponents/Topics/List.js
@@ -3,22 +3,30 @@ import {
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import TopicsTable from '../../PresentationalComponents/TopicsTable/TopicsTable';
 import messages from '../../Messages';
 import { useGetTopicsQuery } from '../../Services/Topics';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { workloadQueryBuilder } from '../../PresentationalComponents/Common/Tables';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 const List = () => {
   const intl = useIntl();
   const selectedTags = useSelector(({ filters }) => filters.selectedTags);
   const workloads = useSelector(({ filters }) => filters.workloads);
   const SID = useSelector(({ filters }) => filters.SID);
-  document.title = intl.formatMessage(messages.documentTitle, {
-    subnav: messages.topics.defaultMessage,
-  });
+  const chrome = useChrome();
+
+  useEffect(() => {
+    chrome.updateDocumentTitle(
+      intl.formatMessage(messages.documentTitle, {
+        subnav: messages.topics.defaultMessage,
+      })
+    );
+  }, [chrome, intl]);
+
   let options = selectedTags?.length && { tags: selectedTags };
   workloads &&
     (options = { ...options, ...workloadQueryBuilder(workloads, SID) });


### PR DESCRIPTION
# Description
This PR adopts the updateDocumentTitle hook from chrome. This is in an effort to fix the flow of the lastSeen objects on the landing page and just for general upkeep. 
Associated Jira ticket: # (issue)

# How to test the PR
Navigate to all the pages in advisor and see the the document title is updating properly
Please include steps to test your PR.


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
