### PR TITLE
fix(RHINENG-5019): enable sorting on recs systems group column

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -319,7 +319,6 @@ const Inventory = ({
       groups = {
         ...groups[0],
         transforms: [wrappable],
-        props: { ...groups[0].props, isStatic: true }, // remove this line after group sorting is enabled in the API
       };
 
       let columnList = [

--- a/src/SmartComponents/HybridInventoryTabs/helpers.js
+++ b/src/SmartComponents/HybridInventoryTabs/helpers.js
@@ -144,10 +144,6 @@ export const mergeAppColumns = (defaultColumns, isRecommendationDetail) => {
     renderFunc: lastSeenColumn.renderFunc,
   };
 
-  //disable sorting on GROUPS. API does not handle this
-  const groupsColumn = defaultColumns.find(({ key }) => key === 'groups');
-  groupsColumn.props = { ...groupsColumn.props, isStatic: true };
-
   return [
     ...defaultColumns,
     ...(isRecommendationDetail ? [impacted_date] : []),

--- a/src/SmartComponents/HybridInventoryTabs/helpers.test.js
+++ b/src/SmartComponents/HybridInventoryTabs/helpers.test.js
@@ -216,12 +216,6 @@ describe('mergeAppColumns', () => {
     );
     expect(impacted_date.renderFunc).toEqual(defaultColumns[0].renderFunc);
   });
-  test('Should extend groups column props to disable sorting', () => {
-    const result = mergeAppColumns(defaultColumns);
-
-    const groups = result.find((column) => column.key === 'groups');
-    expect(groups.props).toEqual({ width: 15, isStatic: true });
-  });
 });
 
 describe('useOnload', () => {


### PR DESCRIPTION
Adds sorting to the groups column in the Recommendations Systems / Inventory table
Continuation of the work for https://issues.redhat.com/browse/RHINENG-5019

After adding Group sorting:
![Screenshot from 2023-12-11 16-50-24](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/b0969b47-616a-411b-82c5-e0fce07a424b)

![Screenshot from 2023-12-11 16-50-38](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/39040276-ec45-45ee-be14-226230d57fd8)


- [X] The commit message has the Jira ticket linked
- [X] PR has a short description
- [X] Screenshots before and after the change are added
- [X] Tests for the changes have been removed
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
