### PR TITLE
Remove deprecated Component.defaultProps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3882,9 +3882,9 @@
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.3.1.tgz",
-      "integrity": "sha512-H6uBoFH3bJjD6PP75qZ4k+2TtF59vxf9sIVerPpwrGJcRgBZbvbMZCniSC3+S2LQ8DgXLnDvieq78jJzHz0hiA=="
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.4.0.tgz",
+      "integrity": "sha512-4ZE0s6LkX/0KsN0FOeogrDoj18m+BPA73YKnabZGB4SDRzrBNeBh2a6bSt546ZseEjkoJ+S81kOG0G8YckPQYg=="
     },
     "node_modules/@patternfly/react-table": {
       "version": "5.3.3",
@@ -3904,9 +3904,9 @@
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.3.1.tgz",
-      "integrity": "sha512-VYK0uVP2/2RJ7ZshJCCLeq0Boih5I1bv+9Z/Bg6h12dCkLs85XsxAX9Ve+BGIo5DF54/mzcRHE1RKYap4ISXuw=="
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.4.0.tgz",
+      "integrity": "sha512-KONkwCVOMyklhuuaYeYgcAsGtCBQXnsBGZeolhOdSzr2Mj0RVSW0oMrQPgZuPVzhhC/kbqgClHJJl6xuG9xheA=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/src/PresentationalComponents/Labels/CategoryLabel.js
+++ b/src/PresentationalComponents/Labels/CategoryLabel.js
@@ -49,11 +49,6 @@ const CategoryLabel = ({ labelList }) => {
 
 CategoryLabel.propTypes = {
   labelList: PropTypes.array,
-  isCompact: PropTypes.bool,
-};
-
-CategoryLabel.defaultProps = {
-  isCompact: true,
 };
 
 export default CategoryLabel;

--- a/src/PresentationalComponents/Labels/RecommendationLevel.js
+++ b/src/PresentationalComponents/Labels/RecommendationLevel.js
@@ -4,7 +4,7 @@ import React from 'react';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
 
-export const RecommendationLevel = ({ recLvl, isCompact }) => {
+export const RecommendationLevel = ({ recLvl, isCompact = true }) => {
   const intl = useIntl();
   const label = (text, recLvl, color) => (
     <Label color={color} isCompact>{`${text} - ${recLvl}%`}</Label>
@@ -25,10 +25,8 @@ export const RecommendationLevel = ({ recLvl, isCompact }) => {
 };
 
 RecommendationLevel.propTypes = {
-  props: PropTypes.array,
-};
-RecommendationLevel.defaultProps = {
-  isCompact: true,
+  recLvl: PropTypes.number,
+  isCompact: PropTypes.bool,
 };
 
 export default RecommendationLevel;

--- a/src/PresentationalComponents/Labels/RuleLabels.js
+++ b/src/PresentationalComponents/Labels/RuleLabels.js
@@ -5,7 +5,7 @@ import React from 'react';
 import messages from '../../Messages';
 import { Label, Tooltip, TooltipPosition } from '@patternfly/react-core';
 
-const RuleLabels = ({ rule, isCompact, noMargin }) => {
+const RuleLabels = ({ rule, isCompact = true, noMargin }) => {
   return (
     <React.Fragment>
       {rule?.tags?.search('incident') !== -1 && (
@@ -50,10 +50,6 @@ RuleLabels.propTypes = {
   rule: PropTypes.object,
   isCompact: PropTypes.bool,
   noMargin: PropTypes.bool,
-};
-
-RuleLabels.defaultProps = {
-  isCompact: true,
 };
 
 export default RuleLabels;

--- a/src/PresentationalComponents/MessageState/MessageState.js
+++ b/src/PresentationalComponents/MessageState/MessageState.js
@@ -13,12 +13,12 @@ import React from 'react';
 const MessageState = ({
   className,
   children,
-  icon,
+  icon = CubesIcon,
   iconClass,
   iconStyle,
   text,
-  title,
-  variant,
+  title = '',
+  variant = EmptyStateVariant.full,
 }) => (
   <EmptyState className={className} variant={variant}>
     {icon !== 'none' && (
@@ -31,6 +31,7 @@ const MessageState = ({
 );
 
 MessageState.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.any,
   icon: PropTypes.any,
   iconClass: PropTypes.any,
@@ -38,13 +39,6 @@ MessageState.propTypes = {
   text: PropTypes.any,
   title: PropTypes.string,
   variant: PropTypes.any,
-  className: PropTypes.string,
-};
-
-MessageState.defaultProps = {
-  icon: CubesIcon,
-  title: '',
-  variant: EmptyStateVariant.full,
 };
 
 export default MessageState;

--- a/src/PresentationalComponents/Modals/DisableRule.js
+++ b/src/PresentationalComponents/Modals/DisableRule.js
@@ -16,12 +16,12 @@ import { useIntl } from 'react-intl';
 import { useSetAckMutation } from '../../Services/Acks';
 
 const DisableRule = ({
-  handleModalToggle,
-  isModalOpen,
+  handleModalToggle = () => {},
+  isModalOpen = false,
   host,
-  hosts,
-  rule,
-  afterFn,
+  hosts = [],
+  rule = {},
+  afterFn = () => {},
 }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
@@ -180,16 +180,6 @@ DisableRule.propTypes = {
   rule: PropTypes.object,
   afterFn: PropTypes.func,
   hosts: PropTypes.array,
-};
-
-DisableRule.defaultProps = {
-  isModalOpen: false,
-  handleModalToggle: () => undefined,
-  system: undefined,
-  rule: {},
-  afterFn: () => undefined,
-  host: undefined,
-  hosts: [],
 };
 
 export default DisableRule;

--- a/src/PresentationalComponents/Modals/ViewHostAcks.js
+++ b/src/PresentationalComponents/Modals/ViewHostAcks.js
@@ -19,7 +19,12 @@ import { useDispatch } from 'react-redux';
 import { useGetHostAcksQuery } from '../../Services/Acks';
 import { useIntl } from 'react-intl';
 
-const ViewHostAcks = ({ handleModalToggle, isModalOpen, rule, afterFn }) => {
+const ViewHostAcks = ({
+  handleModalToggle = () => {},
+  isModalOpen = false,
+  rule = {},
+  afterFn = () => {},
+}) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const addNotification = (data) => dispatch(notification(data));
@@ -129,13 +134,6 @@ ViewHostAcks.propTypes = {
   handleModalToggle: PropTypes.func,
   rule: PropTypes.object,
   afterFn: PropTypes.func,
-};
-
-ViewHostAcks.defaultProps = {
-  isModalOpen: false,
-  handleModalToggle: () => undefined,
-  rule: {},
-  afterFn: () => undefined,
 };
 
 export default ViewHostAcks;


### PR DESCRIPTION
Fix the following error which was printed into console when running Jest tests:

> Warning: MessageState: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
