### PR TITLE
fix(ImmutableDevices): pass edge filer into custom filter prop

### DIFF
--- a/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
+++ b/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
@@ -27,9 +27,6 @@ const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
     offset: 0,
     sort: '-last_seen',
     name: '',
-    ...(isEdgeParityEnabled
-      ? { 'filter[system_profile][host_type]': 'edge' }
-      : {}),
   });
 
   const handleRefresh = (options) => {
@@ -135,7 +132,12 @@ const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
       }}
       key="inventory"
       customFilters={{
-        advisorFilters: filters,
+        advisorFilters: {
+          ...filters,
+          ...(isEdgeParityEnabled
+            ? { 'filter[system_profile][host_type]': 'edge' }
+            : {}),
+        },
       }}
       getEntities={fetchSystems}
       showActions={false}

--- a/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
+++ b/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
@@ -14,14 +14,12 @@ import { systemReducer } from '../../Store/AppReducer';
 import { updateReducers } from '../../Store';
 import { useIntl } from 'react-intl';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
-import { useFeatureFlag } from '../../Utilities/Hooks';
 import { useNavigate } from 'react-router-dom';
 
 const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
   const store = useStore();
   const intl = useIntl();
   const navigate = useNavigate();
-  const isEdgeParityEnabled = useFeatureFlag('advisor.edge_parity');
   const [filters, setFilters] = useState({
     limit: 20,
     offset: 0,
@@ -134,9 +132,8 @@ const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
       customFilters={{
         advisorFilters: {
           ...filters,
-          ...(isEdgeParityEnabled
-            ? { 'filter[system_profile][host_type]': 'edge' }
-            : {}),
+          //Immutable devices table should always be filtered by host_type=edge
+          'filter[system_profile][host_type]': 'edge',
         },
       }}
       getEntities={fetchSystems}


### PR DESCRIPTION
# Description

Associated Jira ticket: # NO TICKET

This fixes the broken immutable devices tab on the Recommendation details page. The issue happens when you filter an already empty table and then click on the 'Reset filter' button. This was due to the fact that the `'filter[system_profile][host_type]': 'edge'` filter was placed inside a state. When the Reset button was clicked, that filter was gone and the API request brought incorrect data. Now, it is outside of useState, and thus API requests have this filter in place always.

# How to test the PR

1. Run the PR
2. Navigate to the Recommendation detail page that has no immutable devices (empty table)
3. Filter the table with Name fitler
4. Click on reset button
5. Observe that the table is not broken. (Make sure to repeat this multiple times)

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
