### PR TITLE
feat(RHINENG-1834): Enable sorting host table by group name

### DIFF
--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -273,6 +273,7 @@ const SystemsTable = () => {
           const sort = `${orderDirection === 'ASC' ? '' : '-'}${
             (orderBy === 'updated' && 'last_seen') ||
             (orderBy === 'operating_system' && 'rhel_version') ||
+            (orderBy === 'groups' && 'group_name') ||
             orderBy
           }`;
 

--- a/src/PresentationalComponents/SystemsTable/SystemsTableAssets.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTableAssets.js
@@ -21,6 +21,7 @@ export const systemsTableColumns = (intl) => [
   {
     key: 'groups',
     requiresDefault: true,
+    transforms: [sortable, wrappable],
   },
   {
     key: 'tags',


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-1834

Allow hosts to be sorted by group name.

Before PR:
![Screenshot from 2023-10-03 11-41-49](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/a044faff-11d9-43f1-9a01-63e66608fd64)

After PR:
![Screenshot from 2023-10-03 11-41-07](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/80143184-2f2a-425a-b4fc-2588a11e61fc)
