### PR TITLE
feat(RHINENG-5544): Remove Prefix From Breadcrumbs

### DIFF
--- a/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
+++ b/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
@@ -5,12 +5,10 @@ import { BreadcrumbItem } from '@patternfly/react-core/dist/esm/components/Bread
 import PropTypes from 'prop-types';
 import messages from '../../Messages';
 import { useGetRecQuery } from '../../Services/Recs';
-import { useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 import Link from '@redhat-cloud-services/frontend-components/InsightsLink';
 
 const Breadcrumbs = ({ current }) => {
-  const intl = useIntl();
   const location = useLocation().pathname?.split('/');
   const [items, setItems] = useState([]);
   const skip =
@@ -24,11 +22,16 @@ const Breadcrumbs = ({ current }) => {
   useEffect(() => {
     const buildBreadcrumbs = () => {
       let crumbs = [];
+
       // add base
-      crumbs.push({
-        title: `${intl.formatMessage(messages.insightsHeader)} ${location[3]}`,
-        navigate: `/${location[3]}`,
-      });
+      if (location[3]) {
+        const baseNameWithCapitalLetter =
+          location[3].slice(0, 1).toUpperCase() + location[3].slice(1);
+        crumbs.push({
+          title: `${baseNameWithCapitalLetter}`,
+          navigate: `/${location[3]}`,
+        });
+      }
 
       // if applicable, add :id breadcrumb
       if (!skip) {
@@ -41,7 +44,7 @@ const Breadcrumbs = ({ current }) => {
       if (location[2] === 'pathways') {
         crumbs = [
           {
-            title: 'Advisor pathways',
+            title: 'Pathways',
             navigate: '/recommendations/pathways',
           },
         ];
@@ -66,7 +69,7 @@ const Breadcrumbs = ({ current }) => {
           <BreadcrumbItem isActive>{current}</BreadcrumbItem>
         </Breadcrumb>
       ) : (
-        intl.formatMessage(messages.loading)
+        messages.loading.defaultMessage
       )}
     </React.Fragment>
   );

--- a/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
+++ b/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { Breadcrumb } from '@patternfly/react-core/dist/esm/components/Breadcrumb/Breadcrumb';
-import { BreadcrumbItem } from '@patternfly/react-core/dist/esm/components/Breadcrumb/BreadcrumbItem';
+import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import messages from '../../Messages';
 import { useGetRecQuery } from '../../Services/Recs';
@@ -41,7 +40,7 @@ const Breadcrumbs = ({ current }) => {
         });
       }
 
-      if (location[2] === 'pathways') {
+      if (location[4] === 'pathways') {
         crumbs = [
           {
             title: 'Pathways',

--- a/src/SmartComponents/Recs/List.js
+++ b/src/SmartComponents/Recs/List.js
@@ -49,7 +49,7 @@ const List = () => {
   }, [chrome, intl]);
 
   const [activeTab, setActiveTab] = useState(
-    pathname === '/recommendations/pathways'
+    pathname === '/insights/advisor/recommendations/pathways'
       ? PATHWAYS_TAB
       : RECOMMENDATIONS_TAB
   );


### PR DESCRIPTION
# Description

* This PR addresses the breadcrumbs issue that is mentioned on the ticket
* Also, removes a use of `useIntl` that we are trying to remove from this app

Associated Jira ticket: [#RHINENG-5544](https://issues.redhat.com/browse/RHINENG-5544)

# How to test the PR

Ensure the breadcrumbs does not show the app name


# Before the change

Recommendations:

![Before: Recommendations](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/e04cdf34-43c0-475d-9b7d-5b84e2f110e7)


Systems:

![Before: Systems](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/c284ca37-9bbf-4f40-a297-352e8065170e)


Topics: 

![Before: Topics](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/e10fd290-45d6-4ec9-8919-00f481ce485a)



# After the change

Recommendations:

![After: Recommendations](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/d06e31e3-9ba7-4cfe-bba3-0e508db467b2)


Systems:

![After: Systems](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/d3833cf1-695a-447a-8285-6cb02dd78078)


Topics:

![After: Topics](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/19cd6d6a-9894-4abb-b864-9df63f827b90)