### PR TITLE
Fix(RHINENG-1847): expand the correct selected recommendation

### DIFF
--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -31,6 +31,7 @@ import {
 import downloadReport from '../../PresentationalComponents/Common/DownloadHelper';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import * as AppConstants from '../../AppConstants';
+import { useParams } from 'react-router-dom';
 const BaseSystemAdvisor = ({ entity, inventoryId }) => {
   const intl = useIntl();
   const systemAdvisorRef = useRef({
@@ -39,7 +40,7 @@ const BaseSystemAdvisor = ({ entity, inventoryId }) => {
   const dispatch = useDispatch();
   const addNotification = (data) => dispatch(addNotificationAction(data));
 
-  const routerData = useSelector(({ routerData }) => routerData);
+  const { id: ruleIdParam } = useParams();
 
   const [inventoryReportFetchStatus, setInventoryReportFetchStatus] =
     useState('pending');
@@ -111,12 +112,9 @@ const BaseSystemAdvisor = ({ entity, inventoryId }) => {
 
   const activeRuleFirst = (activeReports) => {
     const reports = [...activeReports];
-    const activeRuleIndex =
-      routerData && typeof routerData.params !== 'undefined'
-        ? activeReports.findIndex(
-            (report) => report.rule.rule_id === routerData.params.id
-          )
-        : -1;
+    const activeRuleIndex = ruleIdParam
+      ? activeReports.findIndex((report) => report.rule.rule_id === ruleIdParam)
+      : -1;
     const activeReport = reports.splice(activeRuleIndex, 1);
 
     return activeRuleIndex !== -1


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-1847

Selecting an affected host for a particular recommendation, the wrong recommendation is expanded.  


Screenshot showing the recommendation and the affected hosts ...

![Screenshot from 2023-09-08 13-06-35](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/39b349a9-a13d-47e7-b2c6-5a60562e1e8f)


Before the fix - the incorrect recommendation is expanded for the host:

![Screenshot from 2023-09-08 13-03-46](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/e6b9d26e-91f6-4eae-b460-dc87bf6830ae)


After the fix - the correct recommendation is expanded for the host:

![Screenshot from 2023-09-08 13-06-45](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/3e5417f2-02dd-42b7-bed7-aecee94982e2)

