### PR TITLE
fix(RHINENG-9378): Fix recommendations bulk select

### DIFF
--- a/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/__snapshots__/useBulkSelect.test.js.snap
+++ b/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/__snapshots__/useBulkSelect.test.js.snap
@@ -12,6 +12,7 @@ exports[`useBulkSelect returns a bulk select configuration 1`] = `
     "toolbarProps": {
       "bulkSelect": {
         "checked": false,
+        "count": 0,
         "isDisabled": true,
         "items": [
           {
@@ -51,6 +52,7 @@ exports[`useBulkSelect returns a bulk select configuration with the correct opti
   "toolbarProps": {
     "bulkSelect": {
       "checked": null,
+      "count": 1,
       "isDisabled": false,
       "items": [
         {
@@ -70,11 +72,7 @@ exports[`useBulkSelect returns a bulk select configuration with the correct opti
         },
       ],
       "onSelect": [Function],
-      "toggleProps": {
-        "children": [
-          "1 selected",
-        ],
-      },
+      "toggleProps": null,
     },
   },
 }
@@ -93,6 +91,7 @@ exports[`useBulkSelect returns a bulk select configuration with the correct opti
   "toolbarProps": {
     "bulkSelect": {
       "checked": null,
+      "count": 1,
       "isDisabled": false,
       "items": [
         {
@@ -112,11 +111,7 @@ exports[`useBulkSelect returns a bulk select configuration with the correct opti
         },
       ],
       "onSelect": [Function],
-      "toggleProps": {
-        "children": [
-          "1 selected",
-        ],
-      },
+      "toggleProps": null,
     },
   },
 }
@@ -135,6 +130,7 @@ exports[`useBulkSelect returns a bulk select configuration with the correct opti
   "toolbarProps": {
     "bulkSelect": {
       "checked": null,
+      "count": 1,
       "isDisabled": false,
       "items": [
         {
@@ -154,9 +150,51 @@ exports[`useBulkSelect returns a bulk select configuration with the correct opti
         },
       ],
       "onSelect": [Function],
+      "toggleProps": null,
+    },
+  },
+}
+`;
+
+exports[`useBulkSelect returns a spinner on loading 1`] = `
+{
+  "selectNone": [Function],
+  "selectedIds": undefined,
+  "tableProps": {
+    "canSelectAll": false,
+    "onSelect": [Function],
+  },
+  "toolbarProps": {
+    "bulkSelect": {
+      "checked": false,
+      "count": 0,
+      "isDisabled": true,
+      "items": [
+        {
+          "onClick": [Function],
+          "props": {
+            "isDisabled": true,
+          },
+          "title": "Select none",
+        },
+        {
+          "onClick": [Function],
+          "title": "Select page (1 items)",
+        },
+        {
+          "onClick": [Function],
+          "title": "Select all (2 items)",
+        },
+      ],
+      "onSelect": [Function],
       "toggleProps": {
         "children": [
-          "1 selected",
+          <React.Fragment>
+            <Spinner
+              size="sm"
+            />
+                 0 selected
+          </React.Fragment>,
         ],
       },
     },

--- a/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/helpers.js
+++ b/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/helpers.js
@@ -2,9 +2,7 @@ import React from 'react';
 import { Spinner } from '@patternfly/react-core';
 
 export const compileTitle = (itemsTotal, isLoading) => {
-  if (itemsTotal === 0 && !isLoading) {
-    return null;
-  } else if (isLoading) {
+  if (isLoading) {
     return (
       <React.Fragment>
         <Spinner size="sm" />
@@ -12,7 +10,7 @@ export const compileTitle = (itemsTotal, isLoading) => {
       </React.Fragment>
     );
   } else {
-    return `${itemsTotal} selected`;
+    return null;
   }
 };
 

--- a/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/useBulkSelect.js
+++ b/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/useBulkSelect.js
@@ -36,7 +36,7 @@ const useBulkSelect = ({
   const allSelected = selectedIdsTotal === total;
   const noneSelected = selectedIdsTotal === 0;
 
-  const isDisabled = total === 0;
+  const isDisabled = total === 0 || isLoading;
   const checked = checkboxState(selectedIdsTotal, total);
   const title = compileTitle(selectedIdsTotal, isLoading);
 
@@ -79,6 +79,7 @@ const useBulkSelect = ({
         toolbarProps: {
           bulkSelect: {
             toggleProps: title ? { children: [title] } : null,
+            count: selectedIds?.length || 0,
             isDisabled,
             items: [
               {

--- a/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/useBulkSelect.test.js
+++ b/src/PresentationalComponents/Inventory/Hooks/useBulkSelect/useBulkSelect.test.js
@@ -7,6 +7,7 @@ describe('useBulkSelect', () => {
     onSelect: () => ({}),
     itemIdsInTable: () => [],
     itemIdsOnPage: () => [],
+    isLoading: false,
   };
 
   it('returns a bulk select configuration', () => {
@@ -53,6 +54,20 @@ describe('useBulkSelect', () => {
         preselected: ['ID'],
         itemIdsInTable: () => ['ID', 'ID2'],
         itemIdsOnPage: () => ['ID'],
+      })
+    );
+
+    expect(result.current).toMatchSnapshot();
+  });
+
+  it('returns a spinner on loading', () => {
+    const { result } = renderHook(() =>
+      useBulkSelect({
+        ...defaultOptions,
+        total: 2,
+        itemIdsInTable: () => ['ID', 'ID2'],
+        itemIdsOnPage: () => ['ID'],
+        isLoading: true,
       })
     );
 


### PR DESCRIPTION
The issue described in the card has been fix by some other PR:

- Go to recommendation's details page with at least 11 systems so it's is possible to have at least 2 pages in the table
- Select All systems via bulk selector
- Go to the next page of the table

Before, once you went to the next page, you would see that none of the systems on subsequent pages were selected. And clicking a system to select it would suddenly select every system on the page. When I began working on this card, that issue was already fixed.

But, this PR fixes a couple of other issues:

- When you choose Select All from the bulk select, it disables the bulk select box and the Spinner shows up properly
- When you choose Select All from the bulk select, and the selection completes, you will see the checkbox in the bulk select next to the total number of systems selected

# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
