### PR TITLE
fix(RHINENG-5982): use edgeParity.inventory-groups-enabled flag while…

### DIFF
--- a/src/SmartComponents/HybridInventoryTabs/helpers.js
+++ b/src/SmartComponents/HybridInventoryTabs/helpers.js
@@ -8,6 +8,7 @@ import { updateReducers } from '../../Store';
 import { useStore } from 'react-redux';
 import { wrappable } from '@patternfly/react-table';
 import { createSortParam } from '../../PresentationalComponents/helper';
+import { useFeatureFlag } from '../../Utilities/Hooks';
 
 const mergeByInventoryKey = (
   advisorData = [],
@@ -37,9 +38,12 @@ const mergeByInventoryKey = (
   });
 };
 
-export const useGetEntities =
-  (handleRefresh, pathway, rule) =>
-  async (_items, config, showTags, defaultGetEntities) => {
+export const useGetEntities = (handleRefresh, pathway, rule) => {
+  const isInventoryGroupsEnabled = useFeatureFlag(
+    'edgeParity.inventory-groups-enabled'
+  );
+
+  return async (_items, config, showTags, defaultGetEntities) => {
     const {
       per_page,
       page,
@@ -51,6 +55,7 @@ export const useGetEntities =
       SID,
       selectedTags,
     } = config;
+
     const sort = createSortParam(orderBy, orderDirection);
     let options = createOptions(
       advisorFilters,
@@ -88,7 +93,8 @@ export const useGetEntities =
       );
 
       edgeData = devicesData?.data?.devices || [];
-      enforceEdgeGroups = devicesData?.data?.enforce_edge_groups;
+      enforceEdgeGroups =
+        devicesData?.data?.enforce_edge_groups || !isInventoryGroupsEnabled;
     }
 
     const fullData = mergeByInventoryKey(
@@ -103,6 +109,7 @@ export const useGetEntities =
       total: advisorData.meta.count,
     });
   };
+};
 
 export const useActionResolver = (handleModalToggle) =>
   useCallback(


### PR DESCRIPTION
… enforcing groups

# Description

Associated Jira ticket:  https://issues.redhat.com/browse/RHINENG-5982

Adds missing requirement: Advisor should enforce edge groups only when both enforce_edge_groups from the edge API and the new feature flag ** edgeParity.inventory-groups-enabled** are false.

Acceptance Criteria
1. The immutable tab shows groups according to this updated rule:
     - When “enforce_edge_groups”  is true always display edge groups
     - When “enforce_edge_groups”  is false or missing:
            When unleash feature flag “edgeParity.inventory-groups-enabled” value:
                  * false => display edge groups
                  * true => display inventory groups

# How to test the PR

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
