### PR TITLE
fix(ADVISOR-3167): Fix system links on /systems

### DIFF
--- a/src/PresentationalComponents/SystemsTable/SystemsTableAssets.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTableAssets.js
@@ -7,13 +7,11 @@ import RuleLabels from '../Labels/RuleLabels';
 
 export const systemsTableColumns = (intl) => [
   {
-    title: intl.formatMessage(messages.name),
     key: 'display_name',
     transforms: [sortable, wrappable],
-    props: { isStatic: true },
-    renderFunc: (_data, _id, system) => (
+    renderFunc: (data, id, system) => (
       <React.Fragment>
-        <Link key={_id} to={`/systems/${system.system_uuid}`}>
+        <Link key={id} to={`/systems/${system.system_uuid}`}>
           {`${system.display_name} `}
         </Link>
         {system.incident_hits > 0 && <RuleLabels rule={{ tags: 'incident' }} />}
@@ -59,6 +57,5 @@ export const systemsTableColumns = (intl) => [
   {
     key: 'updated',
     transforms: [sortable, wrappable],
-    props: { width: 20 },
   },
 ];

--- a/src/PresentationalComponents/SystemsTable/createColumns.js
+++ b/src/PresentationalComponents/SystemsTable/createColumns.js
@@ -8,8 +8,8 @@ export const createColumns = (defaultColumns, columns) =>
       return column.requiresDefault && correspondingColumn === undefined
         ? undefined
         : {
-            ...column,
             ...correspondingColumn,
+            ...column,
           };
     })
     .filter(Boolean);


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ADVISOR-3167.

This PR fixes how SystemsTable builds columns: now the overridden parameters are prioritised over the default column parameter (like renderFunc) from Inventory. This automatically fixes: 1) incorrect link to the system details page (it was wrongly redirecting to /recommendations on click before), 2) the incident tag is back (was omitted by wrongly applied default renderFunc for the name column).

## How to test

Go to /systems, check that the incident label is rendered next to the name of relevant systems in the table; and check that you are able to go to system details view for any systems.