### PR TITLE
feat(RHINENG-10414): workspaces feature flag

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -317,7 +317,7 @@ const Inventory = ({
 
       groups = {
         ...groups[0],
-        title: isWorkSpaceEnabled && 'Workspaces',
+        title: isWorkSpaceEnabled ? 'Workspaces' : 'Groups',
         transforms: [wrappable],
       };
 

--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -21,6 +21,7 @@ import { useIntl } from 'react-intl';
 import downloadReport from '../Common/DownloadHelper';
 import useBulkSelect from './Hooks/useBulkSelect';
 import { Spinner } from '@patternfly/react-core';
+import { useWorkspaceFeatureFlag } from '../../Utilities/Hooks';
 
 const Inventory = ({
   tableProps,
@@ -60,6 +61,7 @@ const Inventory = ({
     useState(true);
   //This value comes in from the backend as 0, or 1. To be consistent it is set to -1
   const [rulesPlaybookCount, setRulesPlaybookCount] = useState(-1);
+  let isWorkSpaceEnabled = useWorkspaceFeatureFlag();
 
   const handleRefresh = (options) => {
     /* Rec table doesn't use the same sorting params as sys table, switching between the two results in the rec table blowing up cuz its trying to
@@ -279,7 +281,6 @@ const Inventory = ({
       );
       let tags = defaultColumns.filter(({ key }) => key === 'tags');
       let groups = defaultColumns.filter(({ key }) => key === 'groups');
-
       //Link to the Systems in the Recommendation details table and Pathway details table
       displayName = {
         ...displayName[0],
@@ -316,6 +317,7 @@ const Inventory = ({
 
       groups = {
         ...groups[0],
+        title: isWorkSpaceEnabled && 'Workspaces',
         transforms: [wrappable],
       };
 

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -5,3 +5,6 @@ export const useFeatureFlag = (flag) => {
   const isFlagEnabled = useFlag(flag);
   return flagsReady ? isFlagEnabled : false;
 };
+
+export const useWorkspaceFeatureFlag = () =>
+  useFeatureFlag('platform.rbac.groups-to-workspaces-rename');


### PR DESCRIPTION
# Description

[RHINENG-10414](https://issues.redhat.com/browse/RHINENG-10414) 

In advisor the only instance of workspaces is in the inventory table. This changes that instance when the feature flag is enabled. 
Once the backend PR is merged, I can send up another PR that I have stashed locally :) 
# How to test the PR

Navigate to systems pages (or any page with the groups column) and verify it says Workspace and opposed to groups. 


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
