### PR TITLE
fix(HybridInventoryTabs): auto switch to edge conditionally

### DIFF
--- a/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
+++ b/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
@@ -3,6 +3,7 @@ import propTypes from 'prop-types';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { useFeatureFlag } from '../../Utilities/Hooks';
 import { AccountStatContext } from '../../ZeroStateWrapper';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
 const ImmutableDevices = lazy(() =>
   import(/* webpackChunkName: "ImmutableDevices" */ './ImmutableDevices')
@@ -14,33 +15,45 @@ const ConventionalSystems = lazy(() =>
   )
 );
 
-const HybridInventory = (props) => {
+const HybridInventory = ({
+  ruleId,
+  isImmutableTabOpen,
+  conventionalSystemsCount,
+  edgeSystemsCount,
+  areCountsLoading,
+  ...tabProps
+}) => {
   const isEdgeParityEnabled = useFeatureFlag('advisor.edge_parity');
-  const { hasEdgeDevices, hasConventionalSystems } =
-    useContext(AccountStatContext);
+  const { hasEdgeDevices } = useContext(AccountStatContext);
 
-  return (
+  return areCountsLoading ? (
+    <Bullseye>
+      <Spinner size="lg" />
+    </Bullseye>
+  ) : (
     <AsynComponent
       key="hybridInventory"
       appName="inventory"
       module="./HybridInventoryTabs"
       ConventionalSystemsTab={
         <Suspense fallback={Fragment}>
-          <ConventionalSystems {...props} />
+          <ConventionalSystems {...tabProps} />
         </Suspense>
       }
       ImmutableDevicesTab={
         <Suspense fallback={Fragment}>
-          <ImmutableDevices {...props} />
+          <ImmutableDevices {...tabProps} />
         </Suspense>
       }
-      tabPathname={`/insights/advisor/recommendations/${props.ruleId}`}
-      isImmutableTabOpen={props.isImmutableTabOpen}
+      tabPathname={`/insights/advisor/recommendations/${ruleId}`}
+      isImmutableTabOpen={isImmutableTabOpen}
       fallback={<div />}
       columns
       isEdgeParityEnabled={isEdgeParityEnabled}
       accountHasEdgeImages={hasEdgeDevices}
-      hasConventionalSystems={hasConventionalSystems}
+      hasConventionalSystems={
+        conventionalSystemsCount > 0 || edgeSystemsCount <= 0
+      }
     />
   );
 };
@@ -48,6 +61,9 @@ const HybridInventory = (props) => {
 HybridInventory.propTypes = {
   isImmutableTabOpen: propTypes.bool,
   ruleId: propTypes.string,
+  conventionalSystemsCount: propTypes.number,
+  edgeSystemsCount: propTypes.number,
+  areCountsLoading: propTypes.bool,
 };
 
 export default HybridInventory;

--- a/src/SmartComponents/HybridInventoryTabs/HybridInventorytabs.test.js
+++ b/src/SmartComponents/HybridInventoryTabs/HybridInventorytabs.test.js
@@ -1,0 +1,125 @@
+import React from 'react';
+import HybridInventory from './HybridInventoryTabs';
+import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AccountStatContext } from '../../ZeroStateWrapper';
+
+jest.mock('@redhat-cloud-services/frontend-components/AsyncComponent', () => ({
+  __esModule: true,
+  default: jest.fn((props) => (
+    <div {...props} aria-label="hybrid-inventory-mock">
+      AsyncComponent
+    </div>
+  )),
+}));
+
+jest.mock('../../Utilities/Hooks', () => ({
+  ...jest.requireActual('../../Utilities/Hooks'),
+  useFeatureFlag: jest.fn(() => false),
+}));
+
+const accountContextValue = {
+  hasConventionalSystems: true,
+  hasEdgeDevices: true,
+};
+
+const hybridSystemsCounts = {
+  conventionalSystemsCount: 10,
+  edgeSystemsCount: 10,
+  areCountsLoading: false,
+};
+
+const renderComponent = (props, accountContextValues = accountContextValue) => {
+  render(
+    <AccountStatContext.Provider value={accountContextValues}>
+      <HybridInventory {...props} />
+    </AccountStatContext.Provider>
+  );
+};
+
+const waitAsyncComponent = async () => {
+  await waitFor(() => {
+    expect(screen.getByLabelText('hybrid-inventory-mock')).toBeInTheDocument();
+  });
+};
+
+describe('HybridInventory', () => {
+  it('Should auto switch to edge tab  when there is no conventional systems, but there is edge device', async () => {
+    renderComponent(
+      { ...hybridSystemsCounts, conventionalSystemsCount: 0 },
+      accountContextValue
+    );
+
+    await waitAsyncComponent();
+    expect(AsynComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasConventionalSystems: false,
+      }),
+      {}
+    );
+  });
+  it('Should not auto switch to edge tab automatically when there is no conventional systems and no edge device', async () => {
+    renderComponent(
+      {
+        ...hybridSystemsCounts,
+        conventionalSystemsCount: 0,
+        edgeSystemsCount: 0,
+      },
+      accountContextValue
+    );
+
+    await waitAsyncComponent();
+    expect(AsynComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasConventionalSystems: true,
+      }),
+      {}
+    );
+  });
+  it('Should not auto switch to edge tab automatically when there are both conventional systems and edge device', async () => {
+    renderComponent(hybridSystemsCounts, accountContextValue);
+
+    await waitAsyncComponent();
+    expect(AsynComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasConventionalSystems: true,
+      }),
+      {}
+    );
+  });
+  it('Should pass isImmutableTabOpen prop to fed-module', async () => {
+    renderComponent({ isImmutableTabOpen: true, ...hybridSystemsCounts });
+
+    await waitAsyncComponent();
+    expect(AsynComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isImmutableTabOpen: true,
+      }),
+      {}
+    );
+  });
+  it('Should pass accountHasEdgeImages prop to fed-module from accountContext', async () => {
+    renderComponent(hybridSystemsCounts);
+
+    await waitAsyncComponent();
+    expect(AsynComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountHasEdgeImages: true,
+      }),
+      {}
+    );
+  });
+
+  it('Should pass correct tabPath prop to fed-module from accountContext', async () => {
+    renderComponent({ ...hybridSystemsCounts, ruleId: 'testRule' });
+
+    await waitAsyncComponent();
+    expect(AsynComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tabPathname: '/insights/advisor/recommendations/testRule',
+      }),
+      {}
+    );
+  });
+});

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -65,6 +65,7 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
   const [systemsCount, setSystemsCount] = useState(0);
   const [edgeSystemsCount, setEdgeSystemsCount] = useState(0);
   const [conventionalSystemsCount, setConventionalSystemsCount] = useState(0);
+  const [areCountsLoading, setCountsLoading] = useState(true);
   const { hasEdgeDevices } = useContext(AccountStatContext);
   const isEdgeParityEnabled = useFeatureFlag('advisor.edge_parity');
 
@@ -105,7 +106,8 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
         ruleId,
         setSystemsCount,
         setEdgeSystemsCount,
-        setConventionalSystemsCount
+        setConventionalSystemsCount,
+        setCountsLoading
       );
   }, [isEdgeParityEnabled, ruleId]);
 
@@ -257,6 +259,7 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
                   isRecommendationDetail
                   edgeSystemsCount={edgeSystemsCount}
                   conventionalSystemsCount={conventionalSystemsCount}
+                  areCountsLoading={areCountsLoading}
                 />
               </React.Fragment>
             )}

--- a/src/SmartComponents/Recs/helpers.js
+++ b/src/SmartComponents/Recs/helpers.js
@@ -77,7 +77,8 @@ export const edgeSystemsCheck = async (
   ruleId,
   setSystemsCount,
   setEdgeSystemsCount,
-  setConventionalSystemsCount
+  setConventionalSystemsCount,
+  setCountsLoading
 ) => {
   let count = 0;
   try {
@@ -99,7 +100,9 @@ export const edgeSystemsCheck = async (
       });
 
     setSystemsCount(count);
+    setCountsLoading(false);
   } catch (error) {
     console.error(error);
+    setCountsLoading(false);
   }
 };

--- a/src/SmartComponents/Recs/helpers.test.js
+++ b/src/SmartComponents/Recs/helpers.test.js
@@ -6,6 +6,7 @@ jest.mock('axios');
 const setSystemsCount = jest.fn((items) => items);
 const setEdgeSystemsCount = jest.fn();
 const setConventionalSystemsCount = jest.fn();
+const setCountsLoading = jest.fn();
 describe('edgeSystemsCheck state is getting set', () => {
   test('All state variables get called', async () => {
     const resp = { data: { meta: { count: 1 } } };
@@ -16,11 +17,13 @@ describe('edgeSystemsCheck state is getting set', () => {
       'test',
       setSystemsCount,
       setEdgeSystemsCount,
-      setConventionalSystemsCount
+      setConventionalSystemsCount,
+      setCountsLoading
     );
 
     await expect(setSystemsCount).toHaveBeenCalledWith(2);
     await expect(setEdgeSystemsCount).toHaveBeenCalledWith(1);
     await expect(setConventionalSystemsCount).toHaveBeenCalledWith(1);
+    await expect(setCountsLoading).toHaveBeenCalledWith(false);
   });
 });


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)
This fixes the issue on HybridInventoryTabs. The issue happened by the fact that I understood the PM requirement wrong and made hybrid tabs switch to edge automatically when there are no conventional systems at a vulnerability account level. Instead, the correct behavior is the tabs auto-switching to the edge when there are no conventional systems affected by a CVE. Also, the tab should not auto-switch when there are no both conventional and edge devices.

# How to test the PR

1. Go Recommendations page
2. Find a recommendation that has only edge devices affected. For example: **Reboot will fail as the default initramfs file is not generated successfully**
3. Open details page
4. Observe that edge tab is automatically activated
5. Find another recommendation that has no conventional and edge degices.
6. Observe that tab does not auto switch to edge.

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
