### PR TITLE
feat(ADVISOR-3185) - Risk Labels refactor

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -169,7 +169,6 @@
     "ruleIsDisabledJustification": "This recommendation has been disabled for all systems for the following reason:",
     "ruleIsDisabledTooltip": "Indicates this recommendation across all systems will not be shown in reports and dashboards.",
     "rules": "Rules",
-    "rulesDetailsTotalRiskBody": "The total risk of this remediation is <strong>{risk}</strong>, based on the combination of likelihood and impact to remediate.",
     "rulesdetails.modifieddate": "Modified date: {date}",
     "rulestable.action.hide": "Hide recommendations with no impacted systems",
     "rulestable.action.hideDisabled": "Hide disabled recommendations",

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -168,7 +168,6 @@
   "ruleIsDisabledJustification": "This recommendation has been disabled for all systems for the following reason:",
   "ruleIsDisabledTooltip": "Indicates this recommendation across all systems will not be shown in reports and dashboards.",
   "rules": "Rules",
-  "rulesDetailsTotalRiskBody": "The total risk of this remediation is <strong>{risk}</strong>, based on the combination of likelihood and impact to remediate.",
   "rulesdetails.modifieddate": "Modified date: {date}",
   "rulestable.action.hide": "Hide recommendations with no impacted systems",
   "rulestable.action.hideDisabled": "Hide disabled recommendations",

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -368,12 +368,6 @@ export default defineMessages({
     description: 'Risk of Change',
     defaultMessage: 'Risk of change',
   },
-  rulesDetailsTotalRiskBody: {
-    id: 'rulesDetailsTotalRiskBody',
-    description: 'Text explaining the total risk value of this recommendation',
-    defaultMessage: `The total risk of this remediation is <strong>{risk}</strong>,
-                        based on the combination of likelihood and impact to remediate.`,
-  },
   undefined: {
     id: 'undefined',
     description: 'Undefined',

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -30,11 +30,7 @@ import {
 import RuleLabels from '../Labels/RuleLabels';
 import CategoryLabel from '../Labels/CategoryLabel';
 
-import {
-  formatMessages,
-  mapContentToValues,
-  strong,
-} from '../../Utilities/intlHelper';
+import { formatMessages, mapContentToValues } from '../../Utilities/intlHelper';
 import { ruleResolutionRisk } from '../Common/Tables';
 
 export const emptyRows = (filters, toggleRulesDisabled) => [
@@ -398,15 +394,17 @@ export const buildRows = (
               <Tooltip
                 key={key}
                 position={TooltipPosition.bottom}
-                content={intl.formatMessage(
-                  messages.rulesDetailsTotalRiskBody,
-                  {
-                    risk:
-                      AppConstants.TOTAL_RISK_LABEL_LOWER[value.total_risk] ||
-                      intl.formatMessage(messages.undefined),
-                    strong: (str) => strong(str),
-                  }
-                )}
+                content={
+                  <>
+                    The total risk of this remediation is
+                    <strong>
+                      {' '}
+                      {AppConstants.TOTAL_RISK_LABEL_LOWER[value.total_risk]}
+                    </strong>
+                    , based on the combination of likelihood and impact to
+                    remediate.
+                  </>
+                }
               >
                 <InsightsLabel value={value.total_risk} isCompact />
               </Tooltip>

--- a/src/Utilities/intlHelper.js
+++ b/src/Utilities/intlHelper.js
@@ -5,7 +5,6 @@ import {
   LIKELIHOOD_LABEL,
   LIKELIHOOD_LABEL_LOWER,
   RISK_OF_CHANGE_LABEL,
-  TOTAL_RISK_LABEL_LOWER,
 } from '../AppConstants';
 import messages from '../Messages';
 import { ruleResolutionRisk } from '../PresentationalComponents/Common/Tables';
@@ -28,12 +27,6 @@ export const mapContentToValues = (intl, rule) => ({
   impactLevel: { level: IMPACT_LABEL[rule.impact?.impact] },
   impactDescription: {
     level: IMPACT_LABEL_LOWER[rule.impact?.impact],
-  },
-  rulesDetailsTotalRiskBody: {
-    risk:
-      TOTAL_RISK_LABEL_LOWER[rule.total_risk] ||
-      intl.formatMessage(messages.undefined),
-    strong,
   },
   likelihoodLevel: {
     level: LIKELIHOOD_LABEL[rule.likelihood],


### PR DESCRIPTION
# Description
We are trying to get rid of the react-intl dependency, `formatMessage` is one of it's tools and because I used this implementation for another PR #1164 and found a replacement for it that does not use formatMessage, I opened this PR to change this implementation too to help us get rid of this dependency more quickly 
Link to [comment](https://github.com/RedHatInsights/insights-advisor-frontend/pull/1164#issuecomment-1788315909) mentioning that on the PR

Associated Jira ticket: [#ADVISOR-3185](https://issues.redhat.com/browse/ADVISOR-3185)

# How to test the PR

Insure the functionality of the component does not break
It should keep the current functionality without any visual changes

# Before the change
RulesTable Page:
![RulesTable Page](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/8d69769c-7d61-4903-bf8d-02500a2c7fd8)

RulesTable Page (Critical label tooltip open):
![RulesTable Page (Critical label tooltip open)](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/f6bd696a-2cf9-4eb4-876e-65e4e2024a5e)

RulesTable Page (Important label tooltip open):
![RulesTable Page (Important label tooltip open)](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/69a85df3-ca98-42a9-8a87-ec6e5b837039)

RulesTable Page (Moderate label tooltip open):
![RulesTable Page (Moderate label tooltip open)](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/cb95ba4f-487c-4f45-a40a-1d247e9d5568)

RulesTable Page (Low label tooltip open):
![RulesTable Page (Low label tooltip open)](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/23b8154d-6df8-4ed5-91f4-3c742fba2b74)

# After the change
(No UI changes)

# Checklist:

- [X] The commit message has the Jira ticket linked
- [X] PR has a short description
- [X] Screenshots before and after the change are added
- [X] Tests pass 