### PR TITLE
fix(RHIN-1167):Add search value to systemAdvisor exportConfig

### DIFF
--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -426,7 +426,7 @@ const BaseSystemAdvisor = ({ entity, inventoryId }) => {
               downloadReport(
                 'hits',
                 fileType,
-                filters,
+                { ...filters, text: searchValue },
                 selectedTags,
                 workloads,
                 SID,


### PR DESCRIPTION
When exporting a single system the text param wasnt being applied. In the current set up its not attached to the filters object. This was originally part of the massive refactor, but for the time being this adds the param in both the inventory tab and advisor's systemAdvisor component



# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
