### PR TITLE
chore(ImmutableDevices): disables sorting on Groups as API does not h…

### DIFF
--- a/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
+++ b/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
@@ -100,6 +100,9 @@ const ImmutableDevices = ({ rule, pathway, selectedTags }) => {
     const osColumn = defaultColumns.find(({ key }) => key === 'system_profile');
     osColumn.props = { isStatic: true };
 
+    //disable sorting on GROUPS. API does not handle this
+    const groupsColumn = defaultColumns.find(({ key }) => key === 'groups');
+    groupsColumn.props = { isStatic: true };
     return [...defaultColumns, impacted_date];
   };
 


### PR DESCRIPTION
…andle it

# Description

Associated Jira ticket: # (issue)

After groups column sorting is enabled, the groups column in the advisor immutable tab. This will disable sorting on that table till API handles it.

# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
