### PR TITLE
fix(RecommendationSystems): set counts loading to false if edge parit…

### DIFF
--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -101,14 +101,15 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
   }, [chrome, intl, rule.description, ruleId]);
 
   useEffect(() => {
-    isEdgeParityEnabled &&
-      edgeSystemsCheck(
-        ruleId,
-        setSystemsCount,
-        setEdgeSystemsCount,
-        setConventionalSystemsCount,
-        setCountsLoading
-      );
+    isEdgeParityEnabled
+      ? edgeSystemsCheck(
+          ruleId,
+          setSystemsCount,
+          setEdgeSystemsCount,
+          setConventionalSystemsCount,
+          setCountsLoading
+        )
+      : setCountsLoading(false);
   }, [isEdgeParityEnabled, ruleId]);
 
   return (


### PR DESCRIPTION
…y is disabled

# Description

Associated Jira ticket: # (issue)

This fixes continuously loading recommendation systems when the edge parity work is disabled. 


# How to test the PR

1. Make sure **advisor.edge_parity** is disabled in unleash: https://insights-stage.unleash.devshift.net/projects/default/features/advisor.edge_parity
2. Run the PR
3. Navigate to any recommendation detail page
4. Observe that recommendation systems table is loaded without any tab around
5. Enable the flag ^
6. Navigate to recommendation detail page
7. Observe that hybrid inventory tabs shows up

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
