### PR TITLE
Bug(RHINENG-6294): OverviewDashbar Card Titles Capitalization Correction

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -44,8 +44,8 @@ export const SEVERITY_MAP = {
 // Recommendations OverviewDashbarCards titles
 export const PATHWAYS = 'Pathways';
 export const INCIDENTS = 'Incidents';
-export const IMPORTANT_RECOMMENDATIONS = 'Important Recommendations';
-export const CRITICAL_RECOMMENDATIONS = 'Critical Recommendations';
+export const IMPORTANT_RECOMMENDATIONS = 'Important recommendations';
+export const CRITICAL_RECOMMENDATIONS = 'Critical recommendations';
 
 // Recommendations OverviewDashbarCards labels
 export const INCIDENT_TAG = 'incident';

--- a/src/PresentationalComponents/Cards/OverviewDashbarCard/__tests__/DashbarCardTitle.test.js
+++ b/src/PresentationalComponents/Cards/OverviewDashbarCard/__tests__/DashbarCardTitle.test.js
@@ -81,14 +81,14 @@ describe('DashbarCardTitle', () => {
     render(<DashbarCardTitle title={IMPORTANT_RECOMMENDATIONS} />);
 
     // ensure the correct text is displayed
-    expect(screen.getByText(/Important Recommendations/)).toBeInTheDocument();
+    expect(screen.getByText(/Important recommendations/)).toBeInTheDocument();
   });
 
   it("Should render 'Critical Recommendations' title", () => {
     render(<DashbarCardTitle title={CRITICAL_RECOMMENDATIONS} />);
 
     // ensure the correct text is displayed
-    expect(screen.getByText(/Critical Recommendations/)).toBeInTheDocument();
+    expect(screen.getByText(/Critical recommendations/)).toBeInTheDocument();
   });
 
   it('Should not render', () => {
@@ -98,10 +98,10 @@ describe('DashbarCardTitle', () => {
     expect(screen.queryByText(/Pathways/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Incidents/)).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/Important Recommendations/)
+      screen.queryByText(/Important recommendations/)
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/Critical Recommendations/)
+      screen.queryByText(/Critical recommendations/)
     ).not.toBeInTheDocument();
   });
 });

--- a/src/PresentationalComponents/OverviewDashbar/__tests__/OverviewDashbar.test.js
+++ b/src/PresentationalComponents/OverviewDashbar/__tests__/OverviewDashbar.test.js
@@ -55,8 +55,8 @@ describe('OverviewDashbar', () => {
     // ensure that the correct text is displayed
     expect(screen.getByText(/Pathways/)).toBeInTheDocument();
     expect(screen.getByText(/Incidents/)).toBeInTheDocument();
-    expect(screen.getByText(/Important Recommendations/)).toBeInTheDocument();
-    expect(screen.getByText(/Critical Recommendations/)).toBeInTheDocument();
+    expect(screen.getByText(/Important recommendations/)).toBeInTheDocument();
+    expect(screen.getByText(/Critical recommendations/)).toBeInTheDocument();
 
     await screen.findByText(/1/);
 
@@ -67,10 +67,10 @@ describe('OverviewDashbar', () => {
     const pathwaysBtn = screen.getByTestId(/Pathways/);
     const incidentsBtn = screen.getByTestId(/Incidents/);
     const criticalRecommendationsBtn = screen.getByTestId(
-      /Critical Recommendations/
+      /Critical recommendations/
     );
     const importantRecommendationsBtn = screen.getByTestId(
-      /Important Recommendations/
+      /Important recommendations/
     );
 
     expect(pathwaysBtn).toBeInTheDocument();


### PR DESCRIPTION
# Description

This PR addresses the title capitalization problem mentioned in the issue

Associated Jira ticket: [#RHINENG-6294](https://issues.redhat.com/browse/RHINENG-6294)

# How to test the PR

Ensure the titles of 'Important recommendations' & 'Critical recommendations' appear in the UI like written here

# Before the change
![(Before) OverviewDashbar card titles capitalization correction](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/5af8b8fa-d018-4009-9df1-3247ecf7a78b)


# After the change
![(After) OverviewDashbar card titles capitalization correction](https://github.com/RedHatInsights/insights-advisor-frontend/assets/93318917/c65f9bdd-5edb-41f7-b408-29d7a629240a)


# Checklist:

- [X] The commit message has the Jira ticket linked
- [X] PR has a short description
- [X] Screenshots before and after the change are added
- [X] Tests for the changes have been updated
- [X] README.md is updated if necessary
- [X] Needs additional dependent work