### PR TITLE
fix(RuleDetails): pass correct argument to viewAffectedSystems to fix intl warning

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -913,13 +913,6 @@ export default defineMessages({
     description: 'Error',
     defaultMessage: 'Error',
   },
-  viewAffectedSystems: {
-    id: 'viewAffectedSystems',
-    description:
-      'Link text to view all hosts that are affected by a recommendation',
-    defaultMessage:
-      'View {systemsCount, plural, one {the affected system} other {# affected systems}}',
-  },
   ruleHelpful: {
     id: 'ruleHelpful',
     description: 'Asking the user if they find a recommendation helpful',
@@ -1273,5 +1266,11 @@ export default defineMessages({
     id: 'edgeWarning',
     description: 'Warning text for edge devices',
     defaultMessage: 'Immutable systems are not shown in this list.',
+  },
+  viewAffectedSystems: {
+    id: 'viewAffectedSystems',
+    description: 'Label text for systems count in rule detail expanded row',
+    defaultMessage:
+      'View {systems, plural, one {the affected system} other {# affected systems}}',
   },
 });

--- a/src/PresentationalComponents/ExecutiveReport/Download.js
+++ b/src/PresentationalComponents/ExecutiveReport/Download.js
@@ -59,7 +59,6 @@ const DownloadExecReport = ({ isDisabled }) => {
     }
   };
 
-  console.log('heeloo');
   return useMemo(() => {
     return (
       <DownloadButtonWrapper

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -496,7 +496,7 @@ export const buildRows = (
                       {value.impacted_systems_count === 0
                         ? ''
                         : intl.formatMessage(messages.viewAffectedSystems, {
-                            systemsCount: value.impacted_systems_count,
+                            systems: value.impacted_systems_count,
                           })}
                     </Link>
                   }


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)

fixes the intl warning that was caused by passing incorrect message value. As we are migrating away intl, I tried to replace this intl message with plain text. However I have found out that advisor-components FEC package, heavily relies on intl and we need to allocate dedicated effort to remove intl from both advisor, advisor4openshift and adv-components 

![image](https://github.com/RedHatInsights/insights-advisor-frontend/assets/59481011/99c58c60-e4e7-412a-a648-aa8daf5730e3)


# How to test the PR

1. Run the PR
2. Go to recommendations table
3. Observe that the warning is gone

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
