### PR TITLE
fix(ADVISOR-3139): Resolve system pdf export error

### DIFF
--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -5,7 +5,7 @@ import {
   SYSTEM_FILTER_CATEGORIES as SFC,
   SYSTEMS_FETCH_URL,
 } from '../../AppConstants';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { TableVariant } from '@patternfly/react-table';
 import {
   filterFetchBuilder,
@@ -219,6 +219,10 @@ const SystemsTable = () => {
     urlBuilder(combinedFilters, selectedTags);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedTags]);
+  const pdfFilters = useMemo(() => {
+    const { tags: _tags, ...filtersWithoutTags } = filterFetchBuilder(filters);
+    return filtersWithoutTags;
+  }, [filters]);
 
   return (
     !filterBuilding && (
@@ -323,7 +327,7 @@ const SystemsTable = () => {
             ),
           extraItems: [
             <li key="download-pd" role="menuitem">
-              <SystemsPdf filters={{ ...filterFetchBuilder(filters) }} />
+              <SystemsPdf filters={pdfFilters} />
             </li>,
           ],
           isDisabled: !permsExport,


### PR DESCRIPTION
# Description

Associated Jira ticket: # ([issue](https://issues.redhat.com/browse/ADVISOR-3139))
This is a temporary fix while we wait for the real pdf migration 

# How to test the PR

Navigate to Systems page and clicked the export button.
Once the PDF option loads, select it and verify that there is no 500 error. The backend doesnt support the tags field. Normally a refactor for this would be passed through, but since theres a PR for migrating to the new pdf service I'd like to pass this in until that gets QA'd and eventually removes this commit all together. 
# Before the change
Systems pdf export breaks

# After the change
Doesnt break

# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
