### PR TITLE
fix(RHINENG-1168): Fix empty filter error on inventory advisor tab

### DIFF
--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -52,9 +52,9 @@ const BaseSystemAdvisor = ({ entity, inventoryId }) => {
   const [isSelected, setIsSelected] = useState(false);
   const [isAllExpanded, setIsAllExpanded] = useState(false);
 
-  const selectedTags = useSelector(({ filters }) => filters.selectedTags);
-  const workloads = useSelector(({ filters }) => filters.workloads);
-  const SID = useSelector(({ filters }) => filters.SID);
+  const selectedTags = useSelector(({ filters }) => filters?.selectedTags);
+  const workloads = useSelector(({ filters }) => filters?.workloads);
+  const SID = useSelector(({ filters }) => filters?.SID);
   const permsExport = usePermissions(
     'advisor',
     AppConstants.PERMS.export


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)

Inventory Advisor tab would have errors because certain advisor filters dont exist on that page. This makes it 'optional' 
https://issues.redhat.com/browse/RHINENG-1167

# How to test the PR

Please include steps to test your PR.

# Before the change
Inventory Advisor tab never loads

# After the change
Inventory Advisor tab loads and you can export the recommendation

# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
