### PR TITLE
fix(RHINENG-5019): enable group filtering on recs systems

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -432,6 +432,7 @@ const Inventory = ({
           name: false,
           tags: !showTags,
           operatingSystem: false,
+          hostGroupFilter: false,
         }}
         activeFiltersConfig={activeFiltersConfig}
         columns={(defaultColumns) => createColumns(defaultColumns)}


### PR DESCRIPTION
Associated Jira ticket: # (issue)
https://issues.redhat.com/browse/RHINENG-5019

Adds filtering by group to the Recommendations Systems table.  The API supports filtering on group.

Before the change ...
![Screenshot from 2023-12-20 13-41-15](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/1a48b643-3ccd-47b0-a292-804557ab5a9f)

After the change ...
![Screenshot from 2023-12-20 13-24-37](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/965f5e33-0ca5-4054-b67e-3b66e992d74b)


- [X] The commit message has the Jira ticket linked
- [X] PR has a short description
- [X] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
