### PR TITLE
fix(ZeroStateWrapper): RHINENG-10312 dont show ZeroState on data loading

### DIFF
--- a/src/ZeroStateWrapper.js
+++ b/src/ZeroStateWrapper.js
@@ -70,7 +70,7 @@ export const ZeroStateWrapper = ({ children }) => {
         </Bullseye>
       }
     >
-      {!hasSystems ? (
+      {!hasSystems && conventionalQuerySuccess ? (
         <Suspense
           fallback={
             <Bullseye>

--- a/src/ZeroStateWrapper.test.js
+++ b/src/ZeroStateWrapper.test.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { screen, render } from '@testing-library/react';
+import { ZeroStateWrapper } from './ZeroStateWrapper';
+import { useGetConventionalDevicesQuery } from './Services/SystemVariety';
+import { ComponentWithContext } from './Utilities/TestingUtilities';
+
+jest.mock('./Utilities/Hooks', () => ({
+  ...jest.requireActual('./Utilities/Hooks'),
+  useFeatureFlag: jest.fn(() => false),
+}));
+
+jest.mock('./Services/SystemVariety', () => ({
+  ...jest.requireActual('./Services/SystemVariety'),
+  useGetConventionalDevicesQuery: jest.fn(() => ({
+    data: {
+      total: 5,
+    },
+    isSuccess: true,
+    isError: false,
+  })),
+  useGetEdgeDevicesQuery: jest.fn(() => ({
+    data: {
+      total: 5,
+    },
+    isSuccess: true,
+    isError: false,
+  })),
+}));
+
+const noConvSystems = {
+  data: {
+    total: 0,
+  },
+  isSuccess: true,
+  isError: false,
+};
+
+const notLoaded = {
+  data: {
+    total: 0,
+  },
+  isSuccess: false,
+  isError: false,
+};
+
+describe('ZeroStateWrapper', () => {
+  it('Should render children with conventional devices', () => {
+    render(
+      <ComponentWithContext
+        Component={ZeroStateWrapper}
+        componentProps={{ children: <div>Rendered</div> }}
+      />
+    );
+
+    expect(screen.getByText('Rendered'));
+  });
+
+  it('Should render ZeroState with no systems', () => {
+    useGetConventionalDevicesQuery.mockReturnValue(noConvSystems);
+    render(
+      <ComponentWithContext
+        Component={ZeroStateWrapper}
+        componentProps={{ children: <div>Rendered</div> }}
+      />
+    );
+
+    expect(screen.getByText('AsyncComponent'));
+  });
+
+  it('Should not render ZeroState when waiting for data to load', () => {
+    useGetConventionalDevicesQuery.mockReturnValue(notLoaded);
+    render(
+      <ComponentWithContext
+        Component={ZeroStateWrapper}
+        componentProps={{ children: <div>Rendered</div> }}
+      />
+    );
+
+    expect(screen.getByText('Rendered'));
+  });
+});


### PR DESCRIPTION
# Description

Associated Jira ticket: # [RHINENG-10312](https://issues.redhat.com/browse/RHINENG-10312)

Don't show ZeroState while data are still loading - also fixes persisting Global Filters from Dashboard


# How to test the PR

1. Go to Dashboard application
2. Apply global filter
3. Use any link in Advisor card to go to Advisor application
4. The Global filters should be applied

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
