### PR TITLE
Advisor Systems page and Inventory groups enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Travis is used to test the build for this code.
 - `npm run test` will run tests.
 - `npm run lint` will run all linters.
 
+Before opening a pull request, you can run `npm run verify:local` to make sure your changes pass automated tests (Jest and Cypress) and linter (both JS and CSS linters).
+
 ## Deploying
 Any push to the following branches will trigger a build in [insights-advisor-frontend-build repository](https://github.com/RedHatInsights/insights-advisor-frontend-build) which will deploy to corresponding environment. Travis is used to deploy the application.
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "start:proxy": "NODE_ENV=development PROXY=true webpack serve --config config/dev.webpack.config.js",
     "start:proxy:beta": "BETA=true NODE_ENV=development PROXY=true webpack serve --config config/dev.webpack.config.js",
     "test": "npm run test:jest",
-    "test:jest": "jest --verbose --passWithNoTests --env=jsdom",
+    "test:local": "TZ=UTC jest --verbose --collectCoverage=false --passWithNoTests --env=jsdom",
+    "test:jest": "TZ=UTC jest --verbose --passWithNoTests --env=jsdom",
     "test:ct": "BABEL_ENV=component cypress run --component",
     "test:openct": "cypress open --component",
     "translations": "npm-run-all translations:*",
@@ -33,6 +34,7 @@
     "travis:build": "NODE_ENV=production webpack --config config/prod.webpack.config.js",
     "travis:verify": "npm-run-all travis:build lint",
     "verify": "npm-run-all build lint test",
+    "verify:local": "npm-run-all build lint test:local test:ct",
     "coverage:clean": "rm -rf .nyc_output coverage reports",
     "coverage": "bash coverage.sh && npm run coverage:clean"
   },

--- a/src/PresentationalComponents/SystemsTable/createColumns.js
+++ b/src/PresentationalComponents/SystemsTable/createColumns.js
@@ -1,6 +1,3 @@
-import React from 'react';
-import isEmpty from 'lodash/isEmpty';
-
 export const createColumns = (defaultColumns, columns) =>
   columns
     .map((column) => {
@@ -13,23 +10,6 @@ export const createColumns = (defaultColumns, columns) =>
         : {
             ...column,
             ...correspondingColumn,
-            ...(column.key === 'groups'
-              ? {
-                  renderFunc: (groups) =>
-                    isEmpty(groups) ? (
-                      'N/A'
-                    ) : (
-                      /**
-                       * TODO: change `a` to `Link` once https://issues.redhat.com/browse/ADVISOR-2955 is complete
-                       */
-                      <a href={`./insights/inventory/groups/${groups[0].id}`}>
-                        {
-                          groups[0].name // currently, one group at maximum is supported
-                        }
-                      </a>
-                    ),
-                }
-              : {}),
           };
     })
     .filter(Boolean);

--- a/src/PresentationalComponents/helper.js
+++ b/src/PresentationalComponents/helper.js
@@ -36,7 +36,7 @@ export const createOptions = (
       rhel_version: advisorFilters.rhel_version?.join(','),
     }),
     ...(filters?.hostGroupFilter?.length && {
-      group_name: filters.hostGroupFilter,
+      groups: filters.hostGroupFilter.join(','),
     }),
     ...(filters.tagFilters?.length && buildTagFilter(filters.tagFilters)),
     ...(workloads ? workloadQueryBuilder(workloads, SID) : {}),


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-3715.

- Make sure that the systems table (/advisor/systems) uses "groups" parameter to filter systems by their groups,
- Change the Group column values to plain text instead of links.

## How to test

Go to /advisor/systems, and check that you are able to filter by groups and also can see to which group each hosts relates to (N/A if not in any group).