### PR TITLE
feat(RHINENG-3070): implement two tabs in pathway details page

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -60,6 +60,11 @@ export const AdvisorRoutes = () => {
           element={<DetailsPathways />}
         ></Route>
         <Route
+          key={'Pathway details'}
+          path="recommendations/pathways/systems/:id/manage-edge-inventory"
+          element={<DetailsPathways isImmutableTabOpen />}
+        ></Route>
+        <Route
           key={'Recommendation details'}
           path="recommendations/:id"
           element={<RecsDetails />}

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -61,7 +61,7 @@ export const AdvisorRoutes = () => {
         ></Route>
         <Route
           key={'Pathway details'}
-          path="recommendations/pathways/systems/:id/manage-edge-inventory"
+          path="recommendations/pathways/:id/manage-edge-inventory"
           element={<DetailsPathways isImmutableTabOpen />}
         ></Route>
         <Route

--- a/src/SmartComponents/HybridInventoryTabs/ConventionalSystems/PathwaySystems.js
+++ b/src/SmartComponents/HybridInventoryTabs/ConventionalSystems/PathwaySystems.js
@@ -1,0 +1,40 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import Inventory from '../../../PresentationalComponents/Inventory/Inventory';
+
+const PathwaySystems = ({ pathway, selectedTags, workloads, SID }) => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    return () => {
+      dispatch({
+        type: 'CLEAR_INVENTORY_STORE',
+        payload: [],
+      });
+    };
+  }, [dispatch]);
+
+  return (
+    <Inventory
+      tableProps={{
+        canSelectAll: false,
+        isStickyHeader: true,
+      }}
+      pathway={pathway}
+      selectedTags={selectedTags}
+      workloads={workloads}
+      SID={SID}
+      showTags
+    />
+  );
+};
+
+PathwaySystems.propTypes = {
+  pathway: PropTypes.object,
+  selectedTags: PropTypes.array,
+  SID: PropTypes.string,
+  workloads: PropTypes.array,
+};
+
+export default PathwaySystems;

--- a/src/SmartComponents/HybridInventoryTabs/ConventionalSystems/PathwaySystems.js
+++ b/src/SmartComponents/HybridInventoryTabs/ConventionalSystems/PathwaySystems.js
@@ -1,34 +1,20 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { useDispatch } from 'react-redux';
 import Inventory from '../../../PresentationalComponents/Inventory/Inventory';
 
-const PathwaySystems = ({ pathway, selectedTags, workloads, SID }) => {
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    return () => {
-      dispatch({
-        type: 'CLEAR_INVENTORY_STORE',
-        payload: [],
-      });
-    };
-  }, [dispatch]);
-
-  return (
-    <Inventory
-      tableProps={{
-        canSelectAll: false,
-        isStickyHeader: true,
-      }}
-      pathway={pathway}
-      selectedTags={selectedTags}
-      workloads={workloads}
-      SID={SID}
-      showTags
-    />
-  );
-};
+const PathwaySystems = ({ pathway, selectedTags, workloads, SID }) => (
+  <Inventory
+    tableProps={{
+      canSelectAll: false,
+      isStickyHeader: true,
+    }}
+    pathway={pathway}
+    selectedTags={selectedTags}
+    workloads={workloads}
+    SID={SID}
+    showTags
+  />
+);
 
 PathwaySystems.propTypes = {
   pathway: PropTypes.object,

--- a/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
+++ b/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
@@ -22,7 +22,6 @@ const PathwaySystems = lazy(() =>
 );
 
 const HybridInventory = ({
-  ruleId,
   isImmutableTabOpen,
   conventionalSystemsCount,
   edgeSystemsCount,
@@ -71,7 +70,6 @@ const HybridInventory = ({
 
 HybridInventory.propTypes = {
   isImmutableTabOpen: propTypes.bool,
-  ruleId: propTypes.string,
   conventionalSystemsCount: propTypes.number,
   edgeSystemsCount: propTypes.number,
   areCountsLoading: propTypes.bool,

--- a/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
+++ b/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
@@ -9,9 +9,15 @@ const ImmutableDevices = lazy(() =>
   import(/* webpackChunkName: "ImmutableDevices" */ './ImmutableDevices')
 );
 
-const ConventionalSystems = lazy(() =>
+const RecommendationSystems = lazy(() =>
   import(
-    /* webpackChunkName: "ConventionalSystems" */ './ConventionalSystems/RecommendationSystems'
+    /* webpackChunkName: "RecommendationSystems" */ './ConventionalSystems/RecommendationSystems'
+  )
+);
+
+const PathwaySystems = lazy(() =>
+  import(
+    /* webpackChunkName: "RecommendationSystems" */ './ConventionalSystems/PathwaySystems'
   )
 );
 
@@ -21,6 +27,7 @@ const HybridInventory = ({
   conventionalSystemsCount,
   edgeSystemsCount,
   areCountsLoading,
+  tabPathname,
   ...tabProps
 }) => {
   const isEdgeParityEnabled = useFeatureFlag('advisor.edge_parity');
@@ -37,7 +44,11 @@ const HybridInventory = ({
       module="./HybridInventoryTabs"
       ConventionalSystemsTab={
         <Suspense fallback={Fragment}>
-          <ConventionalSystems {...tabProps} />
+          {tabProps.isRecommendationDetail ? (
+            <RecommendationSystems {...tabProps} />
+          ) : (
+            <PathwaySystems {...tabProps} />
+          )}
         </Suspense>
       }
       ImmutableDevicesTab={
@@ -45,7 +56,7 @@ const HybridInventory = ({
           <ImmutableDevices {...tabProps} />
         </Suspense>
       }
-      tabPathname={`/insights/advisor/recommendations/${ruleId}`}
+      tabPathname={tabPathname}
       isImmutableTabOpen={isImmutableTabOpen}
       fallback={<div />}
       columns
@@ -64,6 +75,9 @@ HybridInventory.propTypes = {
   conventionalSystemsCount: propTypes.number,
   edgeSystemsCount: propTypes.number,
   areCountsLoading: propTypes.bool,
+  tabPathname: propTypes.string,
+  rule: propTypes.object,
+  isRecommendationDetail: propTypes.bool,
 };
 
 export default HybridInventory;

--- a/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
+++ b/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
@@ -17,7 +17,7 @@ const RecommendationSystems = lazy(() =>
 
 const PathwaySystems = lazy(() =>
   import(
-    /* webpackChunkName: "RecommendationSystems" */ './ConventionalSystems/PathwaySystems'
+    /* webpackChunkName: "PathwaySystems" */ './ConventionalSystems/PathwaySystems'
   )
 );
 

--- a/src/SmartComponents/HybridInventoryTabs/HybridInventorytabs.test.js
+++ b/src/SmartComponents/HybridInventoryTabs/HybridInventorytabs.test.js
@@ -7,9 +7,27 @@ import { AccountStatContext } from '../../ZeroStateWrapper';
 
 jest.mock('@redhat-cloud-services/frontend-components/AsyncComponent', () => ({
   __esModule: true,
-  default: jest.fn((props) => (
+  default: jest.fn(({ ConventionalSystemsTab, ...props }) => (
     <div {...props} aria-label="hybrid-inventory-mock">
-      AsyncComponent
+      {ConventionalSystemsTab}
+    </div>
+  )),
+}));
+
+jest.mock('./ConventionalSystems/RecommendationSystems', () => ({
+  __esModule: true,
+  default: jest.fn((props) => (
+    <div {...props} aria-label="recommendation-component-mock">
+      Mocked recommendation component
+    </div>
+  )),
+}));
+
+jest.mock('./ConventionalSystems/PathwaySystems', () => ({
+  __esModule: true,
+  default: jest.fn((props) => (
+    <div {...props} aria-label="pathway-component-mock">
+      Mocked pathway component
     </div>
   )),
 }));
@@ -44,7 +62,7 @@ const waitAsyncComponent = async () => {
   });
 };
 
-describe('HybridInventory', () => {
+describe('HybridInventoryTabs', () => {
   it('Should auto switch to edge tab  when there is no conventional systems, but there is edge device', async () => {
     renderComponent(
       { ...hybridSystemsCounts, conventionalSystemsCount: 0 },
@@ -112,7 +130,10 @@ describe('HybridInventory', () => {
   });
 
   it('Should pass correct tabPath prop to fed-module from accountContext', async () => {
-    renderComponent({ ...hybridSystemsCounts, ruleId: 'testRule' });
+    renderComponent({
+      ...hybridSystemsCounts,
+      tabPathname: '/insights/advisor/recommendations/testRule',
+    });
 
     await waitAsyncComponent();
     expect(AsynComponent).toHaveBeenCalledWith(
@@ -121,5 +142,29 @@ describe('HybridInventory', () => {
       }),
       {}
     );
+  });
+
+  it('Should load PathwaySystems when isRecommendationDetail is set to true', async () => {
+    renderComponent({ isRecommendationDetail: true });
+
+    await waitAsyncComponent();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('recommendation-component-mock')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('Should load PathwaySystems with tab props when isRecommendationDetail is set to false', async () => {
+    renderComponent({ isRecommendationDetail: false });
+
+    await waitAsyncComponent();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('pathway-component-mock')
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
+++ b/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
@@ -122,7 +122,9 @@ const ImmutableDevices = ({
         operatingSystem: false,
         tags: false,
       }}
-      mergeAppColumns={mergeAppColumns}
+      mergeAppColumns={(defaultColumns) =>
+        mergeAppColumns(defaultColumns, isRecommendationDetail)
+      }
       activeFiltersConfig={activeFiltersConfig}
       onRowClick={onSystemNameClick}
       {...(isRecommendationDetail ? { tableActions: actionResolver } : {})}

--- a/src/SmartComponents/HybridInventoryTabs/helpers.js
+++ b/src/SmartComponents/HybridInventoryTabs/helpers.js
@@ -7,7 +7,7 @@ import { useCallback } from 'react';
 import { systemReducer } from '../../Store/AppReducer';
 import { updateReducers } from '../../Store';
 import { useStore } from 'react-redux';
-import { sortable, wrappable } from '@patternfly/react-table';
+import { wrappable } from '@patternfly/react-table';
 
 export const useGetEntities =
   (handleRefresh, pathway, rule) =>
@@ -117,13 +117,13 @@ export const useOnLoad = (filters) => {
   );
 };
 
-export const mergeAppColumns = (defaultColumns) => {
+export const mergeAppColumns = (defaultColumns, isRecommendationDetail) => {
   const lastSeenColumn = defaultColumns.find(({ key }) => key === 'updated');
   const impacted_date = {
     key: 'impacted_date',
     title: 'First Impacted',
     sortKey: 'impacted_date',
-    transforms: [sortable, wrappable],
+    transforms: [wrappable],
     props: { width: 15 },
     renderFunc: lastSeenColumn.renderFunc,
   };
@@ -135,5 +135,9 @@ export const mergeAppColumns = (defaultColumns) => {
   //disable sorting on GROUPS. API does not handle this
   const groupsColumn = defaultColumns.find(({ key }) => key === 'groups');
   groupsColumn.props = { ...groupsColumn.props, isStatic: true };
-  return [...defaultColumns, impacted_date];
+
+  return [
+    ...defaultColumns,
+    ...(isRecommendationDetail ? [impacted_date] : []),
+  ];
 };

--- a/src/SmartComponents/HybridInventoryTabs/helpers.test.js
+++ b/src/SmartComponents/HybridInventoryTabs/helpers.test.js
@@ -209,7 +209,7 @@ const defaultColumns = [
 
 describe('mergeAppColumns', () => {
   test('Should use last seen column render function for impacted column', () => {
-    const result = mergeAppColumns(defaultColumns);
+    const result = mergeAppColumns(defaultColumns, true);
 
     const impacted_date = result.find(
       (column) => column.key === 'impacted_date'

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -261,6 +261,7 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
                   edgeSystemsCount={edgeSystemsCount}
                   conventionalSystemsCount={conventionalSystemsCount}
                   areCountsLoading={areCountsLoading}
+                  tabPathname={`/insights/advisor/recommendations/${ruleId}`}
                 />
               </React.Fragment>
             )}

--- a/src/SmartComponents/Recs/DetailsPathways.js
+++ b/src/SmartComponents/Recs/DetailsPathways.js
@@ -216,7 +216,7 @@ const PathwayDetails = ({ isImmutableTabOpen }) => {
                   workloads={workloads}
                   SID={SID}
                   isImmutableTabOpen={isImmutableTabOpen}
-                  tabPathname={`/insights/advisor/recommendations/pathways/systems/${pathwayName}`}
+                  tabPathname={`/insights/advisor/recommendations/pathways/${pathwayName}`}
                 />
               </Suspense>
             )}

--- a/src/SmartComponents/Recs/DetailsPathways.js
+++ b/src/SmartComponents/Recs/DetailsPathways.js
@@ -33,6 +33,8 @@ import { workloadQueryBuilder } from '../../PresentationalComponents/Common/Tabl
 import { useLocation } from 'react-router-dom';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import HybridInventory from '../HybridInventoryTabs/HybridInventoryTabs';
+import { useFeatureFlag } from '../../Utilities/Hooks';
+import { edgeSystemsCheck } from './helpers';
 
 const RulesTable = lazy(() =>
   import(
@@ -50,6 +52,11 @@ const PathwayDetails = ({ isImmutableTabOpen }) => {
   const SID = useSelector(({ filters }) => filters.SID);
   const recFilters = useSelector(({ filters }) => filters.recState);
   const sysFilters = useSelector(({ filters }) => filters.sysState);
+
+  const isEdgeParityEnabled = useFeatureFlag('advisor.edge_parity');
+  const [edgeSystemsCount, setEdgeSystemsCount] = useState(0);
+  const [conventionalSystemsCount, setConventionalSystemsCount] = useState(0);
+  const [areCountsLoading, setCountsLoading] = useState(true);
 
   let options = {};
   selectedTags?.length &&
@@ -129,6 +136,18 @@ const PathwayDetails = ({ isImmutableTabOpen }) => {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    isEdgeParityEnabled &&
+      edgeSystemsCheck(
+        undefined,
+        undefined,
+        setEdgeSystemsCount,
+        setConventionalSystemsCount,
+        setCountsLoading,
+        pathwayName
+      );
+  }, [isEdgeParityEnabled, pathwayName]);
 
   return (
     <React.Fragment>
@@ -217,6 +236,9 @@ const PathwayDetails = ({ isImmutableTabOpen }) => {
                   SID={SID}
                   isImmutableTabOpen={isImmutableTabOpen}
                   tabPathname={`/insights/advisor/recommendations/pathways/${pathwayName}`}
+                  edgeSystemsCount={edgeSystemsCount}
+                  conventionalSystemsCount={conventionalSystemsCount}
+                  areCountsLoading={areCountsLoading}
                 />
               </Suspense>
             )}

--- a/src/SmartComponents/Recs/DetailsPathways.js
+++ b/src/SmartComponents/Recs/DetailsPathways.js
@@ -1,5 +1,6 @@
 import './Details.scss';
 
+import PropTypes from 'prop-types';
 import {
   Grid,
   GridItem,
@@ -22,7 +23,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import Breadcrumbs from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
 import CategoryLabel from '../../PresentationalComponents/Labels/CategoryLabel';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
-import Inventory from '../../PresentationalComponents/Inventory/Inventory';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import RuleLabels from '../../PresentationalComponents/Labels/RuleLabels';
 import messages from '../../Messages';
@@ -32,6 +32,7 @@ import { useParams } from 'react-router-dom';
 import { workloadQueryBuilder } from '../../PresentationalComponents/Common/Tables';
 import { useLocation } from 'react-router-dom';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import HybridInventory from '../HybridInventoryTabs/HybridInventoryTabs';
 
 const RulesTable = lazy(() =>
   import(
@@ -39,7 +40,7 @@ const RulesTable = lazy(() =>
   )
 );
 
-const PathwayDetails = () => {
+const PathwayDetails = ({ isImmutableTabOpen }) => {
   const intl = useIntl();
   const pathwayName = useParams().id;
   const dispatch = useDispatch();
@@ -209,16 +210,13 @@ const PathwayDetails = () => {
               <Loading />
             ) : (
               <Suspense fallback={<Loading />}>
-                <Inventory
-                  tableProps={{
-                    canSelectAll: false,
-                    isStickyHeader: true,
-                  }}
+                <HybridInventory
                   pathway={pathway}
                   selectedTags={selectedTags}
                   workloads={workloads}
                   SID={SID}
-                  showTags={true}
+                  isImmutableTabOpen={isImmutableTabOpen}
+                  tabPathname={`/insights/advisor/recommendations/pathways/systems/${pathwayName}`}
                 />
               </Suspense>
             )}
@@ -229,4 +227,7 @@ const PathwayDetails = () => {
   );
 };
 
+PathwayDetails.propTypes = {
+  isImmutableTabOpen: PropTypes.bool,
+};
 export default PathwayDetails;

--- a/src/SmartComponents/Recs/helpers.test.js
+++ b/src/SmartComponents/Recs/helpers.test.js
@@ -3,6 +3,10 @@ import { edgeSystemsCheck } from './helpers';
 
 jest.mock('axios');
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 const setSystemsCount = jest.fn((items) => items);
 const setEdgeSystemsCount = jest.fn();
 const setConventionalSystemsCount = jest.fn();
@@ -25,5 +29,48 @@ describe('edgeSystemsCheck state is getting set', () => {
     await expect(setEdgeSystemsCount).toHaveBeenCalledWith(1);
     await expect(setConventionalSystemsCount).toHaveBeenCalledWith(1);
     await expect(setCountsLoading).toHaveBeenCalledWith(false);
+  });
+
+  test('should get recommendation data', async () => {
+    const resp = { data: { meta: { count: 1 } } };
+
+    axios.get.mockImplementation(() => Promise.resolve(resp));
+
+    await edgeSystemsCheck(
+      'test',
+      setSystemsCount,
+      setEdgeSystemsCount,
+      setConventionalSystemsCount,
+      setCountsLoading
+    );
+
+    expect(axios.get).toHaveBeenCalledWith(
+      '/api/insights/v1/rule/test/systems_detail/?filter[system_profile][host_type][nil]=true&limit=1'
+    );
+    expect(axios.get).toHaveBeenCalledWith(
+      '/api/insights/v1/rule/test/systems_detail/?filter[system_profile][host_type]=edge&limit=1'
+    );
+  });
+
+  test('should get pathway data', async () => {
+    const resp = { data: { meta: { count: 1 } } };
+
+    axios.get.mockImplementation(() => Promise.resolve(resp));
+
+    await edgeSystemsCheck(
+      undefined,
+      setSystemsCount,
+      setEdgeSystemsCount,
+      setConventionalSystemsCount,
+      setCountsLoading,
+      'pathway'
+    );
+
+    expect(axios.get).toHaveBeenCalledWith(
+      '/api/insights/v1/system/?limit=1&filter[system_profile][host_type][nil]=true&pathway=pathway'
+    );
+    expect(axios.get).toHaveBeenCalledWith(
+      '/api/insights/v1/system/?limit=1&filter[system_profile][host_type]=edge&pathway=pathway'
+    );
   });
 });


### PR DESCRIPTION
# Description

Associated Jira ticket: # RHINENG-3070

This creates hybrid tabs for the pathways details page.

Acceptance criteria:

**Important: Immutable tab should behave as it is in recommendation detail page without table row actions**

1. Select the system number from a Pathway row on the main page and go to the Pathway details. If there are any conventional systems, land on details with Conventional systems in view ([Table](https://www.sketch.com/s/ac25729e-df9b-4e74-a09c-badb62787d24/a/ZVvo0ja#Inspect))
2. If ALL systems are Immutable, go to details with the Immutable tab in focus.
3. If there are NO immutable systems on the account, [Hide the tabs.](https://www.sketch.com/s/ac25729e-df9b-4e74-a09c-badb62787d24/a/kKdnAeg#Inspect)
4. Add tabs to the table if at least one Immutable system exists.
5. If there are no conventional systems but the account has immutable systems, keep the conventional tab with an empty state.
6. These columns exist: Name, Group, Tags, OS, Last Seen, First impacted
7. The system link goes to  “Inventory > System Details > Advisor tab 
8. Table can be filtered by Name, Tags, OS

# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
