### PR TITLE
RHINENG-5291 Link from System detail page to Recommendation detail page

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -291,7 +291,6 @@ const Inventory = ({
               renderFunc: (name, id) => {
                 return (
                   <Link
-                    className="pf-v5-u-font-size-lg"
                     to={`/recommendations/${rule.rule_id}/${id}?activeRule=true`}
                   >
                     {name}

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisorAssets.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisorAssets.js
@@ -20,6 +20,7 @@ import {
   InventoryReportFetchFailed,
 } from './EmptyStates';
 import { useLocation } from 'react-router-dom';
+import Link from '@redhat-cloud-services/frontend-components/InsightsLink';
 
 import messages from '../../Messages';
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
@@ -179,8 +180,15 @@ export const useBuildRows = (
             cells: [
               {
                 title: (
-                  <span>
-                    {rule.description} <RuleLabels rule={rule} />
+                  <span key={key}>
+                    <Link
+                      key={key}
+                      app="advisor"
+                      to={`/recommendations/${rule.rule_id}`}
+                    >
+                      {rule.description}{' '}
+                    </Link>
+                    <RuleLabels rule={rule} isCompact />
                   </span>
                 ),
               },


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-5291

System detail page table rule names are now links.

### How to test:
a. Advisor
  1. Go to System detail page
  2. Click on any recommendation link
  3. It should take you to the detail view of that recommendation

b. Inventory
  1. Go to System detail page
  2. Click on any recommendation link
  3. It should take you to the Advisor app detail view of that recommendation