### PR TITLE
fix(RHINENG-10409): Limit justification to backend max length

### DIFF
--- a/src/PresentationalComponents/Modals/DisableRule.js
+++ b/src/PresentationalComponents/Modals/DisableRule.js
@@ -30,6 +30,7 @@ const DisableRule = ({
   const [singleSystem, setSingleSystem] = useState(
     host !== undefined || hosts.length > 0
   );
+  const justificationMaxLength = 255;
 
   const [setAck] = useSetAckMutation();
 
@@ -160,6 +161,7 @@ const DisableRule = ({
             id="disable-rule-justification"
             aria-describedby="disable-rule-justification"
             value={justification}
+            maxLength={justificationMaxLength}
             onChange={(_event, text) => setJustificaton(text)}
             onKeyDown={(e) =>
               e.key === 'Enter' && (e.preventDefault(), disableRule())


### PR DESCRIPTION
Recently we had a customer entering a value into the justification field that was longer than the max length of the field, and it had us scratching our heads for a while trying to figure out what the problem was.  We have increased the size of the field in the backend in https://gitlab.cee.redhat.com/insights-platform/advisor-backend/-/merge_requests/887 but we also think we should limit the UI text input to the same max length, to make it harder for customers to 'do the wrong thing'.  This is a simplistic solution and can easily be defeated by determined customers, but its a low-hanging fruit solution to the problem, so I'm going with it.
