### PR TITLE
fix(RHINENG-10414): use singular form Group/Workspace

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -317,7 +317,7 @@ const Inventory = ({
 
       groups = {
         ...groups[0],
-        title: isWorkSpaceEnabled ? 'Workspaces' : 'Groups',
+        title: isWorkSpaceEnabled ? 'Workspace' : 'Group',
         transforms: [wrappable],
       };
 


### PR DESCRIPTION
# Description

Associated Jira ticket: https://issues.redhat.com/browse/RHINENG-10414

Small fix where we use singular form instead of plural for consistency between apps


# How to test the PR

Ensure that Recommendations details page has "Group"/"Workspace" column. Note that This is the only one place where naming form appeared, other tables are coming from inventory


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
