### PR TITLE
feat(RHINENG-3414): enable recommendation disabling action in ImmutableDevices

### DIFF
--- a/src/SmartComponents/HybridInventoryTabs/ConventionalSystems/RecommendationSystems.js
+++ b/src/SmartComponents/HybridInventoryTabs/ConventionalSystems/RecommendationSystems.js
@@ -4,6 +4,7 @@ import { usePermissions } from '@redhat-cloud-services/frontend-components-utili
 import Inventory from '../../../PresentationalComponents/Inventory/Inventory';
 import { useSelector } from 'react-redux';
 import { PERMS } from '../../../AppConstants';
+import { useActionResolver } from '../helpers';
 
 const ConventionalSystems = ({ rule, afterDisableFn, handleModalToggle }) => {
   const selectedTags = useSelector(({ filters }) => filters.selectedTags);
@@ -11,12 +12,7 @@ const ConventionalSystems = ({ rule, afterDisableFn, handleModalToggle }) => {
   const SID = useSelector(({ filters }) => filters.SID);
   const permsExport = usePermissions('advisor', PERMS.export).hasAccess;
 
-  const actionResolver = () => [
-    {
-      title: 'Disable recommendation for system',
-      onClick: (event, rowIndex, item) => handleModalToggle(true, item),
-    },
-  ];
+  const actionResolver = useActionResolver(handleModalToggle);
 
   return (
     <Inventory

--- a/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
+++ b/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
@@ -6,7 +6,7 @@ import {
   urlBuilder,
 } from '../../PresentationalComponents/Common/Tables';
 import { useStore } from 'react-redux';
-import { useGetEntities } from './helpers';
+import { useGetEntities, useActionResolver } from './helpers';
 import PropTypes from 'prop-types';
 import {} from '../../AppConstants';
 import messages from '../../Messages';
@@ -16,7 +16,13 @@ import { useIntl } from 'react-intl';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { useNavigate } from 'react-router-dom';
 
-const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
+const ImmutableDevices = ({
+  rule,
+  pathway,
+  selectedTags,
+  handleModalToggle,
+  isRecommendationDetail,
+}) => {
   const store = useStore();
   const intl = useIntl();
   const navigate = useNavigate();
@@ -107,6 +113,8 @@ const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
     navigate(`/insights/inventory/${systemId}?appName=advisor`);
   };
 
+  const actionResolver = useActionResolver(handleModalToggle);
+
   return (
     <AsynComponent
       appName="inventory"
@@ -147,6 +155,7 @@ const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
       mergeAppColumns={mergeAppColumns}
       activeFiltersConfig={activeFiltersConfig}
       onRowClick={onSystemNameClick}
+      {...(isRecommendationDetail ? { tableActions: actionResolver } : {})}
     />
   );
 };
@@ -162,5 +171,7 @@ ImmutableDevices.propTypes = {
   permsExport: PropTypes.bool,
   exportTable: PropTypes.string,
   showTags: PropTypes.bool,
+  handleModalToggle: PropTypes.func,
+  isRecommendationDetail: PropTypes.bool,
 };
 export default ImmutableDevices;

--- a/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.test.js
+++ b/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.test.js
@@ -5,7 +5,7 @@ import { ComponentWithContext } from '../../Utilities/TestingUtilities';
 import ImmutableDevices from './ImmutableDevices';
 import { render } from '@testing-library/react';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
-import { useGetEntities } from './helpers';
+import { useGetEntities, useActionResolver } from './helpers';
 
 jest.mock('@redhat-cloud-services/frontend-components/AsyncComponent', () => ({
   __esModule: true,
@@ -25,6 +25,7 @@ jest.mock('@unleash/proxy-client-react', () => ({
 jest.mock('./helpers', () => ({
   ...jest.requireActual('./helpers'),
   useGetEntities: jest.fn(() => {}),
+  useActionResolver: jest.fn(() => () => {}),
 }));
 
 const renderAndWait = async (componentProps = {}, renderOptions = {}) => {
@@ -111,6 +112,41 @@ describe('ImmutableDevices', () => {
       expect.any(Function),
       'test-pathway',
       'test-rule'
+    );
+  });
+
+  test('should not provide actionsResolver when pathway detail ', async () => {
+    const handleModalToggle = jest.fn();
+    await renderAndWait({
+      pathway: 'test-pathway',
+      rule: 'test-rule',
+      isRecommendationDetail: false,
+      handleModalToggle,
+    });
+
+    expect(AsynComponent).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        tableActions: expect.any(Function),
+      }),
+      {}
+    );
+  });
+
+  test('should provide actionsResolver with handleModalToggle prop when recommendation detail', async () => {
+    const handleModalToggle = jest.fn();
+    await renderAndWait({
+      pathway: 'test-pathway',
+      rule: 'test-rule',
+      isRecommendationDetail: true,
+      handleModalToggle,
+    });
+
+    expect(useActionResolver).toHaveBeenCalledWith(handleModalToggle);
+    expect(AsynComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableActions: expect.any(Function),
+      }),
+      {}
     );
   });
 });

--- a/src/SmartComponents/HybridInventoryTabs/helpers.js
+++ b/src/SmartComponents/HybridInventoryTabs/helpers.js
@@ -3,6 +3,7 @@ import { paginatedRequestHelper } from '../../PresentationalComponents/Inventory
 import { mergeArraysByDiffKeys } from '../../PresentationalComponents/Common/Tables';
 import { Post } from '../../Utilities/Api';
 import { EDGE_DEVICE_BASE_URL } from '../../AppConstants';
+import { useCallback } from 'react';
 
 export const useGetEntities =
   (handleRefresh, pathway, rule) =>
@@ -75,3 +76,14 @@ export const useGetEntities =
       total: advisorData.meta.count,
     });
   };
+
+export const useActionResolver = (handleModalToggle) =>
+  useCallback(
+    () => [
+      {
+        title: 'Disable recommendation for system',
+        onClick: (event, rowIndex, item) => handleModalToggle(true, item),
+      },
+    ],
+    []
+  );

--- a/src/SmartComponents/HybridInventoryTabs/helpers.test.js
+++ b/src/SmartComponents/HybridInventoryTabs/helpers.test.js
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { act } from '@testing-library/react';
-import { useGetEntities } from './helpers';
+import { useGetEntities, useActionResolver } from './helpers';
 import { Get, Post } from '../../Utilities/Api';
 import inventoryData from './fixtures/inventoryData.json';
 import advisorPathwayData from './fixtures/advisorPathwayData.json';
@@ -119,5 +119,28 @@ describe('getEntities', () => {
     });
 
     testApiCallArguments();
+  });
+});
+
+const handleModalToggle = jest.fn();
+describe('useActionResolver', () => {
+  test('Should return actionsResolver', async () => {
+    const { result } = renderHook(() => useActionResolver(handleModalToggle));
+
+    expect(result.current()).toEqual([
+      {
+        onClick: expect.any(Function),
+        title: 'Disable recommendation for system',
+      },
+    ]);
+  });
+
+  test('Should call callback function on action click', async () => {
+    const { result } = renderHook(() => useActionResolver(handleModalToggle));
+
+    const recDisableAction = result.current()[0];
+    recDisableAction.onClick('event', 'rowIndex', 'test-device-id');
+
+    expect(handleModalToggle).toHaveBeenCalledWith(true, 'test-device-id');
   });
 });

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -235,6 +235,7 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
                   afterDisableFn={afterDisableFn}
                   handleModalToggle={handleModalToggle}
                   isImmutableTabOpen={isImmutableTabOpen}
+                  isRecommendationDetail
                 />
               </React.Fragment>
             )}


### PR DESCRIPTION

# Description

Associated Jira ticket: # [(issue)](https://issues.redhat.com/browse/RHINENG-3414)

We need to enable recommendation disabling action in the recommendation details page Immutable devices tab. This action should work as it is in the conventional systems tab.

# How to test the PR

1. Open a recommendation that has an immutable device
2. Observe that now there is a table action in each row
3. Copy one of the device name in the first column
4. Try disabling the recommendation for one of them
5. Observe that the device you disabled does not exist in the table anymore by searching for your copied device name

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
