### PR TITLE
chore(RecDetails): prevent rec-detail fetch when rec id is undefined

### DIFF
--- a/src/PresentationalComponents/Filters/impactingFilter.js
+++ b/src/PresentationalComponents/Filters/impactingFilter.js
@@ -8,7 +8,7 @@ export const getImpactingFilterChips = (hasEdgeDevices) => ({
   [getImpactingFilterKey(hasEdgeDevices)]: {
     type: 'radio',
     title: 'Systems impacted',
-    urlParam: 'rule_status',
+    urlParam: getImpactingFilterKey(hasEdgeDevices),
     values: getImpactingFitlerItems(hasEdgeDevices),
   },
 });


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)

This prevents fetching recommendation details when rec id is undefined. 


![image](https://github.com/RedHatInsights/insights-advisor-frontend/assets/59481011/20a1cb6e-c1e8-4025-9366-06499ae4a87d)


# How to test the PR

1. Run the PR
2. navigate to any recommendation detail page
3. open the networks debugger 
4. observe that no API call to advisor api is failin with 404

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
