### PR TITLE
feat(RHINENG-5544): Remove Application Name Prefix From Titles

### DIFF
--- a/src/SmartComponents/Recs/List.js
+++ b/src/SmartComponents/Recs/List.js
@@ -63,11 +63,7 @@ const List = () => {
   return (
     <React.Fragment>
       <PageHeader className="adv-c-page-recommendations__header">
-        <PageHeaderTitle
-          title={`${
-            messages.insightsHeader.defaultMessage
-          } ${messages.recommendations.defaultMessage.toLowerCase()}`}
-        />
+        <PageHeaderTitle title={`${messages.recommendations.defaultMessage}`} />
         {!permsExport.isLoading && (
           <Tooltip
             trigger={!permsExport.hasAccess ? 'mouseenter' : ''}

--- a/src/SmartComponents/Systems/List.js
+++ b/src/SmartComponents/Systems/List.js
@@ -25,11 +25,7 @@ const List = () => {
   return (
     <React.Fragment>
       <PageHeader>
-        <PageHeaderTitle
-          title={`${intl.formatMessage(messages.insightsHeader)} ${intl
-            .formatMessage(messages.systems)
-            .toLowerCase()}`}
-        />
+        <PageHeaderTitle title={`${messages.systems.defaultMessage}`} />
       </PageHeader>
       <section className="pf-l-page__main-section pf-c-page__main-section">
         {edgeParityFFlag ? <EdgeSystemsBanner /> : null}

--- a/src/SmartComponents/Topics/List.js
+++ b/src/SmartComponents/Topics/List.js
@@ -41,11 +41,7 @@ const List = () => {
   return (
     <React.Fragment>
       <PageHeader>
-        <PageHeaderTitle
-          title={`${intl.formatMessage(messages.insightsHeader)} ${intl
-            .formatMessage(messages.topics)
-            .toLowerCase()}`}
-        />
+        <PageHeaderTitle title={`${messages.topics.defaultMessage}`} />
       </PageHeader>
       <section className="pf-l-page__main-section pf-c-page__main-section">
         <TopicsTable props={{ data, isLoading, isFetching, isError }} />


### PR DESCRIPTION
# Description

* This PR addresses the title changes, "Advisor titles should be presented without an 'Advisor' prefix"
* It also removes some use cases of `useIntl` that we are trying to remove from this project

Associated Jira ticket: [#RHINENG-5544](https://issues.redhat.com/browse/RHINENG-5544)


Checklist: 

- [X] Get a review from the UX department 
- [x] Update the screenshots attached to this PR


# How to test the PR

Check the presented titles are shown without the "Advisor" prefix.

# Before the change

Recommendations Page:

![Before: Recommendations Page](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/dd082507-8015-41ce-a117-b75e0100a4cb)


Systems Page:

![Before: Systems Page](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/c3b6fcd7-2182-4ae5-9ac8-15a0566567ad)


Topics Page:

![Before: Topics Page](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/b5c6cb95-f4c1-4b15-8641-5222d129cc3a)



# After the change

Recommendations Page:

![After: Recommendations Page](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/3f1d0317-23b0-4d2e-9907-cb0c26af302c)


Systems Page:

![After: Systems Page](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/db08151a-bcde-47a0-87cd-9265a2a2cfbd)


Topics Page:
![After: Topics Page](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/5cc9e9c8-4481-4219-b95b-4160e99eb64a)