### PR TITLE
fix: URL encode the pipe character in rule ids

### DIFF
--- a/src/Services/Acks.js
+++ b/src/Services/Acks.js
@@ -7,7 +7,7 @@ export const Acks = createApi({
   baseQuery: AxiosBaseQuery({ baseUrl: BASE_URL }),
   endpoints: (build) => ({
     getRecAcks: build.query({
-      query: (options) => ({ url: `/ack/${options.ruleId}/` }),
+      query: (options) => ({ url: `/ack/${encodeURI(options.ruleId)}/` }),
     }),
     getHostAcks: build.query({
       query: (options) => ({ url: `/hostack/`, options }),

--- a/src/Services/Recs.js
+++ b/src/Services/Recs.js
@@ -11,10 +11,13 @@ export const Recs = createApi({
       query: (options) => ({ url: `/rule/`, options }),
     }),
     getRec: build.query({
-      query: (options) => ({
-        url: `/rule/${options.ruleId}/`,
-        options,
-      }),
+      query: (options) => {
+        const ruleId = encodeURI(options.ruleId);
+        return {
+          url: `/rule/${ruleId}/`,
+          options: { ...options, ruleId },
+        };
+      },
     }),
     getRecSystems: build.query({
       query: (options, search) => ({

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -264,7 +264,9 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
                   edgeSystemsCount={edgeSystemsCount}
                   conventionalSystemsCount={conventionalSystemsCount}
                   areCountsLoading={areCountsLoading}
-                  tabPathname={`/insights/advisor/recommendations/${ruleId}`}
+                  tabPathname={`/insights/advisor/recommendations/${encodeURI(
+                    ruleId
+                  )}`}
                 />
               </React.Fragment>
             )}

--- a/src/SmartComponents/Recs/helpers.js
+++ b/src/SmartComponents/Recs/helpers.js
@@ -18,7 +18,7 @@ export const enableRule = async (
   handleModalToggle
 ) => {
   try {
-    await DeleteApi(`${BASE_URL}/ack/${rule.rule_id}/`);
+    await DeleteApi(`${BASE_URL}/ack/${encodeURI(rule.rule_id)}/`);
     addNotification({
       variant: 'success',
       timeout: true,
@@ -55,7 +55,11 @@ export const bulkHostActions = async ({
       systems: hostAckResponse?.data?.map((item) => item.system_uuid),
     };
 
-    await Post(`${BASE_URL}/rule/${rule.rule_id}/unack_hosts/`, {}, data);
+    await Post(
+      `${BASE_URL}/rule/${encodeURI(rule.rule_id)}/unack_hosts/`,
+      {},
+      data
+    );
     refetch();
     addNotification({
       variant: 'success',
@@ -76,8 +80,12 @@ export const bulkHostActions = async ({
 const getSystemCheckEndpoints = ({ ruleId, pathway }) => {
   if (ruleId) {
     return {
-      conventionalURL: `/api/insights/v1/rule/${ruleId}/systems_detail/?filter[system_profile][host_type][nil]=true&limit=1`,
-      edgeURL: `/api/insights/v1/rule/${ruleId}/systems_detail/?filter[system_profile][host_type]=edge&limit=1`,
+      conventionalURL: `/api/insights/v1/rule/${encodeURI(
+        ruleId
+      )}/systems_detail/?filter[system_profile][host_type][nil]=true&limit=1`,
+      edgeURL: `/api/insights/v1/rule/${encodeURI(
+        ruleId
+      )}/systems_detail/?filter[system_profile][host_type]=edge&limit=1`,
     };
   }
 


### PR DESCRIPTION
# Description
This PR URL encodes RHEL Advisor recommendation / rule id values whenever they are sent to the backend so the request may pass through environments enforcing strict HTTP standards (eg not allowing the pipe character "|" in URLs)

Associated Jira ticket: # (issue)
This came from a Slack discussion and I'm not sure if a Jira has been created.


Before the change, the pipe character is sent in URLs unencoded:
![Screenshot from 2024-01-15 13-16-15](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/14214568-8594-446a-a1cf-4a0abc75fe81)


After the change, the pipe character is encoded:
![Screenshot from 2024-01-15 13-18-17](https://github.com/RedHatInsights/insights-advisor-frontend/assets/4008744/222f64e4-fc4c-4b3b-b0a6-365cb7d6adf2)


# Checklist:
- [ ] The commit message has the Jira ticket linked
- [X] PR has a short description
- [X] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
