### PR TITLE
fix(RHINENG-3078): fix impacting systems filter chips removal

### DIFF
--- a/src/PresentationalComponents/Filters/impactingFilter.js
+++ b/src/PresentationalComponents/Filters/impactingFilter.js
@@ -8,7 +8,7 @@ export const getImpactingFilterChips = (hasEdgeDevices) => ({
   [getImpactingFilterKey(hasEdgeDevices)]: {
     type: 'radio',
     title: 'Systems impacted',
-    urlParam: 'rule_status',
+    urlParam: getImpactingFilterKey(hasEdgeDevices),
     values: getImpactingFitlerItems(hasEdgeDevices),
   },
 });


### PR DESCRIPTION
# Description

Associated Jira ticket: # https://issues.redhat.com/browse/RHINENG-3078

This addresses the comment by @computercamplove . The chips for impacting sytems filter was not working as expected due to incorrect url_param in the filter definitions. Now the url_param is made correct and removing active impacting systems filter works as it should


# How to test the PR

1. Run the PR
2. in the landing page, observe that the table is by default filtered by 2 system filters.
3. try removing one/2 of them by clicking on the X button next to the chips
4. observe that only associate chip to the X button gets removed and the filter also is removed

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
