### PR TITLE
feat(RHINENG-405): Add single recommendation to export

### DIFF
--- a/src/PresentationalComponents/Common/DownloadHelper.js
+++ b/src/PresentationalComponents/Common/DownloadHelper.js
@@ -20,7 +20,8 @@ const downloadHelper = async (
   selectedTags,
   workloads,
   SID,
-  dispatch
+  dispatch,
+  display_name
 ) => {
   try {
     let options = selectedTags?.length && { tags: selectedTags };
@@ -33,7 +34,11 @@ const downloadHelper = async (
           format === 'json' ? 'json' : 'csv'
         }`,
         {},
-        { ...filters, ...options }
+        {
+          ...filters,
+          ...options,
+          ...(display_name && { display_name: display_name }),
+        }
       )
         .then((result) => {
           dispatch(addNotification(exportNotifications.success));


### PR DESCRIPTION
# Description
This ticket allows for the new export on systems advisor page to export for just one system as opposed to all. 

Associated Jira ticket: # ([RHINENG-405](https://issues.redhat.com/browse/RHINENG-405))

# How to test the PR
Head to advisor systems page and select a system
There is now an export button, click it 
select both csv and json exports and verify that the data returned is just for one system.
![Screen Shot 2023-07-19 at 9 57 54 AM](https://github.com/RedHatInsights/insights-advisor-frontend/assets/60629070/bf5b70b1-c1bf-4d98-adf5-0aa0926826ae)



- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
