### PR TITLE
feat(RHINENG-3076): Add banner for immutable systems

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1269,4 +1269,9 @@ export default defineMessages({
     description: 'First impacted',
     defaultMessage: 'First impacted',
   },
+  edgeWarning: {
+    id: 'edgeWarning',
+    description: 'Warning text for edge devices',
+    defaultMessage: 'Immutable systems are not shown in this list.',
+  },
 });

--- a/src/SmartComponents/Systems/EdgeSystemsBanner.js
+++ b/src/SmartComponents/Systems/EdgeSystemsBanner.js
@@ -1,0 +1,22 @@
+import React, { useContext } from 'react';
+import { useIntl } from 'react-intl';
+import { Alert } from '@patternfly/react-core';
+import messages from '../../Messages';
+import { AccountStatContext } from '../../ZeroStateWrapper';
+
+const EdgeSystemsBanner = () => {
+  const intl = useIntl();
+  const { hasEdgeDevices } = useContext(AccountStatContext);
+
+  return !hasEdgeDevices ? null : (
+    <Alert
+      variant="info"
+      aria-label="Immutable Systems Warning"
+      isInline
+      style={{ marginBottom: '1.5rem' }}
+      title={intl.formatMessage(messages.edgeWarning)}
+    />
+  );
+};
+
+export default EdgeSystemsBanner;

--- a/src/SmartComponents/Systems/EdgeSystemsBanner.test.js
+++ b/src/SmartComponents/Systems/EdgeSystemsBanner.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import EdgeSystemsBanner from './EdgeSystemsBanner';
+import { ComponentWithContext } from '../../Utilities/TestingUtilities';
+import { AccountStatContext } from '../../ZeroStateWrapper';
+
+describe('EdgeSystemsBanner', () => {
+  it('does render with edge hosts present', () => {
+    const { asFragment } = render(
+      <ComponentWithContext
+        Component={EdgeSystemsBanner}
+        Context={AccountStatContext}
+        contextValue={{ hasEdgeDevices: true, hasConventionalSystems: true }}
+      />
+    );
+
+    expect(
+      screen.getByLabelText('Immutable Systems Warning')
+    ).toBeInTheDocument();
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('does not render with no edge hosts', () => {
+    const { asFragment } = render(
+      <ComponentWithContext
+        Component={EdgeSystemsBanner}
+        Context={AccountStatContext}
+        contextValue={{ hasEdgeDevices: false, hasConventionalSystems: true }}
+      />
+    );
+
+    expect(
+      screen.queryByLabelText('Immutable Systems Warning')
+    ).not.toBeInTheDocument();
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/SmartComponents/Systems/List.js
+++ b/src/SmartComponents/Systems/List.js
@@ -7,10 +7,13 @@ import SystemsTable from '../../PresentationalComponents/SystemsTable/SystemsTab
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import EdgeSystemsBanner from './EdgeSystemsBanner';
+import { useFeatureFlag } from '../../Utilities/Hooks';
 
 const List = () => {
   const intl = useIntl();
   const chrome = useChrome();
+  const edgeParityFFlag = useFeatureFlag('advisor.edge_parity');
   useEffect(() => {
     chrome.updateDocumentTitle(
       intl.formatMessage(messages.documentTitle, {
@@ -29,6 +32,7 @@ const List = () => {
         />
       </PageHeader>
       <section className="pf-l-page__main-section pf-c-page__main-section">
+        {edgeParityFFlag ? <EdgeSystemsBanner /> : null}
         <SystemsTable />
       </section>
     </React.Fragment>

--- a/src/SmartComponents/Systems/__snapshots__/EdgeSystemsBanner.test.js.snap
+++ b/src/SmartComponents/Systems/__snapshots__/EdgeSystemsBanner.test.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EdgeSystemsBanner does not render with no edge hosts 1`] = `<DocumentFragment />`;
+
+exports[`EdgeSystemsBanner does render with edge hosts present 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="Immutable Systems Warning"
+    class="pf-c-alert pf-m-inline pf-m-info"
+    data-ouia-component-id="OUIA-Generated-Alert-info-1"
+    data-ouia-component-type="PF4/Alert"
+    data-ouia-safe="true"
+    style="margin-bottom: 1.5rem;"
+  >
+    <div
+      class="pf-c-alert__icon"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 512 512"
+        width="1em"
+      >
+        <path
+          d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+        />
+      </svg>
+    </div>
+    <h4
+      class="pf-c-alert__title"
+    >
+      <span
+        class="pf-u-screen-reader"
+      >
+        Info alert:
+      </span>
+      Immutable systems are not shown in this list.
+    </h4>
+  </div>
+</DocumentFragment>
+`;

--- a/src/Utilities/TestingUtilities.js
+++ b/src/Utilities/TestingUtilities.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createContext } from 'react';
 import PropTypes from 'prop-types';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
@@ -9,6 +9,8 @@ export const ComponentWithContext = ({
   Component,
   componentProps,
   renderOptions = {},
+  Context = createContext({}),
+  contextValue = {},
 }) => {
   const mockStore = configureStore();
 
@@ -16,15 +18,17 @@ export const ComponentWithContext = ({
     <IntlProvider locale="en">
       <Provider store={renderOptions?.store || mockStore()}>
         <MemoryRouter initialEntries={renderOptions?.initialEntries || ['/']}>
-          {renderOptions?.componentPath ? (
-            <Routes>
-              <Route>
-                <Component {...componentProps} />
-              </Route>
-            </Routes>
-          ) : (
-            <Component {...componentProps} />
-          )}
+          <Context.Provider value={contextValue}>
+            {renderOptions?.componentPath ? (
+              <Routes>
+                <Route>
+                  <Component {...componentProps} />
+                </Route>
+              </Routes>
+            ) : (
+              <Component {...componentProps} />
+            )}
+          </Context.Provider>
         </MemoryRouter>
       </Provider>
     </IntlProvider>
@@ -35,4 +39,6 @@ ComponentWithContext.propTypes = {
   Component: PropTypes.element,
   componentProps: PropTypes.object,
   renderOptions: PropTypes.object,
+  Context: PropTypes.object,
+  contextValue: PropTypes.object,
 };


### PR DESCRIPTION
# Description

Associated Jira ticket: https://issues.redhat.com/browse/RHINENG-3076

Added banner to Advisor Systems table to indicate presence of edge systems


# How to test the PR

1. Open Advisor Systems table
2. There should be a banner when edge systems are present

# Before the change
![image](https://github.com/RedHatInsights/insights-advisor-frontend/assets/62351699/46a3e59d-8406-4ae4-b2bc-6e81982526f5)

# After the change
![image](https://github.com/RedHatInsights/insights-advisor-frontend/assets/62351699/d02937e7-f9b7-458d-96d2-daa0c9770b1d)

# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
