### PR TITLE
feat(RHINENG-3078): extend systems filter with new hybrid options

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -360,24 +360,45 @@ export const FILTER_CATEGORIES = {
       },
     ],
   },
-  impacting: {
-    type: conditionalFilterType.checkbox,
-    title: 'systems impacted',
-    urlParam: 'impacting',
-    values: [
-      {
-        label: intlHelper(intl.formatMessage(messages.oneOrMore), intlSettings),
-        text: intlHelper(intl.formatMessage(messages.oneOrMore), intlSettings),
-        value: 'true',
-      },
-      {
-        label: intlHelper(intl.formatMessage(messages.none), intlSettings),
-        text: intlHelper(intl.formatMessage(messages.none), intlSettings),
-        value: 'false',
-      },
-    ],
-  },
 };
+
+export const getImpactingFitlerItems = (hasEdgeDevices) =>
+  hasEdgeDevices
+    ? [
+        {
+          value: 'dnfyum',
+          label: '1 or more Conventional systems (RPM-DNF)',
+          text: '1 or more Conventional systems (RPM-DNF)',
+        },
+        {
+          value: 'ostree',
+          label: '1 or more Immutable (OSTree)',
+          text: '1 or more Immutable (OSTree)',
+        },
+        {
+          value: 'none',
+          label: 'None',
+          text: 'None',
+        },
+      ]
+    : [
+        {
+          label: intlHelper(
+            intl.formatMessage(messages.oneOrMore),
+            intlSettings
+          ),
+          text: intlHelper(
+            intl.formatMessage(messages.oneOrMore),
+            intlSettings
+          ),
+          value: 'true',
+        },
+        {
+          label: intlHelper(intl.formatMessage(messages.none), intlSettings),
+          text: intlHelper(intl.formatMessage(messages.none), intlSettings),
+          value: 'false',
+        },
+      ];
 
 export const SYSTEM_FILTER_CATEGORIES = {
   hits: {

--- a/src/PresentationalComponents/Common/Tables.js
+++ b/src/PresentationalComponents/Common/Tables.js
@@ -49,9 +49,42 @@ export const buildTagFilter = (tagFilters) => {
   };
 };
 
+const mapUpdateMethodFilterToAPISpec = (filters) => {
+  //If none option is chosen
+  if (filters?.update_method?.includes('none')) {
+    //remove update_method filter from API options and set impacting to false if only none options is chosen
+    if (filters.update_method === 'none') {
+      delete filters.update_method;
+      filters.impacting = 'false';
+
+      //in any other cases, remove 'none' option from the API options as it does have any handler
+      //concatenate or set false to impacting API option
+    } else {
+      const filteredValues = filters.update_method.replace(
+        /,?none||none,?/g,
+        ''
+      );
+
+      filters.update_method = filteredValues;
+      filters.impacting =
+        filters.impacting.toString().length > 1
+          ? filters.impacting.concat(',false')
+          : 'false';
+    }
+  }
+
+  //when user deselects all update_method filters remove the both update_method and impacting filters
+  if (filters?.update_method === '') {
+    delete filters.update_method;
+    delete filters.impacting;
+  }
+
+  return filters;
+};
+
 // transforms array of strings -> comma seperated strings, required by advisor api
-export const filterFetchBuilder = (filters) =>
-  Object.assign(
+export const filterFetchBuilder = (filters) => {
+  const joinedFilters = Object.assign(
     {},
     ...Object.entries(filters).map(([filterName, filterValue]) =>
       Array.isArray(filterValue)
@@ -62,6 +95,9 @@ export const filterFetchBuilder = (filters) =>
         : { [filterName]: filterValue }
     )
   );
+
+  return mapUpdateMethodFilterToAPISpec(joinedFilters);
+};
 
 // parses url params for use in table/filter chips
 export const paramParser = () => {

--- a/src/PresentationalComponents/Common/Tables.js
+++ b/src/PresentationalComponents/Common/Tables.js
@@ -71,10 +71,8 @@ const mapUpdateMethodFilterToAPISpec = (filters) => {
           ? filters.impacting.concat(',false')
           : 'false';
     }
-  }
-
-  //when user deselects all update_method filters remove the both update_method and impacting filters
-  if (filters?.update_method === '') {
+  } else if (filters?.update_method === '') {
+    //when user deselects all update_method filters remove the both update_method and impacting filters
     delete filters.update_method;
     delete filters.impacting;
   }

--- a/src/PresentationalComponents/Filters/GeneralFilterTypes/CheckboxFilter.js
+++ b/src/PresentationalComponents/Filters/GeneralFilterTypes/CheckboxFilter.js
@@ -1,0 +1,35 @@
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
+
+const checkboxFilter = (
+  applyFilterCallback,
+  currentFilter = {},
+  filterKey,
+  filterItems,
+  filterLabel
+) => {
+  let { [filterKey]: currentValue } = currentFilter;
+
+  const filterBy = (values) => {
+    applyFilterCallback({
+      ...currentFilter,
+      [filterKey]: values.length > 0 ? values : [],
+      page: 1,
+    });
+  };
+
+  return {
+    label: filterLabel,
+    type: conditionalFilterType.checkbox,
+    urlParam: filterKey,
+    filterValues: {
+      onChange: (event, value) => {
+        filterBy(value);
+      },
+      items: filterItems,
+      value: currentValue || [],
+    },
+    values: filterItems,
+  };
+};
+
+export default checkboxFilter;

--- a/src/PresentationalComponents/Filters/impactingFilter.js
+++ b/src/PresentationalComponents/Filters/impactingFilter.js
@@ -1,0 +1,28 @@
+import checkboxFilter from './GeneralFilterTypes/CheckboxFilter';
+import { getImpactingFitlerItems } from '../../AppConstants';
+
+export const getImpactingFilterKey = (hasEdgeDevices) =>
+  hasEdgeDevices ? 'update_method' : 'impacting';
+
+export const getImpactingFilterChips = (hasEdgeDevices) => ({
+  [getImpactingFilterKey(hasEdgeDevices)]: {
+    type: 'radio',
+    title: 'Systems impacted',
+    urlParam: 'rule_status',
+    values: getImpactingFitlerItems(hasEdgeDevices),
+  },
+});
+
+const impactingFilter = (apply, currentFilter = {}, hasEdgeDevices) => {
+  const impactingOptions = getImpactingFitlerItems(hasEdgeDevices);
+
+  return checkboxFilter(
+    apply,
+    currentFilter,
+    getImpactingFilterKey(hasEdgeDevices),
+    impactingOptions,
+    'systems impacted'
+  );
+};
+
+export default impactingFilter;

--- a/src/PresentationalComponents/RulesTable/RulesTable.cy.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.cy.js
@@ -30,6 +30,7 @@ import {
 //NEED TO BE UPDATED
 
 import messages from '../../Messages';
+import { AccountStatContext } from '../../ZeroStateWrapper';
 
 //function and filters config for testing filters
 // function* cumulativeCombinations(arr, current = []) {
@@ -44,17 +45,26 @@ import messages from '../../Messages';
 //     }
 //   }
 // }
-const mountComponent = () => {
+const mountComponent = ({ hasEdgeDevices } = { hasEdgeDevices: false }) => {
   const store = getStore();
   cy.mount(
     <MemoryRouter>
-      <IntlProvider locale={navigator.language.slice(0, 2)} messages={messages}>
-        <Provider store={store}>
-          <Routes>
-            <Route key={'Recommendations'} path="*" element={<RulesTable />} />
-          </Routes>
-        </Provider>
-      </IntlProvider>
+      <AccountStatContext.Provider value={{ hasEdgeDevices }}>
+        <IntlProvider
+          locale={navigator.language.slice(0, 2)}
+          messages={messages}
+        >
+          <Provider store={store}>
+            <Routes>
+              <Route
+                key={'Recommendations'}
+                path="*"
+                element={<RulesTable />}
+              />
+            </Routes>
+          </Provider>
+        </IntlProvider>
+      </AccountStatContext.Provider>
     </MemoryRouter>
   );
 };
@@ -357,7 +367,7 @@ describe('defaults', () => {
 
 //         if (selectorText === filtersConf.impacting.selectorText) {
 //           removeAllChips();
-//           cy.wait(['@call', '@call']);
+//           cy.wait(['@call']);
 //         }
 //         filterApply({ [key]: values[0] });
 //         cy.wait('@call')
@@ -488,3 +498,56 @@ describe('content', () => {
       );
   });
 });
+
+// const UPDATE_METHOD_MAP = {
+//   '1 or more Conventional systems (RPM-DNF)': 'dnfyum',
+// };
+
+// const update_method = {
+//   selectorText: 'Systems impacted',
+//   values: Array.from(cumulativeCombinations(Object.keys(UPDATE_METHOD_MAP))),
+//   type: 'checkbox',
+//   filterFunc: () => {
+//     return 'dnfyum';
+//   },
+//   urlParam: 'update_method',
+//   urlValue: (it) =>
+//     encodeURIComponent(_.map(it, (x) => UPDATE_METHOD_MAP[x]).join(',')),
+// };
+
+// const applyUpdateMethod = (filters) => applyFilters(filters, { update_method });
+
+// describe('sends a request with correct parameters for impacting filter', () => {
+//   beforeEach(() => {
+//     cy.intercept('*', {
+//       statusCode: 201,
+//       body: {
+//         ...fixtures,
+//       },
+//     }).as('impact_call');
+//     mountComponent({ hasEdgeDevices: true });
+//   });
+
+//   it('has dnf, ostree impacting filters and status filter active by default', () => {
+//     hasChip('Status', 'Enabled');
+//     hasChip('Systems impacted', '1 or more Conventional systems (RPM-DNF)');
+//     hasChip('Systems impacted', '1 or more Immutable (OSTree)');
+
+//     cy.get(CHIP_GROUP).find('.pf-c-chip__text').should('have.length', 3);
+//   });
+
+//   it(`with edge devices`, () => {
+//     const { urlParam, values, urlValue } = update_method;
+
+//     // initial call
+//     cy.wait('@impact_call');
+
+//     cy.get('.pf-c-button').contains('Reset filters').click();
+//     cy.wait(['@impact_call', '@impact_call']);
+
+//     applyUpdateMethod({ update_method: values[0] });
+//     cy.wait('@impact_call')
+//       .its('request.url')
+//       .should('include', `${urlParam}=${urlValue(values[0])}`);
+//   });
+// });

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -8,9 +8,7 @@ import {
 } from '@patternfly/react-core/dist/esm/components/Pagination/Pagination';
 import React, { useContext, useEffect, useState } from 'react';
 
-import {
-  TableVariant,
-} from '@patternfly/react-table';
+import { TableVariant } from '@patternfly/react-table';
 import {
   Table,
   TableBody,

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -34,6 +34,7 @@ import { formatMessages, mapContentToValues } from '../../Utilities/intlHelper';
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import { ruleResolutionRisk, pruneFilters } from '../Common/Tables';
 import { cellWidth, fitContent, sortable } from '@patternfly/react-table';
+import { getImpactingFilterChips } from '../Filters/impactingFilter';
 
 export const emptyRows = (filters, toggleRulesDisabled) => [
   {
@@ -340,18 +341,6 @@ export const filterConfigItems = (
         items: FC.rule_status.values,
       },
     },
-    {
-      label: FC.impacting.title,
-      type: conditionalFilterType.checkbox,
-      id: FC.impacting.urlParam,
-      value: `checkbox-${FC.impacting.urlParam}`,
-      filterValues: {
-        key: `${FC.impacting.urlParam}-filter`,
-        onChange: (e, values) => addFilterParam(FC.impacting.urlParam, values),
-        value: filters.impacting,
-        items: FC.impacting.values,
-      },
-    },
   ];
 };
 
@@ -548,14 +537,16 @@ export const getColumns = (intl) => [
   },
 ];
 
-const buildFilterChips = (filters) => {
+const buildFilterChips = (filters, hasEdgeDevice) => {
+  const impactingFilterChips = getImpactingFilterChips(hasEdgeDevice);
+
   const localFilters = { ...filters };
   delete localFilters.topic;
   delete localFilters.sort;
   delete localFilters.offset;
   delete localFilters.limit;
 
-  return pruneFilters(localFilters, FC);
+  return pruneFilters(localFilters, { ...FC, ...impactingFilterChips });
 };
 
 export const sortIndices = {
@@ -571,10 +562,11 @@ export const getActiveFiltersConfig = (
   filters,
   intl,
   setSearchText,
-  setFilters
+  setFilters,
+  hasEdgeDevice
 ) => ({
   deleteTitle: intl.formatMessage(messages.resetFilters),
-  filters: buildFilterChips(filters),
+  filters: buildFilterChips(filters, hasEdgeDevice),
   showDeleteButton: true,
   onDelete: (_event, itemsToRemove, isAll) => {
     if (isAll) {

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -31,8 +31,9 @@ import RuleLabels from '../Labels/RuleLabels';
 import CategoryLabel from '../Labels/CategoryLabel';
 
 import { formatMessages, mapContentToValues } from '../../Utilities/intlHelper';
-import { ruleResolutionRisk } from '../Common/Tables';
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
+import { ruleResolutionRisk, pruneFilters } from '../Common/Tables';
+import { cellWidth, fitContent, sortable } from '@patternfly/react-table';
 
 export const emptyRows = (filters, toggleRulesDisabled) => [
   {
@@ -185,6 +186,7 @@ export const hideReports = async (
     });
   }
 };
+
 export const removeFilterParam = (
   param,
   filters,
@@ -518,3 +520,91 @@ export const buildRows = (
 
   return rows;
 };
+
+export const getColumns = (intl) => [
+  {
+    title: intl.formatMessage(messages.name),
+    transforms: [sortable, cellWidth(40)],
+  },
+  {
+    title: intl.formatMessage(messages.modified),
+    transforms: [sortable, fitContent],
+  },
+  {
+    title: intl.formatMessage(messages.category),
+    transforms: [sortable, fitContent],
+  },
+  {
+    title: intl.formatMessage(messages.totalRisk),
+    transforms: [sortable, fitContent],
+  },
+  {
+    title: intl.formatMessage(messages.systems),
+    transforms: [sortable, fitContent],
+  },
+  {
+    title: intl.formatMessage(messages.remediation),
+    transforms: [sortable, fitContent],
+  },
+];
+
+const buildFilterChips = (filters) => {
+  const localFilters = { ...filters };
+  delete localFilters.topic;
+  delete localFilters.sort;
+  delete localFilters.offset;
+  delete localFilters.limit;
+
+  return pruneFilters(localFilters, FC);
+};
+
+export const sortIndices = {
+  1: 'description',
+  2: 'publish_date',
+  3: 'category',
+  4: 'total_risk',
+  5: 'impacted_count',
+  6: 'playbook_count',
+};
+
+export const getActiveFiltersConfig = (
+  filters,
+  intl,
+  setSearchText,
+  setFilters
+) => ({
+  deleteTitle: intl.formatMessage(messages.resetFilters),
+  filters: buildFilterChips(filters),
+  showDeleteButton: true,
+  onDelete: (_event, itemsToRemove, isAll) => {
+    if (isAll) {
+      setSearchText('');
+      setFilters({
+        ...(filters.topic && { topic: filters.topic }),
+        impacting: ['true'],
+        rule_status: 'enabled',
+        limit: filters.limit,
+        offset: filters.offset,
+        pathway: filters.pathway,
+      });
+    } else {
+      itemsToRemove.map((item) => {
+        const newFilter = {
+          [item.urlParam]: Array.isArray(filters[item.urlParam])
+            ? filters[item.urlParam].filter(
+                (value) => String(value) !== String(item.chips[0].value)
+              )
+            : '',
+        };
+        newFilter[item.urlParam].length > 0
+          ? setFilters({ ...filters, ...newFilter })
+          : removeFilterParam(
+              item.urlParam,
+              filters,
+              setFilters,
+              setSearchText
+            );
+      });
+    }
+  },
+});

--- a/src/PresentationalComponents/RulesTable/useActionsResolver.js
+++ b/src/PresentationalComponents/RulesTable/useActionsResolver.js
@@ -1,0 +1,59 @@
+import { useCallback } from 'react';
+import { useIntl } from 'react-intl';
+import { useDispatch } from 'react-redux';
+import messages from '../../Messages';
+import { hideReports } from './helpers';
+
+export const useActionsResolver = (
+  rows,
+  setSelectedRule,
+  setDisableRuleOpen,
+  refetch
+) => {
+  const intl = useIntl();
+  const dispatch = useDispatch();
+
+  const actionResolver = useCallback(
+    (rowData, { rowIndex }) => {
+      const rule = rows[rowIndex].rule ? rows[rowIndex].rule : null;
+      if (rowIndex % 2 !== 0 || !rule) {
+        return null;
+      }
+
+      return rule && rule.rule_status === 'enabled'
+        ? [
+            {
+              title: intl.formatMessage(messages.disableRule),
+              onClick: (_event, rowId) =>
+                hideReports(
+                  rowId,
+                  rows,
+                  setSelectedRule,
+                  setDisableRuleOpen,
+                  refetch,
+                  dispatch,
+                  intl
+                ),
+            },
+          ]
+        : [
+            {
+              title: intl.formatMessage(messages.enableRule),
+              onClick: (_event, rowId) =>
+                hideReports(
+                  rowId,
+                  rows,
+                  setSelectedRule,
+                  setDisableRuleOpen,
+                  refetch,
+                  dispatch,
+                  intl
+                ),
+            },
+          ];
+    },
+    [rows, setSelectedRule, setDisableRuleOpen, refetch, dispatch, intl]
+  );
+
+  return actionResolver;
+};

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -53,7 +53,12 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
     data: recAck = {},
     isFetching: recAckIsFetching,
     refetch: recAckRefetch,
-  } = useGetRecAcksQuery({ ruleId });
+  } = useGetRecAcksQuery(
+    { ruleId },
+    {
+      skip: !!ruleId,
+    }
+  );
 
   const { data: topics = [], isFetching: topicIsFetching } =
     useGetTopicsQuery();


### PR DESCRIPTION
…o maintain

# Description

Associated Jira ticket: RHINENG-3078

This PR extends the systems impacted filter in advisor to include the new options dnfyum, ostree for only accounts with edge systems. For the rest of the users, behavior should stay the same. After trying out a bunch of approaches, I decided to have simple if else conditions to map the filter values to the complex API spec in `mapUpdateMethodFilterToAPISpec` func.

API filter syntax [(RHINENG-5353)](https://issues.redhat.com/browse/RHINENG-5353)

- All rules: no query parameter
- No impacted systems: impacting=false.
- Only conventional systems: impacting=true&update_method=dnfyum.
- Only immutable systems: impacting=true&update_method=ostree.
- Any system: impacting=true.

I wrote new tests to cover the work, but I had to comment them out as most of the tests are commented out due to the PF migrations :))))

This also cleans up the RulesTable component a bit by moving helpers functions into a separate file. 


# How to test the PR

1. Run the app
2. navigate to recommendations table in landing page
3. Observe that now the table is filtered with both dnfyum and ostree and the filter chips are present
4. Play with the impacting filter with new options, observe it works as expeted. 
5. Repeat the same actions in all pages where rules table is present 

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
