### PR TITLE
feat(RHINENG-5357): modify systems page to show only conventional sys…

### DIFF
--- a/src/PresentationalComponents/Labels/RuleLabels.js
+++ b/src/PresentationalComponents/Labels/RuleLabels.js
@@ -1,11 +1,6 @@
 import './_RuleLabels.scss';
 
-import {
-  Tooltip,
-  TooltipPosition,
-} from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
-
-import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
+import { Tooltip, TooltipPosition, Label } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import React from 'react';
 import messages from '../../Messages';

--- a/src/PresentationalComponents/Loading/Loading.js
+++ b/src/PresentationalComponents/Loading/Loading.js
@@ -1,5 +1,5 @@
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { CardBody } from '@patternfly/react-core/dist/esm/components/Card/CardBody';
+import { Card } from '@patternfly/react-core';
+import { CardBody } from '@patternfly/react-core';
 import { List } from 'react-content-loader';
 import React from 'react';
 const Loading = () => (

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -214,7 +214,11 @@ const SystemsTable = () => {
         showTags
         disableDefaultColumns
         customFilters={{
-          advisorFilters: filters,
+          advisorFilters: {
+            ...filters,
+            //Systems table should always be filtered by host type
+            'filter[system_profile][host_type][nil]': true,
+          },
           workloads,
           SID,
           selectedTags,

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.test.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.test.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { ComponentWithContext } from '../../Utilities/TestingUtilities';
+import SystemsTable from './SystemsTable';
+import { render } from '@testing-library/react';
+import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
+jest.mock('@redhat-cloud-services/frontend-components/Inventory', () => ({
+  __esModule: true,
+  InventoryTable: jest.fn((props) => (
+    <div {...props} aria-label="immutableDevices-module-mock">
+      InventoryTable
+    </div>
+  )),
+}));
+
+jest.mock('../Export/SystemsPdf', () => ({
+  __esModule: true,
+  default: jest.fn((props) => (
+    <div {...props} aria-label="systems-pdf-mock">
+      SystemsPdf
+    </div>
+  )),
+}));
+
+jest.mock('@unleash/proxy-client-react', () => ({
+  ...jest.requireActual('@unleash/proxy-client-react'),
+  useFlag: () => true,
+  useFlagsStatus: () => ({ flagsReady: true }),
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(() => ({ sysState: { page: 1, sort: '-last_seen' } })),
+}));
+
+describe('Systems', () => {
+  it('Should always show conventional systems by filtering host_type', () => {
+    render(<ComponentWithContext Component={SystemsTable} />);
+
+    expect(InventoryTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customFilters: expect.objectContaining({
+          advisorFilters: {
+            'filter[system_profile][host_type][nil]': true,
+            sysState: { page: 1, sort: '-last_seen' },
+          },
+        }),
+      }),
+      {}
+    );
+  });
+});


### PR DESCRIPTION
…tems

# Description

Associated Jira ticket: # [(RHINENG-5357)](https://issues.redhat.com/browse/RHINENG-5357)

Modifies systems page to show only conventional systems. The API started to return all types of systems, thus we need to filter by host type to achieve this.


# How to test the PR

1. Run the PR
2. Go to systems page
3. Observe that the API is now always filtered by `filter[system_profile][host_type][nil]': true`

# Before the change


# After the change


# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
