### PR TITLE
feat(RHINENG-5019): Column modifications to RecommendationsSystems

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -278,6 +278,8 @@ const Inventory = ({
         ({ key }) => key === 'system_profile'
       );
       let tags = defaultColumns.filter(({ key }) => key === 'tags');
+      let groups = defaultColumns.filter(({ key }) => key === 'groups');
+
       //Link to the Systems in the Recommendation details table and Pathway details table
       displayName = {
         ...displayName[0],
@@ -302,20 +304,30 @@ const Inventory = ({
       lastSeenColumn = {
         ...lastSeenColumn[0],
         transforms: [sortable, wrappable],
-        props: { width: 20 },
       };
 
       systemProfile = {
         ...systemProfile[0],
-        transforms: [wrappable],
-        props: { isStatic: true },
+        transforms: [sortable, wrappable],
       };
 
       tags = {
         ...tags[0],
       };
 
-      let columnList = [displayName, tags, systemProfile, lastSeenColumn];
+      groups = {
+        ...groups[0],
+        transforms: [wrappable],
+        props: { ...groups[0].props, isStatic: true }, // remove this line after group sorting is enabled in the API
+      };
+
+      let columnList = [
+        displayName,
+        groups,
+        tags,
+        systemProfile,
+        lastSeenColumn,
+      ];
 
       // Add column for impacted_date which is relevant for the rec system details table, but not pathways system table
       if (!pathway) {

--- a/src/PresentationalComponents/Inventory/helpers.js
+++ b/src/PresentationalComponents/Inventory/helpers.js
@@ -1,7 +1,7 @@
 import { Get } from '../../Utilities/Api';
 import { mergeArraysByDiffKeys } from '../Common/Tables';
 import { RULES_FETCH_URL, SYSTEMS_FETCH_URL } from '../../AppConstants';
-import { createOptions } from '../helper';
+import { createOptions, createSortParam } from '../helper';
 
 /*This functions purpose is to grab the currently set filters, and return all associated systems for it.*/
 export const paginatedRequestHelper = async ({
@@ -69,13 +69,7 @@ export const getEntities =
       selectedTags,
     } = config;
 
-    //operating_system is currently not supported, but will be down the line.
-    const sort =
-      orderBy === 'operating_system'
-        ? 'rhel_version'
-        : `${orderDirection === 'ASC' ? '' : '-'}${
-            orderBy === 'updated' ? 'last_seen' : orderBy
-          }`;
+    const sort = createSortParam(orderBy, orderDirection);
 
     let options = createOptions(
       advisorFilters,

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -30,7 +30,7 @@ import { useLocation } from 'react-router-dom';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import NoSystemsTable from './Components/NoSystemsTable';
 import { systemsTableColumns } from './SystemsTableAssets';
-import { createOptions } from '../helper';
+import { createOptions, createSortParam } from '../helper';
 import { createColumns } from './createColumns';
 
 const SystemsTable = () => {
@@ -246,12 +246,7 @@ const SystemsTable = () => {
             workloads,
             SID,
           } = config;
-          const sort = `${orderDirection === 'ASC' ? '' : '-'}${
-            (orderBy === 'updated' && 'last_seen') ||
-            (orderBy === 'operating_system' && 'rhel_version') ||
-            (orderBy === 'groups' && 'group_name') ||
-            orderBy
-          }`;
+          const sort = createSortParam(orderBy, orderDirection);
 
           let options = createOptions(
             advisorFilters,

--- a/src/PresentationalComponents/helper.js
+++ b/src/PresentationalComponents/helper.js
@@ -54,3 +54,12 @@ export const sortTopics = (data, index, direction) => {
     : (sortingName = 'impacted_systems_count');
   return orderBy(data, [(result) => result[sortingName]], direction);
 };
+
+export const createSortParam = (sortField, sortDirection = 'ASC') => {
+  return `${sortDirection.toUpperCase() === 'ASC' ? '' : '-'}${
+    (sortField === 'updated' && 'last_seen') ||
+    (sortField === 'operating_system' && 'rhel_version') ||
+    (sortField === 'groups' && 'group_name') ||
+    sortField
+  }`;
+};

--- a/src/PresentationalComponents/helper.test.js
+++ b/src/PresentationalComponents/helper.test.js
@@ -1,4 +1,4 @@
-import { sortTopics, createOptions } from './helper';
+import { sortTopics, createOptions, createSortParam } from './helper';
 import fixtures from '../../cypress/fixtures/topics.json';
 
 describe('sortTopics test', () => {
@@ -151,5 +151,38 @@ describe('createOptions', () => {
         systemsPage
       ).tags
     ).toEqual(['tagFilter1/tagKey1=tag1', 'tagFilter1/tagKey2=tag2']);
+  });
+});
+
+describe('createSortParam test', () => {
+  const field = ['updated', 'operating_system', 'groups'];
+  const direction = ['asc', 'desc'];
+
+  it('creates correct updated sort param in asc and desc', () => {
+    const updatedAsc = createSortParam(field[0], direction[0]);
+    expect(updatedAsc).toBe('last_seen');
+    const updatedDesc = createSortParam(field[0], direction[1]);
+    expect(updatedDesc).toBe('-last_seen');
+  });
+
+  it('creates correct operating_system sort param in asc and desc in uppercase', () => {
+    const OSAsc = createSortParam(field[1], direction[0].toUpperCase());
+    expect(OSAsc).toBe('rhel_version');
+    const OSDesc = createSortParam(field[1], direction[1].toUpperCase());
+    expect(OSDesc).toBe('-rhel_version');
+  });
+
+  it('creates correct groups sort param with missing / unknown sort direction', () => {
+    const groupsAsc = createSortParam(field[2]);
+    expect(groupsAsc).toBe('group_name');
+    const groupsDesc = createSortParam(field[2], 'foobar');
+    expect(groupsDesc).toBe('-group_name');
+  });
+
+  it('creates other sort params verbatim', () => {
+    const sortAsc = createSortParam('misc', 'AsC');
+    expect(sortAsc).toBe('misc');
+    const sortDesc = createSortParam('misc', 'misc');
+    expect(sortDesc).toBe('-misc');
   });
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-5019

Adds the Group column to the RecommendationsSystems table and enables sorting on the OS column.  However sorting on Group column isn't enabled yet because the API doesn't support it yet.

Before PR (no group column and no sorting on OS): 
![Screenshot from 2023-11-25 03-04-40](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/34b8090d-9963-4782-9e32-d11285a858a5)

After PR:
![Screenshot from 2023-11-25 03-04-34](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/8902f3d1-0414-405d-b03b-d256e6d1dd46)
