### PR TITLE
fix(Inventory): remove extra sorting icon on inventory tables

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -304,12 +304,12 @@ const Inventory = ({
 
       lastSeenColumn = {
         ...lastSeenColumn[0],
-        transforms: [sortable, wrappable],
+        transforms: [wrappable],
       };
 
       systemProfile = {
         ...systemProfile[0],
-        transforms: [sortable, wrappable],
+        transforms: [wrappable],
       };
 
       tags = {
@@ -336,7 +336,7 @@ const Inventory = ({
           key: 'impacted_date',
           title: 'First Impacted',
           sortKey: 'impacted_date',
-          transforms: [sortable, wrappable],
+          transforms: [wrappable],
           props: { width: 15 },
           renderFunc: lastSeenColumn.renderFunc,
         };

--- a/src/PresentationalComponents/SystemsTable/SystemsTableAssets.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTableAssets.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Link from '@redhat-cloud-services/frontend-components/InsightsLink';
-import { sortable, wrappable } from '@patternfly/react-table';
+import { wrappable } from '@patternfly/react-table';
 
 import messages from '../../Messages';
 import RuleLabels from '../Labels/RuleLabels';
@@ -8,7 +8,7 @@ import RuleLabels from '../Labels/RuleLabels';
 export const systemsTableColumns = (intl) => [
   {
     key: 'display_name',
-    transforms: [sortable, wrappable],
+    transforms: [wrappable],
     renderFunc: (data, id, system) => (
       <React.Fragment>
         <Link key={id} to={`/systems/${system.system_uuid}`}>
@@ -21,42 +21,42 @@ export const systemsTableColumns = (intl) => [
   {
     key: 'groups',
     requiresDefault: true,
-    transforms: [sortable, wrappable],
+    transforms: [wrappable],
   },
   {
     key: 'tags',
   },
   {
     key: 'system_profile',
-    transforms: [sortable, wrappable],
+    transforms: [wrappable],
   },
   {
     title: intl.formatMessage(messages.numberRuleHits),
-    transforms: [sortable, wrappable],
+    transforms: [wrappable],
     key: 'hits',
   },
   {
     title: intl.formatMessage(messages.critical),
-    transforms: [sortable, wrappable],
+    transforms: [wrappable],
     key: 'critical_hits',
   },
   {
     title: intl.formatMessage(messages.important),
-    transforms: [sortable, wrappable],
+    transforms: [wrappable],
     key: 'important_hits',
   },
   {
     title: intl.formatMessage(messages.moderate),
-    transforms: [sortable, wrappable],
+    transforms: [wrappable],
     key: 'moderate_hits',
   },
   {
     title: intl.formatMessage(messages.low),
-    transforms: [sortable, wrappable],
+    transforms: [wrappable],
     key: 'low_hits',
   },
   {
     key: 'updated',
-    transforms: [sortable, wrappable],
+    transforms: [wrappable],
   },
 ];


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)

Removes the extra icon on initial table load in inventory pages by removing sortable table transformer. The table columns are by default made sortable in inventory module and advisor should not another transformer that is causing the extra icon. 


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
