### PR TITLE
chore: refactor pdf-generator migration to use shared FEC hook

### DIFF
--- a/src/PresentationalComponents/ExecutiveReport/Download.js
+++ b/src/PresentationalComponents/ExecutiveReport/Download.js
@@ -1,40 +1,26 @@
 import './_Download.scss';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useDispatch } from 'react-redux';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux/actions/notifications';
 import ExportIcon from '@patternfly/react-icons/dist/esm/icons/export-icon';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
 import { Button } from '@patternfly/react-core';
-import { fetchPDFReport } from '../../Utilities/Api';
-import { renderPDF } from '../../Utilities/Helpers';
-import { exportNotifications } from '../../AppConstants';
+import usePDFExport from '@redhat-cloud-services/frontend-components-utilities/useExportPDF/useExportPDF';
 
 const DownloadExecReport = ({ isDisabled }) => {
   const intl = useIntl();
-  const dispatch = useDispatch();
+  const downloadReport = usePDFExport('advisor');
+  const fileName = `Advisor-Executive-Report--${new Date()
+    .toUTCString()
+    .replace(/ /g, '-')}.pdf`;
 
-  const dataFetch = async () => {
-    dispatch(addNotification(exportNotifications.pending));
-
-    try {
-      const result = await fetchPDFReport('advisor');
-      renderPDF(
-        result,
-        `Advisor-Executive-Report--${new Date()
-          .toUTCString()
-          .replace(/ /g, '-')}.pdf`
-      );
-      dispatch(addNotification(exportNotifications.success));
-    } catch (e) {
-      dispatch(addNotification(exportNotifications.error));
-    }
+  const downloadPDFReport = () => {
+    downloadReport('advisor', fileName);
   };
 
   return (
     <Button
-      onClick={dataFetch}
+      onClick={downloadPDFReport}
       variant="link"
       isInline
       isDisabled={isDisabled}
@@ -49,4 +35,5 @@ const DownloadExecReport = ({ isDisabled }) => {
 DownloadExecReport.propTypes = {
   isDisabled: PropTypes.bool,
 };
+
 export default DownloadExecReport;

--- a/src/PresentationalComponents/ExecutiveReport/Download.js
+++ b/src/PresentationalComponents/ExecutiveReport/Download.js
@@ -6,10 +6,12 @@ import messages from '../../Messages';
 import { useIntl } from 'react-intl';
 import { Button } from '@patternfly/react-core';
 import usePDFExport from '@redhat-cloud-services/frontend-components-utilities/useExportPDF/useExportPDF';
+import { useDispatch } from 'react-redux';
 
 const DownloadExecReport = ({ isDisabled }) => {
   const intl = useIntl();
-  const downloadReport = usePDFExport('advisor');
+  const dispatch = useDispatch();
+  const downloadReport = usePDFExport('advisor', dispatch);
   const fileName = `Advisor-Executive-Report--${new Date()
     .toUTCString()
     .replace(/ /g, '-')}.pdf`;

--- a/src/Utilities/Api.js
+++ b/src/Utilities/Api.js
@@ -50,28 +50,4 @@ const AxiosBaseQuery =
     }
   };
 
-export function fetchPDFReport(template, filters) {
-  const CRC_PDF_GENERATE_API = '/api/crc-pdf-generator/v1/generate';
-  const url = new URL(CRC_PDF_GENERATE_API, window.location.origin);
-
-  return fetch(
-    url,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-
-      body: JSON.stringify({
-        service: 'advisor',
-        template,
-        params: {
-          ...filters,
-        },
-      }),
-    },
-    50000
-  ).then((response) => response.blob());
-}
-
 export { AxiosBaseQuery, Get, Post, Put, DeleteApi };


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)

Refactors the pdf-migration work to use the FEC shared usePDFExport hook. 


# How to test the PR
1. Run the PR locally
2. verify that you can download the executive report by clicking on 'Download executive report' on the top right corner'

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
