### PR TITLE
feat(RHIF-274): add HybridInventoryTabs wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@reduxjs/toolkit": "1.6.1",
         "@scalprum/react-core": "^0.1.9",
         "@testing-library/react-hooks": "^8.0.0",
+        "@unleash/proxy-client-react": "^4.0.3",
         "babel-plugin-transform-imports": "^2.0.0",
         "babel-plugin-transform-inline-environment-variables": "^0.4.4",
         "classnames": "2.3.1",
@@ -6137,6 +6138,17 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.4.tgz",
       "integrity": "sha512-RRHc1+8Hc5mf/2lZKnom6kCnqcNS07s8keahniWTOva0KELF6RgDJmaEcvGEKUUJgN4UgessmEsWuidaOycIOw=="
+    },
+    "node_modules/@unleash/proxy-client-react": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-4.0.3.tgz",
+      "integrity": "sha512-/+COnnXjIHIXN0Kqmx5jJrQn25BRF+U7cPcvnOeHp4M1X5vxfrlB00jp0loTXQDbFFvgNWKupsPMjNamKmkEvQ==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "unleash-proxy-client": "^3.0.0"
+      }
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.2.37",
@@ -21901,6 +21913,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "peer": true
+    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -22473,6 +22491,29 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unleash-proxy-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-3.1.0.tgz",
+      "integrity": "sha512-CV33Jl0sTmR9JfiDY7dSXde4qmaNwPFZVkbnHtuH0aarUO23hbFOnoEh7SfXYY8ZkGgBYlWRPbVjkbBWHjYWIw==",
+      "peer": true,
+      "dependencies": {
+        "tiny-emitter": "^2.1.0",
+        "uuid": "^9.0.1"
+      }
+    },
+    "node_modules/unleash-proxy-client/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/unpipe": {
@@ -29587,6 +29628,12 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.4.tgz",
       "integrity": "sha512-RRHc1+8Hc5mf/2lZKnom6kCnqcNS07s8keahniWTOva0KELF6RgDJmaEcvGEKUUJgN4UgessmEsWuidaOycIOw=="
+    },
+    "@unleash/proxy-client-react": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-4.0.3.tgz",
+      "integrity": "sha512-/+COnnXjIHIXN0Kqmx5jJrQn25BRF+U7cPcvnOeHp4M1X5vxfrlB00jp0loTXQDbFFvgNWKupsPMjNamKmkEvQ==",
+      "requires": {}
     },
     "@vue/compiler-core": {
       "version": "3.2.37",
@@ -41363,6 +41410,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "peer": true
+    },
     "tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -41779,6 +41832,24 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "unleash-proxy-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-3.1.0.tgz",
+      "integrity": "sha512-CV33Jl0sTmR9JfiDY7dSXde4qmaNwPFZVkbnHtuH0aarUO23hbFOnoEh7SfXYY8ZkGgBYlWRPbVjkbBWHjYWIw==",
+      "peer": true,
+      "requires": {
+        "tiny-emitter": "^2.1.0",
+        "uuid": "^9.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+          "peer": true
+        }
+      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@reduxjs/toolkit": "1.6.1",
     "@scalprum/react-core": "^0.1.9",
     "@testing-library/react-hooks": "^8.0.0",
+    "@unleash/proxy-client-react": "^4.0.3",
     "babel-plugin-transform-imports": "^2.0.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.4",
     "classnames": "2.3.1",

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -65,6 +65,11 @@ export const AdvisorRoutes = () => {
           element={<RecsDetails />}
         ></Route>
         <Route
+          key={'Recommendation details'}
+          path="recommendations/:id/manage-edge-inventory"
+          element={<RecsDetails isImmutableTabOpen />}
+        ></Route>
+        <Route
           key={'Inventory details'}
           path="recommendations/:id/:inventoryId/"
           element={<InventoryDetails />}

--- a/src/SmartComponents/HybridInventoryTabs/ConventionalSystems.js
+++ b/src/SmartComponents/HybridInventoryTabs/ConventionalSystems.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import Inventory from '../../PresentationalComponents/Inventory/Inventory';
+import { useSelector } from 'react-redux';
+import { PERMS } from '../../AppConstants';
+
+const ConventionalSystems = ({ rule, afterDisableFn, handleModalToggle }) => {
+  const selectedTags = useSelector(({ filters }) => filters.selectedTags);
+  const workloads = useSelector(({ filters }) => filters.workloads);
+  const SID = useSelector(({ filters }) => filters.SID);
+  const permsExport = usePermissions('advisor', PERMS.export).hasAccess;
+
+  const actionResolver = () => [
+    {
+      title: 'Disable recommendation for system',
+      onClick: (event, rowIndex, item) => handleModalToggle(true, item),
+    },
+  ];
+
+  return (
+    <Inventory
+      tableProps={{
+        canSelectAll: false,
+        actionResolver,
+        isStickyHeader: true,
+      }}
+      rule={rule}
+      afterDisableFn={afterDisableFn}
+      selectedTags={selectedTags}
+      workloads={workloads}
+      SID={SID}
+      permsExport={permsExport}
+      exportTable="systems"
+      showTags={true}
+    />
+  );
+};
+
+ConventionalSystems.propTypes = {
+  rule: PropTypes.object,
+  afterDisableFn: PropTypes.func,
+  handleModalToggle: PropTypes.func,
+};
+export default ConventionalSystems;

--- a/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
+++ b/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
@@ -1,0 +1,47 @@
+import React, { Suspense, Fragment, lazy } from 'react';
+import propTypes from 'prop-types';
+import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
+import { useFeatureFlag } from '../../Utilities/Hooks';
+
+const ImmutableDevices = lazy(() =>
+  import(/* webpackChunkName: "ImmutableDevices" */ './ImmutableDevices')
+);
+
+const ConventionalSystems = lazy(() =>
+  import(/* webpackChunkName: "ConventionalSystems" */ './ConventionalSystems')
+);
+
+const HybridInventory = (props) => {
+  const isEdgeParityEnabled = useFeatureFlag('advisor.edge_parity');
+
+  return (
+    <AsynComponent
+      key="hybridInventory"
+      appName="inventory"
+      module="./HybridInventoryTabs"
+      ConventionalSystemsTab={
+        <Suspense fallback={Fragment}>
+          <ConventionalSystems {...props} />
+        </Suspense>
+      }
+      ImmutableDevicesTab={
+        <Suspense fallback={Fragment}>
+          <ImmutableDevices {...props} />
+        </Suspense>
+      }
+      tabPathname={`/insights/advisor/recommendations/${props.ruleId}`}
+      //TODO: uncomment when ImmutableDevices tab is ready RHIF-307
+      //isImmutableTabOpen={props.isImmutableTabOpen}
+      fallback={<div />}
+      columns
+      isEdgeParityEnabled={isEdgeParityEnabled}
+    />
+  );
+};
+
+HybridInventory.propTypes = {
+  isImmutableTabOpen: propTypes.bool,
+  ruleId: propTypes.string,
+};
+
+export default HybridInventory;

--- a/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
+++ b/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ImmutableDevices = () => {
+  return <div></div>;
+};
+
+export default ImmutableDevices;

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -3,10 +3,10 @@ import './Details.scss';
 import { PERMS, UI_BASE } from '../../AppConstants';
 import messages from '../../Messages';
 import React, { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import propTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
 import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
-
 import {
   Card,
   CardBody,
@@ -17,17 +17,13 @@ import BellSlashIcon from '@patternfly/react-icons/dist/esm/icons/bell-slash-ico
 import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
-
 import { InvalidObject } from '@redhat-cloud-services/frontend-components/InvalidObject';
-import Inventory from '../../PresentationalComponents/Inventory/Inventory';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import MessageState from '../../PresentationalComponents/MessageState/MessageState';
 import DisableRule from '../../PresentationalComponents/Modals/DisableRule';
 import ViewHostAcks from '../../PresentationalComponents/Modals/ViewHostAcks';
-
 import { addNotification as notification } from '@redhat-cloud-services/frontend-components-notifications/';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
-
 import { cveToRuleid } from '../../cveToRuleid.js';
 import { useGetRecAcksQuery } from '../../Services/Acks';
 import { useGetRecQuery } from '../../Services/Recs';
@@ -35,19 +31,14 @@ import { useGetTopicsQuery } from '../../Services/Topics';
 import { enableRule, bulkHostActions } from './helpers';
 import { DetailsRules } from './DetailsRules';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import HybridInventory from '../HybridInventoryTabs/HybridInventoryTabs';
 
-const OverviewDetails = () => {
+const OverviewDetails = ({ isImmutableTabOpen }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
-
-  const selectedTags = useSelector(({ filters }) => filters.selectedTags);
-  const workloads = useSelector(({ filters }) => filters.workloads);
-  const SID = useSelector(({ filters }) => filters.SID);
   const ruleId = useParams().id;
   const addNotification = (data) => dispatch(notification(data));
-  const permsExport = usePermissions('advisor', PERMS.export).hasAccess;
   const chrome = useChrome();
-
   const {
     data: rule = {},
     isFetching,
@@ -80,13 +71,6 @@ const OverviewDetails = () => {
     refetch();
     recAckRefetch();
   };
-
-  const actionResolver = () => [
-    {
-      title: 'Disable recommendation for system',
-      onClick: (event, rowIndex, item) => handleModalToggle(true, item),
-    },
-  ];
 
   useEffect(() => {
     const isCVE =
@@ -245,20 +229,12 @@ const OverviewDetails = () => {
                 <Title className="pf-u-mb-lg" headingLevel="h3" size="2xl">
                   {intl.formatMessage(messages.affectedSystems)}
                 </Title>
-                <Inventory
-                  tableProps={{
-                    canSelectAll: false,
-                    actionResolver,
-                    isStickyHeader: true,
-                  }}
+                <HybridInventory
+                  ruleId={ruleId}
                   rule={rule}
                   afterDisableFn={afterDisableFn}
-                  selectedTags={selectedTags}
-                  workloads={workloads}
-                  SID={SID}
-                  permsExport={permsExport}
-                  exportTable="systems"
-                  showTags={true}
+                  handleModalToggle={handleModalToggle}
+                  isImmutableTabOpen={isImmutableTabOpen}
                 />
               </React.Fragment>
             )}
@@ -293,4 +269,7 @@ const OverviewDetails = () => {
   );
 };
 
+OverviewDetails.propTypes = {
+  isImmutableTabOpen: propTypes.bool,
+};
 export default OverviewDetails;

--- a/src/SmartComponents/Recs/DetailsRules.js
+++ b/src/SmartComponents/Recs/DetailsRules.js
@@ -21,7 +21,6 @@ import Breadcrumbs from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs'
 import RuleLabels from '../../PresentationalComponents/Labels/RuleLabels';
 import CategoryLabel from '../../PresentationalComponents/Labels/CategoryLabel';
 import { useIntl } from 'react-intl';
-
 import {
   RuleDetails,
   RuleDetailsMessagesKeys,

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -1,0 +1,7 @@
+import { useFlag, useFlagsStatus } from '@unleash/proxy-client-react';
+
+export const useFeatureFlag = (flag) => {
+  const { flagsReady } = useFlagsStatus();
+  const isFlagEnabled = useFlag(flag);
+  return flagsReady ? isFlagEnabled : false;
+};


### PR DESCRIPTION
# Description

Associated Jira ticket: # [(RHIF-274)](https://issues.redhat.com/browse/RHIF-274)

Creates Hybrid inventory tabs on the recommendation details page. The immutable devices tab is disabled until RHIF-307.  The work is behind the feature flag: `advisor.edge_parity`

To test:
1. Visit advisor app
2. click on any recommendation to go the details page
3. Observe that now there 2 tabs
4. Observe that Conventional systems tab works as expected
5. Observe that clicking on Immutable device adds /manage-edge-inventory into the URL.

# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [x] Needs additional dependent work
