### PR TITLE
fix(RHINENG-5907): remove disable rule kebab for pathway systems

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -391,6 +391,27 @@ const Inventory = ({
     },
   };
 
+  const getActionsConfig = () => {
+    const actions = [
+      <RemediationButton
+        key="remediation-button"
+        fallback={<Spinner size="md" />}
+        isDisabled={isRemediationButtonDisabled}
+        dataProvider={remediationDataProvider}
+        onRemediationCreated={(result) => onRemediationCreated(result)}
+      >
+        {intl.formatMessage(messages.remediate)}
+      </RemediationButton>,
+    ];
+    !pathway &&
+      actions.push({
+        label: intl.formatMessage(messages.disableRuleForSystems),
+        props: { isDisabled: (selectedIds || []).length === 0 },
+        onClick: () => handleModalToggle(true),
+      });
+    return { actions };
+  };
+
   return (
     <React.Fragment>
       {disableRuleModalOpen && (
@@ -428,24 +449,7 @@ const Inventory = ({
         }}
         showTags={showTags}
         getEntities={fetchSystems}
-        actionsConfig={{
-          actions: [
-            <RemediationButton
-              key="remediation-button"
-              fallback={<Spinner size="md" />}
-              isDisabled={isRemediationButtonDisabled}
-              dataProvider={remediationDataProvider}
-              onRemediationCreated={(result) => onRemediationCreated(result)}
-            >
-              {intl.formatMessage(messages.remediate)}
-            </RemediationButton>,
-            {
-              label: intl.formatMessage(messages.disableRuleForSystems),
-              props: { isDisabled: (selectedIds || []).length === 0 },
-              onClick: () => handleModalToggle(true),
-            },
-          ],
-        }}
+        actionsConfig={getActionsConfig()}
         {...toolbarProps}
         onLoad={({
           mergeWithEntities,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-5907

The toolbar kebab to disable rule(s) shouldn't be displayed for pathway systems because it doesn't make sense to disable individual pathway rules.  This simple PR / change removes the kebab when the inventory table shows pathway systems and displays it when they are individual rule systems.

- [X] The commit message has the Jira ticket linked
- [X] PR has a short description
- [X] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

Before PR - pressing the kebab leads to a 404:
![Screenshot from 2023-12-06 14-09-37](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/4cb821c0-d441-48f2-a62c-31c8c89bc394)

After PR - kebab removed:
![Screenshot from 2023-12-06 13-53-27](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/4d6d9b33-e9f2-4287-b107-c3f07bd628ad)

