### PR TITLE
fix(RHINENG-9594): Only retrieve/display recs for the chosen pathway

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4627,9 +4627,9 @@
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.2.1.tgz",
-      "integrity": "sha512-GT96hzI1QenBhq6Pfc51kxnj9aVLjL1zSLukKZXcYVe0HPOy0BFm90bT1Fo4e/z7V9cDYw4SqSX1XLc3O4jsTw=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.3.0.tgz",
+      "integrity": "sha512-/EdkURW+v7Rzw/CiEqL+NfGtLvLMGIwOEyDhvlMDbRip2usGw4HLZv3Bep0cJe29zOeY27cDVZDM1HfyXLebtw=="
     },
     "node_modules/@patternfly/react-table": {
       "version": "5.1.2",
@@ -4649,9 +4649,9 @@
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.2.1.tgz",
-      "integrity": "sha512-8GYz/jnJTGAWUJt5eRAW5dtyiHPKETeFJBPGHaUQnvi/t1ZAkoy8i4Kd/RlHsDC7ktiu813SKCmlzwBwldAHKg=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.3.0.tgz",
+      "integrity": "sha512-24ZY5hgwt11InW3XtINM5p9Fo1hDiVor6Q4uphPZh8Mt89AsZZw1UweTaGg54I0Ah2Wzv6rkQy51LX7tZtIwjQ=="
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.11",

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -52,7 +52,7 @@ import { useActionsResolver } from './useActionsResolver';
 import { AccountStatContext } from '../../ZeroStateWrapper';
 import impactingFilter from '../Filters/impactingFilter';
 
-const RulesTable = ({ isTabActive }) => {
+const RulesTable = ({ isTabActive, pathway }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const { search } = useLocation();
@@ -84,14 +84,11 @@ const RulesTable = ({ isTabActive }) => {
 
   const setFilters = (filters) => dispatch(updateRecFilters(filters));
 
-  let options = {};
-  selectedTags?.length &&
-    (options = {
-      ...options,
-      ...{ tags: selectedTags.join(',') },
-    });
-  workloads &&
-    (options = { ...options, ...workloadQueryBuilder(workloads, SID) });
+  const options = {
+    ...(selectedTags?.length ? { tags: selectedTags.join(',') } : {}),
+    ...(workloads ? workloadQueryBuilder(workloads, SID) : {}),
+    ...(pathway ? { pathway } : {}),
+  };
 
   const {
     data: rules = [],
@@ -341,6 +338,7 @@ const RulesTable = ({ isTabActive }) => {
 
 RulesTable.propTypes = {
   isTabActive: PropTypes.bool,
+  pathway: PropTypes.string,
 };
 
 export default RulesTable;

--- a/src/SmartComponents/Recs/DetailsPathways.js
+++ b/src/SmartComponents/Recs/DetailsPathways.js
@@ -213,7 +213,7 @@ const PathwayDetails = ({ isImmutableTabOpen }) => {
               <Loading />
             ) : (
               <Suspense fallback={<Loading />}>
-                <RulesTable />
+                <RulesTable pathway={pathwayName} />
               </Suspense>
             )}
           </Tab>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-9594

When selecting a pathway, the rules table component displays all rules regardless of whether they are associated with the selected pathway or not.

- Log into console.stage.redhat.com
- Go to the Insights -> Operations -> Advisor
- Select the '5' under Pathways - this lists the pathways.
- Choose one of the pathways - e.g. 'Update Kernel Boot Options'.
... all rules matching the filter conditions are displayed, not just the rules for 'Update Kernel Boot Options'


- [X] The commit message has the Jira ticket linked
- [X] PR has a short description
- [X] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
