### PR TITLE
feat(RHINENG-3415): enforce edge groups conditionally

### DIFF
--- a/src/SmartComponents/HybridInventoryTabs/fixtures/edgeData.json
+++ b/src/SmartComponents/HybridInventoryTabs/fixtures/edgeData.json
@@ -2,8 +2,16 @@
     "data": {
       "data": {
         "devices": [
-          { "DeviceUUID": "edge.id-1", "deviceName": "test-device-1" },
-          { "DeviceUUID": "edge.id-2", "deviceName": "test-device-2" }
+          { 
+            "DeviceUUID": "edge.id-1", 
+            "deviceName": "test-device-1",
+            "DeviceGroups": [{ "ID": "edge.group.id-1", "Name": "edge.group-1" }]
+          },
+          { 
+            "DeviceUUID": "edge.id-2", 
+            "deviceName": "test-device-2",
+            "DeviceGroups": [{ "ID": "edge.group.id-2", "Name": "edge.group-2" }] 
+          }
         ]
       }
     }

--- a/src/SmartComponents/HybridInventoryTabs/fixtures/inventoryData.json
+++ b/src/SmartComponents/HybridInventoryTabs/fixtures/inventoryData.json
@@ -1,3 +1,12 @@
 {
-    "results": [{ "id": "edge.id-1" }, { "id": "edge.id-2" }]
+    "results": [
+        { 
+            "id": "edge.id-1", 
+            "groups": [{ "id": "inventory-group.id-1", "name": "inventory-group-1" }] 
+        }, 
+        { 
+            "id": "edge.id-2", 
+            "groups": [{ "id": "inventory-group.id-2", "name": "inventory-group-2" }]
+        }
+    ]
 }

--- a/src/SmartComponents/HybridInventoryTabs/helpers.js
+++ b/src/SmartComponents/HybridInventoryTabs/helpers.js
@@ -60,6 +60,7 @@ export const useGetEntities =
         {},
         { devices_uuid: systemIDs }
       );
+
       fullData = devicesData?.data?.devices?.map((device) => {
         const system = inventoryData.results.find(
           (system) => device.DeviceUUID === system.id
@@ -67,6 +68,12 @@ export const useGetEntities =
         return {
           ...system,
           ...device,
+          groups: devicesData?.data?.enforce_edge_groups
+            ? device.DeviceGroups?.map((group) => ({
+                id: group.ID,
+                name: group.Name,
+              })) || []
+            : system.groups,
         };
       });
     }


### PR DESCRIPTION
# Description

Implements: https://issues.redhat.com/browse/RHINENG-3415

According to the state of enforce_edge_group from /api/edge/v1/devices/devicesview endpoint, we should show groups info from edge endpoint inventory endpoint.

**When enforce_edge_group is set to true:**

groups column uses DeviceGroups from /api/edge/v1/devices/devicesview


**When enforce_edge_group is set to false:**

groups column uses groups from /api/insights/inventory/hosts



# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
