### PR TITLE
fix(RHINENG-2741): disables zero state when there is edge devices

### DIFF
--- a/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
+++ b/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
@@ -1,7 +1,8 @@
-import React, { Suspense, Fragment, lazy } from 'react';
+import React, { Suspense, Fragment, lazy, useContext } from 'react';
 import propTypes from 'prop-types';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { useFeatureFlag } from '../../Utilities/Hooks';
+import { AccountStatContext } from '../../ZeroStateWrapper';
 
 const ImmutableDevices = lazy(() =>
   import(/* webpackChunkName: "ImmutableDevices" */ './ImmutableDevices')
@@ -13,6 +14,8 @@ const ConventionalSystems = lazy(() =>
 
 const HybridInventory = (props) => {
   const isEdgeParityEnabled = useFeatureFlag('advisor.edge_parity');
+  const { hasEdgeDevices, hasConventionalSystems } =
+    useContext(AccountStatContext);
 
   return (
     <AsynComponent
@@ -35,6 +38,8 @@ const HybridInventory = (props) => {
       fallback={<div />}
       columns
       isEdgeParityEnabled={isEdgeParityEnabled}
+      accountHasEdgeImages={hasEdgeDevices}
+      hasConventionalSystems={hasConventionalSystems}
     />
   );
 };

--- a/src/ZeroStateWrapper.js
+++ b/src/ZeroStateWrapper.js
@@ -1,4 +1,4 @@
-import React, { Suspense, useState, useEffect } from 'react';
+import React, { Suspense, useState, useEffect, createContext } from 'react';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
@@ -8,17 +8,35 @@ import { addNotification } from '@redhat-cloud-services/frontend-components-noti
 import { useDispatch } from 'react-redux';
 import { useIntl } from 'react-intl';
 import messages from './Messages';
+import { useFeatureFlag } from './Utilities/Hooks';
+
+export const AccountStatContext = createContext({
+  hasConventionalSystems: true,
+  hasEdgeDevices: false,
+});
 
 export const ZeroStateWrapper = ({ children }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const [hasSystems, setHasSystems] = useState(true);
+  const isEdgeParityEnabled = useFeatureFlag('advisor.edge_parity');
+  const [hasConventionalSystems, setHasConventionalSystems] = useState(true);
+  const [hasEdgeDevices, setHasEdgeDevices] = useState(true);
+
   useEffect(() => {
     try {
       axios
-        .get(`/api/inventory/v1/hosts?page=1&per_page=1`)
+        .get(
+          `/api/inventory/v1/hosts?page=1&per_page=1&filter[system_profile][host_type]=nil`
+        )
         .then(({ data }) => {
-          setHasSystems(data.total > 0);
+          setHasConventionalSystems(data.total > 0);
+        });
+      axios
+        .get(
+          `/api/inventory/v1/hosts?page=1&per_page=1&filter[system_profile][host_type]=edge`
+        )
+        .then(({ data }) => {
+          setHasEdgeDevices(data.total > 0);
         });
     } catch (e) {
       dispatch(
@@ -30,7 +48,11 @@ export const ZeroStateWrapper = ({ children }) => {
         })
       );
     }
-  }, [hasSystems]);
+  }, []);
+
+  const hasSystems = isEdgeParityEnabled
+    ? hasEdgeDevices || hasConventionalSystems
+    : hasConventionalSystems;
 
   return (
     <Suspense

--- a/src/ZeroStateWrapper.js
+++ b/src/ZeroStateWrapper.js
@@ -80,7 +80,11 @@ export const ZeroStateWrapper = ({ children }) => {
           />
         </Suspense>
       ) : (
-        <>{children}</>
+        <AccountStatContext.Provider
+          value={{ hasConventionalSystems, hasEdgeDevices }}
+        >
+          {children}
+        </AccountStatContext.Provider>
       )}
     </Suspense>
   );


### PR DESCRIPTION
# Description

Associated Jira ticket: # [(issue)](https://issues.redhat.com/browse/RHINENG-2741)

Shows the zero state only when there is no both conventional and immutable systems.

Also, improves the API requests scattered around components to check the presence of conventional and edge systems by sharing one request result through the react context provider.

# How to test the PR

To test (preparing accounts to test the PR):
    1. Open first the account without any system
    2. Observe that Zero state is shown
    3. Open another account with edge system
    4. Observe that Zero state is not shown
    5. Open another account with conventional system
    6. Observe that Zero state is not shown

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
