### PR TITLE
chore(SystemsAdvisor): do not show remediation button whil systems_pr

### DIFF
--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -58,6 +58,7 @@ const BaseSystemAdvisor = ({ entity, inventoryId }) => {
   const [isSelected, setIsSelected] = useState(false);
   const [isAllExpanded, setIsAllExpanded] = useState(false);
   const [systemProfile, setSystemsProfile] = useState({});
+  const [isSystemProfileLoading, setSystemsProfileLoading] = useState(true);
   const selectedTags = useSelector(({ filters }) => filters?.selectedTags);
   const workloads = useSelector(({ filters }) => filters?.workloads);
   const SID = useSelector(({ filters }) => filters?.SID);
@@ -105,7 +106,7 @@ const BaseSystemAdvisor = ({ entity, inventoryId }) => {
   };
 
   const actions =
-    systemProfile?.host_type !== 'edge'
+    !isSystemProfileLoading && systemProfile?.host_type !== 'edge'
       ? [
           <RemediationButton
             key="remediation-button"
@@ -398,8 +399,10 @@ const BaseSystemAdvisor = ({ entity, inventoryId }) => {
         );
 
         setSystemsProfile(profileData?.data?.results[0]?.system_profile || {});
+        setSystemsProfileLoading(false);
       } catch (error) {
         setInventoryReportFetchStatus('failed');
+        setSystemsProfileLoading(false);
       }
     };
     dataFetch();


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)

This just hides remediation button while systems_profile is being fetched from the API. This will prevent the button from being shown for a short time which decreases user experience when an immutable system is being looked at. 

# How to test the PR

Run this PR with the inventory app
1. Go to the inventory landing page and open the Immutable tab
2. Click on any immutable tab to go to the detail page
3. Open the advisor tab
4. Observe that there is no Remediate button in the table toolbar at all even while the API call is in progress
5. Navigate back to the inventory landing page, conventional tab
6. Click on any conventional system to go to the detail page
7. Open the advisor tab
7. Observe that there is a remediate button

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
