### PR TITLE
fix(Tables): RHINENG-2325 - Add padding to footer via TableToolbar

### DIFF
--- a/src/PresentationalComponents/PathwaysTable/PathwaysTable.js
+++ b/src/PresentationalComponents/PathwaysTable/PathwaysTable.js
@@ -21,6 +21,7 @@ import {
   info,
   sortable,
 } from '@patternfly/react-table';
+import TableToolbar from '@redhat-cloud-services/frontend-components/TableToolbar';
 import {
   filterFetchBuilder,
   paramParser,
@@ -400,20 +401,22 @@ const PathwaysTable = ({ isTabActive }) => {
           <TableBody />
         </Table>
       )}
-      <Pagination
-        ouiaId="page"
-        itemCount={pathways?.meta?.count || 0}
-        page={filters.offset / filters.limit + 1}
-        perPage={Number(filters.limit)}
-        onSetPage={(_e, page) => {
-          onSetPage(page);
-        }}
-        onPerPageSelect={(_e, perPage) => {
-          setFilters({ ...filters, limit: perPage, offset: 0 });
-        }}
-        widgetId={`pagination-options-menu-bottom`}
-        variant={PaginationVariant.bottom}
-      />
+      <TableToolbar isFooter>
+        <Pagination
+          ouiaId="page"
+          itemCount={pathways?.meta?.count || 0}
+          page={filters.offset / filters.limit + 1}
+          perPage={Number(filters.limit)}
+          onSetPage={(_e, page) => {
+            onSetPage(page);
+          }}
+          onPerPageSelect={(_e, perPage) => {
+            setFilters({ ...filters, limit: perPage, offset: 0 });
+          }}
+          widgetId={`pagination-options-menu-bottom`}
+          variant={PaginationVariant.bottom}
+        />
+      </TableToolbar>
     </React.Fragment>
   );
 };

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -17,6 +17,7 @@ import {
   fitContent,
   sortable,
 } from '@patternfly/react-table';
+import TableToolbar from '@redhat-cloud-services/frontend-components/TableToolbar';
 
 import {
   filterFetchBuilder,
@@ -402,20 +403,22 @@ const RulesTable = ({ isTabActive }) => {
           <TableBody className="pf-m-width-100" />
         </Table>
       )}
-      <Pagination
-        ouiaId="page"
-        itemCount={results}
-        page={filters.offset / filters.limit + 1}
-        perPage={Number(filters.limit)}
-        onSetPage={(_e, page) => {
-          onSetPage(page);
-        }}
-        onPerPageSelect={(_e, perPage) => {
-          setFilters({ ...filters, limit: perPage, offset: 0 });
-        }}
-        widgetId={`pagination-options-menu-bottom`}
-        variant={PaginationVariant.bottom}
-      />
+      <TableToolbar isFooter>
+        <Pagination
+          ouiaId="page"
+          itemCount={results}
+          page={filters.offset / filters.limit + 1}
+          perPage={Number(filters.limit)}
+          onSetPage={(_e, page) => {
+            onSetPage(page);
+          }}
+          onPerPageSelect={(_e, perPage) => {
+            setFilters({ ...filters, limit: perPage, offset: 0 });
+          }}
+          widgetId={`pagination-options-menu-bottom`}
+          variant={PaginationVariant.bottom}
+        />
+      </TableToolbar>
     </React.Fragment>
   );
 };


### PR DESCRIPTION
# Description

Associated Jira ticket: #RHINENG-2325

The padding via the TableToolbar is required to avoid colliding with the "lightbulb"

# How to test the PR

Verify the pagination on any table does not get obscured by the lightbulb

# Before the change



![Screenshot 2023-10-27 at 12 32 33](https://github.com/RedHatInsights/insights-advisor-frontend/assets/7757/1c9afac4-4a3d-4f55-81d8-03259cd9d3f5)
![Screenshot 2023-10-27 at 12 32 51](https://github.com/RedHatInsights/insights-advisor-frontend/assets/7757/993e21d7-e439-4347-86c6-97373e04d073)

# After the change

![Screenshot 2023-10-27 at 12 25 51](https://github.com/RedHatInsights/insights-advisor-frontend/assets/7757/7c5d922f-0bb0-432a-80d9-f55820e132fb)
![Screenshot 2023-10-27 at 12 26 11](https://github.com/RedHatInsights/insights-advisor-frontend/assets/7757/0cef8cc7-8695-41ba-8057-79e146e1cd4b)

