### PR TITLE
fix(RHINENG-8777): unable to unselect total risk in recommendations

### DIFF
--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -211,7 +211,7 @@ export const filterConfigItems = (
   const addFilterParam = (param, values) => {
     values.length > 0
       ? setFilters({ ...filters, offset: 0, ...{ [param]: values } })
-      : removeFilterParam(param);
+      : removeFilterParam(param, filters, setFilters, setSearchText);
   };
 
   return [


### PR DESCRIPTION
[RHINENG-8777](https://issues.redhat.com/browse/RHINENG-8777)

![image](https://github.com/RedHatInsights/insights-advisor-frontend/assets/20592948/b0b45743-cb32-4831-8c3b-4361ec819a3b)
Not all parameters were set

How to test: 
1. Advisor > Recommendations
2. Find the Total risk filter
3. Click on Critical to check it
4. Try to uncheck it
5. It should remove the filter