### PR TITLE
fix(RHINENG-11227): Prevent sending both true and false for incident filter

### DIFF
--- a/src/PresentationalComponents/helper.js
+++ b/src/PresentationalComponents/helper.js
@@ -34,6 +34,9 @@ export const createOptions = (
   systemsPage
 ) => {
   const osFilter = filters.osFilter && buildOsFilter(filters.osFilter);
+  // RHINENG-11227: remove system incident filter if it has multiple elements, which will be both
+  // 'true' and 'false', because it will result in a 400 BadRequest from the API
+  advisorFilters.incident?.length > 1 && delete advisorFilters.incident;
   const options = {
     ...advisorFilters,
     limit: per_page,


### PR DESCRIPTION
The API doesn't accept the incident parameter having both true and false values at the same time, eg incident=true&incident=false.  The API will return a 400 BadRequest if it does which will cause an error in the frontend.  The PR prevents the frontend from sending multiple values for the incident parameter to the API.

- [X] The commit message has the Jira ticket linked
- [X] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
