### PR TITLE
fix(SystemsTable): RHIN-338 - Remove custom OS filter handling

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -20,7 +20,6 @@ import { updateReducers } from '../../Store';
 import { useIntl } from 'react-intl';
 import downloadReport from '../Common/DownloadHelper';
 import useBulkSelect from './Hooks/useBulkSelect';
-import { Spinner } from '@scalprum/react-core';
 
 const Inventory = ({
   tableProps,
@@ -436,7 +435,6 @@ const Inventory = ({
           ],
         }}
         {...toolbarProps}
-        fallback={Spinner}
         onLoad={({
           mergeWithEntities,
           INVENTORY_ACTION_TYPES,

--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -20,7 +20,7 @@ import { updateReducers } from '../../Store';
 import { useIntl } from 'react-intl';
 import downloadReport from '../Common/DownloadHelper';
 import useBulkSelect from './Hooks/useBulkSelect';
-import { useLoadModule, Spinner } from '@scalprum/react-core';
+import { Spinner } from '@scalprum/react-core';
 
 const Inventory = ({
   tableProps,
@@ -59,14 +59,6 @@ const Inventory = ({
     useState(true);
   //This value comes in from the backend as 0, or 1. To be consistent it is set to -1
   const [rulesPlaybookCount, setRulesPlaybookCount] = useState(-1);
-  const [{ toGroupSelectionValue, buildOSFilterConfig } = {}] = useLoadModule({
-    appName: 'inventory',
-    scope: 'inventory',
-    module: './OsFilterHelpers',
-  });
-  const operatingSystems = useSelector(
-    ({ entities }) => entities?.operatingSystems || []
-  );
 
   const handleRefresh = (options) => {
     /* Rec table doesn't use the same sorting params as sys table, switching between the two results in the rec table blowing up cuz its trying to
@@ -349,35 +341,6 @@ const Inventory = ({
     delete filter[param];
     setFilters(filter);
   };
-  const addFilterParam = (param, values) => {
-    const passValue =
-      param === SFC.rhel_version.urlParam
-        ? Object.values(values || {}).flatMap((majorOsVersion) =>
-            Object.keys(majorOsVersion)
-          )
-        : values;
-
-    passValue.length > 0
-      ? setFilters({ ...filters, offset: 0, ...{ [param]: passValue } })
-      : removeFilterParam(param);
-  };
-  const filterConfigItems = [
-    ...(buildOSFilterConfig
-      ? [
-          buildOSFilterConfig(
-            {
-              label: SFC.rhel_version.title.toLowerCase(),
-              type: SFC.rhel_version.type,
-              id: SFC.rhel_version.urlParam,
-              value: toGroupSelectionValue(filters.rhel_version || []),
-              onChange: (_e, value) =>
-                addFilterParam(SFC.rhel_version.urlParam, value),
-            },
-            operatingSystems
-          ),
-        ]
-      : []),
-  ];
 
   const buildFilterChips = () => {
     const localFilters = { ...filters };
@@ -431,8 +394,12 @@ const Inventory = ({
         hasCheckbox
         initialLoading
         autoRefresh
-        hideFilters={{ all: true, name: false, tags: !showTags }}
-        filterConfig={{ items: filterConfigItems }}
+        hideFilters={{
+          all: true,
+          name: false,
+          tags: !showTags,
+          operatingSystem: false,
+        }}
         activeFiltersConfig={activeFiltersConfig}
         columns={(defaultColumns) => createColumns(defaultColumns)}
         tableProps={{

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -29,7 +29,6 @@ import { useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import NoSystemsTable from './Components/NoSystemsTable';
-import { useLoadModule } from '@scalprum/react-core';
 import { systemsTableColumns } from './SystemsTableAssets';
 import { createOptions } from '../helper';
 import { createColumns } from './createColumns';
@@ -38,20 +37,11 @@ const SystemsTable = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const store = useStore();
-  const [{ toGroupSelectionValue, buildOSFilterConfig } = {}] = useLoadModule({
-    appName: 'inventory',
-    scope: 'inventory',
-    module: './OsFilterHelpers',
-  });
-
   const { search } = useLocation();
   const selectedTags = useSelector(({ filters }) => filters.selectedTags);
   const workloads = useSelector(({ filters }) => filters.workloads);
   const SID = useSelector(({ filters }) => filters.SID);
   const filters = useSelector(({ filters }) => filters.sysState);
-  const operatingSystems = useSelector(
-    ({ entities }) => entities?.operatingSystems || []
-  );
   const setFilters = (filters) => dispatch(updateSysFilters(filters));
   const permsExport = usePermissions('advisor', PERMS.export).hasAccess;
   const [filterBuilding, setFilterBuilding] = useState(true);
@@ -108,21 +98,6 @@ const SystemsTable = () => {
         items: SFC.incident.values,
       },
     },
-    ...(buildOSFilterConfig
-      ? [
-          buildOSFilterConfig(
-            {
-              label: SFC.rhel_version.title.toLowerCase(),
-              type: SFC.rhel_version.type,
-              id: SFC.rhel_version.urlParam,
-              value: toGroupSelectionValue(filters.rhel_version || []),
-              onChange: (_e, value) =>
-                addFilterParam(SFC.rhel_version.urlParam, value),
-            },
-            operatingSystems
-          ),
-        ]
-      : []),
   ];
 
   const buildFilterChips = () => {
@@ -232,6 +207,7 @@ const SystemsTable = () => {
           name: false,
           tags: false,
           hostGroupFilter: false,
+          operatingSystem: false,
         }}
         initialLoading
         autoRefresh

--- a/src/PresentationalComponents/helper.js
+++ b/src/PresentationalComponents/helper.js
@@ -32,8 +32,8 @@ export const createOptions = (
       pathway && {
         display_name: filters?.hostnameOrId,
       }),
-    ...(advisorFilters.rhel_version && {
-      rhel_version: advisorFilters.rhel_version?.join(','),
+    ...(filters.osFilter?.length > 0 && {
+      rhel_version: filters.osFilter.map(({ value }) => value).join(','),
     }),
     ...(filters?.hostGroupFilter?.length && {
       groups: filters.hostGroupFilter.join(','),

--- a/src/PresentationalComponents/helper.test.js
+++ b/src/PresentationalComponents/helper.test.js
@@ -1,4 +1,4 @@
-import { sortTopics } from './helper';
+import { sortTopics, createOptions } from './helper';
 import fixtures from '../../cypress/fixtures/topics.json';
 
 describe('sortTopics test', () => {
@@ -33,5 +33,123 @@ describe('sortTopics test', () => {
     let sortResult = sortTopics(fixtures, indexes[2], directions[0]);
 
     expect(sortResult[0].impacted_systems_count).toBe(0);
+  });
+});
+
+describe('createOptions', () => {
+  const advisorFilters = '';
+  const page = 1;
+  const per_page = 20;
+  const sort = '';
+  const pathway = '';
+  const filters = '';
+  const selectedTags = '';
+  const workloads = '';
+  const SID = '';
+  const systemsPage = '';
+
+  it('returns API options', () => {
+    expect(
+      createOptions(
+        advisorFilters,
+        page,
+        per_page,
+        sort,
+        pathway,
+        filters,
+        selectedTags,
+        workloads,
+        SID,
+        systemsPage
+      )
+    ).toEqual({
+      sort: '',
+      offset: 0,
+      limit: 20,
+    });
+  });
+
+  it('returns a name prop in the API options when hostnameOrId is in filters', () => {
+    const hostnameOrId = 'HOST_NAME_ID';
+
+    expect(
+      createOptions(
+        advisorFilters,
+        page,
+        per_page,
+        sort,
+        pathway,
+        { hostnameOrId },
+        selectedTags,
+        workloads,
+        SID,
+        systemsPage
+      ).name
+    ).toEqual(hostnameOrId);
+  });
+
+  it('returns a rhel_version prop in the API options when osFilter is in filters', () => {
+    const osFilter = [{ value: '7.8' }, { value: '7.9' }];
+
+    expect(
+      createOptions(
+        advisorFilters,
+        page,
+        per_page,
+        sort,
+        pathway,
+        { osFilter },
+        selectedTags,
+        workloads,
+        SID,
+        systemsPage
+      ).rhel_version
+    ).toEqual('7.8,7.9');
+  });
+
+  it('returns a groups prop in the API options when hostGroupFilter is in filters', () => {
+    const hostGroupFilter = ['group1', 'group2'];
+
+    expect(
+      createOptions(
+        advisorFilters,
+        page,
+        per_page,
+        sort,
+        pathway,
+        { hostGroupFilter },
+        selectedTags,
+        workloads,
+        SID,
+        systemsPage
+      ).groups
+    ).toEqual('group1,group2');
+  });
+
+  it('returns a tags prop in the API options when tagFilters is in filters', () => {
+    const tagFilters = [
+      {
+        key: 'tagFilter1',
+        values: [
+          { key: 'tag1', tagKey: 'tagKey1', value: 'tag1' },
+          { key: 'tag2', tagKey: 'tagKey2', value: 'tag2' },
+        ],
+      },
+    ];
+
+    expect(
+      createOptions(
+        advisorFilters,
+        page,
+        per_page,
+        sort,
+        pathway,
+        { tagFilters },
+        selectedTags,
+        workloads,
+        SID,
+        systemsPage
+      ).tags
+    ).toEqual(['tagFilter1/tagKey1=tag1', 'tagFilter1/tagKey2=tag2']);
   });
 });


### PR DESCRIPTION
# Description

Associated Jira ticket: #RHIN-338

This migrates the SystemsTable to use the default OS filter provided by the InventoryTable and let it handle the filter selection.

# Before the change

https://github.com/RedHatInsights/insights-advisor-frontend/assets/7757/e7e2d0a1-49ad-4cf4-a086-b91349e11cff

# After the change

https://github.com/RedHatInsights/insights-advisor-frontend/assets/7757/1400f080-c693-47ca-b3c9-e465490fbb6d
