### PR TITLE
feat(RHIF-307): create immutable device tab for recommendation detail

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   __esModule: true,
   default: () => ({
@@ -27,6 +29,15 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
     getApp: jest.fn(),
     getBundle: jest.fn(),
   }),
+}));
+
+jest.mock('@redhat-cloud-services/frontend-components/AsyncComponent', () => ({
+  __esModule: true,
+  default: (props) => (
+    <div {...props} aria-label="immutableDevices-module-mock">
+      AsyncComponent
+    </div>
+  ),
 }));
 
 global.insights = {

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -24,6 +24,7 @@ export const RULES_FETCH_URL = `${BASE_URL}/rule/`;
 export const STATS_SYSTEMS_FETCH_URL = `${BASE_URL}/stats/systems/`;
 export const STATS_REPORTS_FETCH_URL = `${BASE_URL}/stats/reports/`;
 export const SYSTEMS_FETCH_URL = `${BASE_URL}/system/`;
+export const EDGE_DEVICE_BASE_URL = '/api/edge/v1';
 export const SYSTEM_TYPES = { rhel: 105, ocp: 325 };
 export const RULE_CATEGORIES = {
   availability: 1,

--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -41,6 +41,7 @@ const Inventory = ({
     offset: 0,
     sort: '-last_seen',
     name: '',
+    'filter[system_profile][host_type][nil]': true,
   });
   const [fullFilters, setFullFilters] = useState();
   const [total, setTotal] = useState(0);

--- a/src/SmartComponents/HybridInventoryTabs/ConventionalSystems/RecommendationSystems.js
+++ b/src/SmartComponents/HybridInventoryTabs/ConventionalSystems/RecommendationSystems.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
-import Inventory from '../../PresentationalComponents/Inventory/Inventory';
+import Inventory from '../../../PresentationalComponents/Inventory/Inventory';
 import { useSelector } from 'react-redux';
-import { PERMS } from '../../AppConstants';
+import { PERMS } from '../../../AppConstants';
 
 const ConventionalSystems = ({ rule, afterDisableFn, handleModalToggle }) => {
   const selectedTags = useSelector(({ filters }) => filters.selectedTags);

--- a/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
+++ b/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
@@ -9,7 +9,9 @@ const ImmutableDevices = lazy(() =>
 );
 
 const ConventionalSystems = lazy(() =>
-  import(/* webpackChunkName: "ConventionalSystems" */ './ConventionalSystems')
+  import(
+    /* webpackChunkName: "ConventionalSystems" */ './ConventionalSystems/RecommendationSystems'
+  )
 );
 
 const HybridInventory = (props) => {
@@ -33,8 +35,7 @@ const HybridInventory = (props) => {
         </Suspense>
       }
       tabPathname={`/insights/advisor/recommendations/${props.ruleId}`}
-      //TODO: uncomment when ImmutableDevices tab is ready RHIF-307
-      //isImmutableTabOpen={props.isImmutableTabOpen}
+      isImmutableTabOpen={props.isImmutableTabOpen}
       fallback={<div />}
       columns
       isEdgeParityEnabled={isEdgeParityEnabled}

--- a/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
+++ b/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
@@ -5,7 +5,7 @@ import {
   pruneFilters,
   urlBuilder,
 } from '../../PresentationalComponents/Common/Tables';
-import { useSelector, useStore } from 'react-redux';
+import { useStore } from 'react-redux';
 import { getEntities } from './helpers';
 import PropTypes from 'prop-types';
 import {} from '../../AppConstants';
@@ -13,7 +13,6 @@ import messages from '../../Messages';
 import { systemReducer } from '../../Store/AppReducer';
 import { updateReducers } from '../../Store';
 import { useIntl } from 'react-intl';
-import { useLoadModule } from '@scalprum/react-core';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { useFeatureFlag } from '../../Utilities/Hooks';
 import { useNavigate } from 'react-router-dom';
@@ -32,15 +31,6 @@ const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
       ? { 'filter[system_profile][host_type]': 'edge' }
       : {}),
   });
-
-  const [{ toGroupSelectionValue, buildOSFilterConfig } = {}] = useLoadModule({
-    appName: 'inventory',
-    scope: 'inventory',
-    module: './OsFilterHelpers',
-  });
-  const operatingSystems = useSelector(
-    ({ entities }) => entities?.operatingSystems || []
-  );
 
   const handleRefresh = (options) => {
     const { name, display_name } = options;
@@ -63,35 +53,6 @@ const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
     delete filter[param];
     setFilters(filter);
   };
-  const addFilterParam = (param, values) => {
-    const passValue =
-      param === SFC.rhel_version.urlParam
-        ? Object.values(values || {}).flatMap((majorOsVersion) =>
-            Object.keys(majorOsVersion)
-          )
-        : values;
-
-    passValue.length > 0
-      ? setFilters({ ...filters, offset: 0, ...{ [param]: passValue } })
-      : removeFilterParam(param);
-  };
-  const filterConfigItems = [
-    ...(buildOSFilterConfig
-      ? [
-          buildOSFilterConfig(
-            {
-              label: SFC.rhel_version.title.toLowerCase(),
-              type: SFC.rhel_version.type,
-              id: SFC.rhel_version.urlParam,
-              value: toGroupSelectionValue(filters.rhel_version || []),
-              onChange: (_e, value) =>
-                addFilterParam(SFC.rhel_version.urlParam, value),
-            },
-            operatingSystems
-          ),
-        ]
-      : []),
-  ];
 
   const buildFilterChips = () => {
     const localFilters = { ...filters };
@@ -181,12 +142,10 @@ const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
       hideFilters={{
         all: true,
         name: false,
+        operatingSystem: false,
       }}
       noSystemsTable={<div />}
       mergeAppColumns={mergeAppColumns}
-      filterConfig={{
-        items: filterConfigItems,
-      }}
       activeFiltersConfig={activeFiltersConfig}
       onRowClick={onSystemNameClick}
     />

--- a/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
+++ b/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
@@ -16,9 +16,12 @@ import { useIntl } from 'react-intl';
 import { useLoadModule } from '@scalprum/react-core';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { useFeatureFlag } from '../../Utilities/Hooks';
+import { useNavigate } from 'react-router-dom';
+
 const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
   const store = useStore();
   const intl = useIntl();
+  const navigate = useNavigate();
   const isEdgeParityEnabled = useFeatureFlag('advisor.edge_parity');
   const [filters, setFilters] = useState({
     limit: 20,
@@ -144,6 +147,10 @@ const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
     return [...defaultColumns, impacted_date];
   };
 
+  const onSystemNameClick = (_key, systemId) => {
+    navigate(`/insights/inventory/${systemId}?appName=advisor`);
+  };
+
   return (
     <AsynComponent
       appName="inventory"
@@ -181,6 +188,7 @@ const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
         items: filterConfigItems,
       }}
       activeFiltersConfig={activeFiltersConfig}
+      onRowClick={onSystemNameClick}
     />
   );
 };

--- a/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
+++ b/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
@@ -6,7 +6,7 @@ import {
   urlBuilder,
 } from '../../PresentationalComponents/Common/Tables';
 import { useStore } from 'react-redux';
-import { getEntities } from './helpers';
+import { useGetEntities } from './helpers';
 import PropTypes from 'prop-types';
 import {} from '../../AppConstants';
 import messages from '../../Messages';
@@ -46,7 +46,7 @@ const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
     !pathway && urlBuilder(refreshedFilters, selectedTags);
   };
 
-  const fetchSystems = getEntities(handleRefresh, pathway, rule);
+  const fetchSystems = useGetEntities(handleRefresh, pathway, rule);
 
   const removeFilterParam = (param) => {
     const filter = { ...filters, offset: 0 };

--- a/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.test.js
+++ b/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.test.js
@@ -1,7 +1,19 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { renderWithContext } from '../../Utilities/TestingUtilities';
+import { screen, waitFor } from '@testing-library/react';
+import { ComponentWithContext } from '../../Utilities/TestingUtilities';
 import ImmutableDevices from './ImmutableDevices';
+import { render } from '@testing-library/react';
+import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
+
+jest.mock('@redhat-cloud-services/frontend-components/AsyncComponent', () => ({
+  __esModule: true,
+  default: jest.fn((props) => (
+    <div {...props} aria-label="immutableDevices-module-mock">
+      AsyncComponent
+    </div>
+  )),
+}));
 
 jest.mock('@unleash/proxy-client-react', () => ({
   ...jest.requireActual('@unleash/proxy-client-react'),
@@ -9,26 +21,97 @@ jest.mock('@unleash/proxy-client-react', () => ({
   useFlagsStatus: () => ({ flagsReady: true }),
 }));
 
-jest.mock('@redhat-cloud-services/frontend-components/AsyncComponent', () => (
-  <div aria-label="immutableDevices-module-mock"></div>
-));
-
-afterEach(() => {
-  jest.resetAllMocks();
-});
-
 const renderComponent = async (componentProps = {}, renderOptions = {}) => {
-  renderWithContext(ImmutableDevices, componentProps, renderOptions);
-
-  //   await waitFor(() => {
-  //     expect(
-  //       screen.getByLabelText('Affected systems table title')
-  //     ).toBeInTheDocument();
-  //   });
+  render(
+    <ComponentWithContext
+      Component={ImmutableDevices}
+      {...componentProps}
+      {...renderOptions}
+    />
+  );
+};
+const renderAndWait = async () => {
+  await renderComponent();
+  await waitFor(() => {
+    expect(
+      screen.getByLabelText('immutableDevices-module-mock')
+    ).toBeInTheDocument();
+  });
 };
 
 describe('ImmutableDevices', () => {
-  test('renders without issues', () => {
-    renderComponent();
+  test('renders without issues', async () => {
+    renderAndWait();
+  });
+
+  test('renders with correct custom filters', async () => {
+    expect(AsynComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customFilters: {
+          advisorFilters: {
+            'filter[system_profile][host_type]': 'edge',
+            limit: 20,
+            name: '',
+            offset: 0,
+            sort: '-last_seen',
+          },
+        },
+      }),
+      {}
+    );
+  });
+
+  test('renders load ImmutableDevices federated module', async () => {
+    await renderComponent();
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('immutableDevices-module-mock')
+      ).toBeInTheDocument();
+    });
+
+    expect(AsynComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appName: 'inventory',
+        module: './ImmutableDevices',
+      }),
+      {}
+    );
+  });
+
+  test('loads ImmutableDevices federated module', async () => {
+    await renderComponent();
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('immutableDevices-module-mock')
+      ).toBeInTheDocument();
+    });
+
+    expect(AsynComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appName: 'inventory',
+        module: './ImmutableDevices',
+      }),
+      {}
+    );
+  });
+
+  test('should display name and os filter from the ImmutableDevices federated module', async () => {
+    await renderComponent();
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('immutableDevices-module-mock')
+      ).toBeInTheDocument();
+    });
+
+    expect(AsynComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hideFilters: {
+          all: true,
+          name: false,
+          operatingSystem: false,
+        },
+      }),
+      {}
+    );
   });
 });

--- a/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.test.js
+++ b/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.test.js
@@ -5,6 +5,7 @@ import { ComponentWithContext } from '../../Utilities/TestingUtilities';
 import ImmutableDevices from './ImmutableDevices';
 import { render } from '@testing-library/react';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
+import { useGetEntities } from './helpers';
 
 jest.mock('@redhat-cloud-services/frontend-components/AsyncComponent', () => ({
   __esModule: true,
@@ -21,17 +22,19 @@ jest.mock('@unleash/proxy-client-react', () => ({
   useFlagsStatus: () => ({ flagsReady: true }),
 }));
 
-const renderComponent = async (componentProps = {}, renderOptions = {}) => {
+jest.mock('./helpers', () => ({
+  ...jest.requireActual('./helpers'),
+  useGetEntities: jest.fn(() => {}),
+}));
+
+const renderAndWait = async (componentProps = {}, renderOptions = {}) => {
   render(
     <ComponentWithContext
       Component={ImmutableDevices}
-      {...componentProps}
-      {...renderOptions}
+      componentProps={componentProps}
+      renderOptions={renderOptions}
     />
   );
-};
-const renderAndWait = async () => {
-  await renderComponent();
   await waitFor(() => {
     expect(
       screen.getByLabelText('immutableDevices-module-mock')
@@ -41,10 +44,11 @@ const renderAndWait = async () => {
 
 describe('ImmutableDevices', () => {
   test('renders without issues', async () => {
-    renderAndWait();
+    await renderAndWait();
   });
 
   test('renders with correct custom filters', async () => {
+    await renderAndWait();
     expect(AsynComponent).toHaveBeenCalledWith(
       expect.objectContaining({
         customFilters: {
@@ -62,12 +66,7 @@ describe('ImmutableDevices', () => {
   });
 
   test('renders load ImmutableDevices federated module', async () => {
-    await renderComponent();
-    await waitFor(() => {
-      expect(
-        screen.getByLabelText('immutableDevices-module-mock')
-      ).toBeInTheDocument();
-    });
+    await renderAndWait();
 
     expect(AsynComponent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -79,12 +78,7 @@ describe('ImmutableDevices', () => {
   });
 
   test('loads ImmutableDevices federated module', async () => {
-    await renderComponent();
-    await waitFor(() => {
-      expect(
-        screen.getByLabelText('immutableDevices-module-mock')
-      ).toBeInTheDocument();
-    });
+    await renderAndWait();
 
     expect(AsynComponent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -96,12 +90,7 @@ describe('ImmutableDevices', () => {
   });
 
   test('should display name and os filter from the ImmutableDevices federated module', async () => {
-    await renderComponent();
-    await waitFor(() => {
-      expect(
-        screen.getByLabelText('immutableDevices-module-mock')
-      ).toBeInTheDocument();
-    });
+    await renderAndWait();
 
     expect(AsynComponent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -112,6 +101,15 @@ describe('ImmutableDevices', () => {
         },
       }),
       {}
+    );
+  });
+
+  test('should call getEntities with correct function arguments', async () => {
+    await renderAndWait({ pathway: 'test-pathway', rule: 'test-rule' });
+    expect(useGetEntities).toHaveBeenCalledWith(
+      expect.any(Function),
+      'test-pathway',
+      'test-rule'
     );
   });
 });

--- a/src/SmartComponents/HybridInventoryTabs/fixtures/advisorPathwayData.json
+++ b/src/SmartComponents/HybridInventoryTabs/fixtures/advisorPathwayData.json
@@ -1,0 +1,9 @@
+{
+    "data": {
+      "data": [
+        { "system_uuid": "edge.id-1", "pathwayName": "test-pathway-1" },
+        { "system_uuid": "edge.id-2", "pathwayName": "test-pathway-2" }
+      ],
+      "meta": { "count": 2 }
+    }
+}

--- a/src/SmartComponents/HybridInventoryTabs/fixtures/advisorRecommendationData.json
+++ b/src/SmartComponents/HybridInventoryTabs/fixtures/advisorRecommendationData.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "data": [
+      {
+        "system_uuid": "edge.id-1",
+        "recommendationName": "test-recommendation-1"
+      },
+      {
+        "system_uuid": "edge.id-2",
+        "recommendationName": "test-recommendation-2"
+      }
+    ],
+    "meta": { "count": 2 }
+  }
+}

--- a/src/SmartComponents/HybridInventoryTabs/fixtures/edgeData.json
+++ b/src/SmartComponents/HybridInventoryTabs/fixtures/edgeData.json
@@ -1,0 +1,10 @@
+{
+    "data": {
+      "data": {
+        "devices": [
+          { "DeviceUUID": "edge.id-1", "deviceName": "test-device-1" },
+          { "DeviceUUID": "edge.id-2", "deviceName": "test-device-2" }
+        ]
+      }
+    }
+}

--- a/src/SmartComponents/HybridInventoryTabs/fixtures/inventoryData.json
+++ b/src/SmartComponents/HybridInventoryTabs/fixtures/inventoryData.json
@@ -1,0 +1,3 @@
+{
+    "results": [{ "id": "edge.id-1" }, { "id": "edge.id-2" }]
+}

--- a/src/SmartComponents/HybridInventoryTabs/helpers.js
+++ b/src/SmartComponents/HybridInventoryTabs/helpers.js
@@ -1,0 +1,77 @@
+import { createOptions } from '../../PresentationalComponents/helper';
+import { paginatedRequestHelper } from '../../PresentationalComponents/Inventory/helpers';
+import { mergeArraysByDiffKeys } from '../../PresentationalComponents/Common/Tables';
+import { Post } from '../../Utilities/Api';
+import { EDGE_DEVICE_BASE_URL } from '../../AppConstants';
+
+export const getEntities =
+  (handleRefresh, pathway, rule) =>
+  async (_items, config, showTags, defaultGetEntities) => {
+    const {
+      per_page,
+      page,
+      orderBy,
+      orderDirection,
+      advisorFilters,
+      filters,
+      workloads,
+      SID,
+      selectedTags,
+    } = config;
+    //operating_system is currently not supported, but will be down the line.
+    const sort =
+      orderBy === 'operating_system'
+        ? 'rhel_version'
+        : `${orderDirection === 'ASC' ? '' : '-'}${
+            orderBy === 'updated' ? 'last_seen' : orderBy
+          }`;
+
+    let options = createOptions(
+      advisorFilters,
+      page,
+      per_page,
+      sort,
+      pathway,
+      filters,
+      selectedTags,
+      workloads,
+      SID
+    );
+    handleRefresh(options);
+    const allDetails = { ...config, pathway, rule, sort };
+    const advisorData = await paginatedRequestHelper(allDetails);
+    const systemIDs = advisorData?.data?.map((system) => system.system_uuid);
+
+    const inventoryData = await defaultGetEntities(
+      systemIDs,
+      {
+        per_page,
+        hasItems: true,
+        fields: { system_profile: ['operating_system'] },
+      },
+      showTags
+    );
+
+    let fullData = [];
+    if (systemIDs?.length) {
+      const { data: devicesData } = await Post(
+        `${EDGE_DEVICE_BASE_URL}/devices/devicesview`,
+        {},
+        { devices_uuid: systemIDs }
+      );
+      fullData = devicesData?.data?.devices?.map((device) => {
+        const system = inventoryData.results.find(
+          (system) => device.DeviceUUID === system.id
+        );
+        return {
+          ...system,
+          ...device,
+        };
+      });
+    }
+
+    return Promise.resolve({
+      results: mergeArraysByDiffKeys(advisorData.data, fullData),
+      total: advisorData.meta.count,
+    });
+  };

--- a/src/SmartComponents/HybridInventoryTabs/helpers.js
+++ b/src/SmartComponents/HybridInventoryTabs/helpers.js
@@ -4,7 +4,7 @@ import { mergeArraysByDiffKeys } from '../../PresentationalComponents/Common/Tab
 import { Post } from '../../Utilities/Api';
 import { EDGE_DEVICE_BASE_URL } from '../../AppConstants';
 
-export const getEntities =
+export const useGetEntities =
   (handleRefresh, pathway, rule) =>
   async (_items, config, showTags, defaultGetEntities) => {
     const {

--- a/src/SmartComponents/HybridInventoryTabs/helpers.test.js
+++ b/src/SmartComponents/HybridInventoryTabs/helpers.test.js
@@ -1,0 +1,123 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react';
+import { useGetEntities } from './helpers';
+import { Get, Post } from '../../Utilities/Api';
+import inventoryData from './fixtures/inventoryData.json';
+import advisorPathwayData from './fixtures/advisorPathwayData.json';
+import advisorRecommendationData from './fixtures/advisorRecommendationData.json';
+import edgeData from './fixtures/edgeData.json';
+
+jest.mock('../../Utilities/Api', () => ({
+  ...jest.requireActual('../../Utilities/Api'),
+  Get: jest.fn(() => Promise.resolve({})),
+  Post: jest.fn(() => Promise.resolve({})),
+}));
+
+Post.mockReturnValue(edgeData);
+
+const handleRefreshMock = jest.fn();
+const defaultGetEntities = jest.fn(() => inventoryData);
+const fetchConfig = {
+  per_page: 10,
+  page: 1,
+  orderBy: '-last-seen',
+  advisorFilters: { name: 'test-name' },
+  filters: { os: 'test-os' },
+  workloads: [],
+  SID: [],
+  selectedTags: [],
+};
+const fetchArguments = [[], fetchConfig, true, defaultGetEntities];
+
+const testApiCallArguments = () => {
+  expect(Get).toHaveBeenCalledWith(
+    '/api/insights/v1/rule/test-rule/systems_detail/',
+    {},
+    { limit: 10, name: 'test-name', offset: 0, sort: '--last-seen' }
+  );
+  expect(Post).toHaveBeenCalledWith(
+    '/api/edge/v1/devices/devicesview',
+    {},
+    { devices_uuid: ['edge.id-1', 'edge.id-2'] }
+  );
+  expect(defaultGetEntities).toHaveBeenCalledWith(
+    ['edge.id-1', 'edge.id-2'],
+    {
+      fields: { system_profile: ['operating_system'] },
+      hasItems: true,
+      per_page: 10,
+    },
+    true
+  );
+};
+
+describe('getEntities', () => {
+  test('Should fetch hybrid data for recommendations', async () => {
+    Get.mockReturnValue(Promise.resolve(advisorRecommendationData));
+
+    const { result } = renderHook(() =>
+      useGetEntities(handleRefreshMock, undefined, { rule_id: 'test-rule' })
+    );
+
+    let fetchedResult;
+    await act(async () => {
+      fetchedResult = await result.current(...fetchArguments);
+    });
+
+    expect(fetchedResult).toEqual({
+      results: [
+        {
+          id: 'edge.id-1',
+          DeviceUUID: 'edge.id-1',
+          deviceName: 'test-device-1',
+          system_uuid: 'edge.id-1',
+          recommendationName: 'test-recommendation-1',
+        },
+        {
+          id: 'edge.id-2',
+          DeviceUUID: 'edge.id-2',
+          deviceName: 'test-device-2',
+          system_uuid: 'edge.id-2',
+          recommendationName: 'test-recommendation-2',
+        },
+      ],
+      total: 2,
+    });
+
+    testApiCallArguments();
+  });
+
+  test('Should fetch hybrid data for pathways', async () => {
+    Get.mockReturnValue(Promise.resolve(advisorPathwayData));
+    const { result } = renderHook(() =>
+      useGetEntities(handleRefreshMock, 'test-pathway')
+    );
+
+    let fetchedResult;
+    await act(async () => {
+      fetchedResult = await result.current(...fetchArguments);
+    });
+
+    expect(fetchedResult).toEqual({
+      results: [
+        {
+          DeviceUUID: 'edge.id-1',
+          deviceName: 'test-device-1',
+          id: 'edge.id-1',
+          pathwayName: 'test-pathway-1',
+          system_uuid: 'edge.id-1',
+        },
+        {
+          DeviceUUID: 'edge.id-2',
+          deviceName: 'test-device-2',
+          id: 'edge.id-2',
+          pathwayName: 'test-pathway-2',
+          system_uuid: 'edge.id-2',
+        },
+      ],
+      total: 2,
+    });
+
+    testApiCallArguments();
+  });
+});

--- a/src/Utilities/TestingUtilities.js
+++ b/src/Utilities/TestingUtilities.js
@@ -1,18 +1,17 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { IntlProvider } from 'react-intl';
 
-const mockStore = configureStore();
-
-export const renderWithContext = (
+export const ComponentWithContext = ({
   Component,
   componentProps,
   renderOptions = {}
-) => {
-  const { container, unmount, rerender } = render(
+}) => {
+  const mockStore = configureStore();
+
+  return (
     <IntlProvider locale="en">
       <Provider store={renderOptions?.store || mockStore()}>
         <MemoryRouter initialEntries={renderOptions?.initialEntries || ['/']}>
@@ -29,6 +28,4 @@ export const renderWithContext = (
       </Provider>
     </IntlProvider>
   );
-
-  return { container, unmount, rerender };
 };

--- a/src/Utilities/TestingUtilities.js
+++ b/src/Utilities/TestingUtilities.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
@@ -7,7 +8,7 @@ import { IntlProvider } from 'react-intl';
 export const ComponentWithContext = ({
   Component,
   componentProps,
-  renderOptions = {}
+  renderOptions = {},
 }) => {
   const mockStore = configureStore();
 
@@ -28,4 +29,10 @@ export const ComponentWithContext = ({
       </Provider>
     </IntlProvider>
   );
+};
+
+ComponentWithContext.propTypes = {
+  Component: PropTypes.element,
+  componentProps: PropTypes.object,
+  renderOptions: PropTypes.object,
 };


### PR DESCRIPTION
# Description

Associated Jira ticket: https://issues.redhat.com/browse/RHIF-307

With this initial PR, we will have a new immutable device tab according to this [mockup](https://www.sketch.com/s/ac25729e-df9b-4e74-a09c-badb62787d24/p/43FFE7E9-F052-4552-8B5D-494C0CE0861E/canvas). This is the first PR dedicated for this tab. Additional, the group and tag filters will be added later.


# How to test the PR

1. Run the PR locally, 
2. Navigate to a recommendation detail page by clicking on one of them from the recommendations list
3. Observe that there is a new tab called Immutable devices(OSTREE)
4. Observe that the name and operating systems are working as expected
5. Observe that sorting works for only name, last seen and first impacted columns are sortable and they work
6. Clicking on the image name from the image column takes you to the image detail page in the edge application
7. Observe that clicking on the system name in the first column takes you to the inventory app detail page advisor tab is open. (This will work after [PR in inventory](https://github.com/RedHatInsights/insights-inventory-frontend/pull/2080/files) gets merged).



# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
