### PR TITLE
Fix(RHINENG-8792): Unify initial filters with reset filters on Topic D…

### DIFF
--- a/src/SmartComponents/Topics/Details.cy.js
+++ b/src/SmartComponents/Topics/Details.cy.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import Details from './Details';
+import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations/';
+import { Provider } from 'react-redux';
+import { initStore } from '../../Store';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AccountStatContext } from '../../ZeroStateWrapper';
+//eslint-disable-next-line rulesdir/disallow-fec-relative-imports
+import { hasChip } from '@redhat-cloud-services/frontend-components-utilities';
+
+const mountComponent = (hasEdgeDevices) => {
+  cy.mount(
+    <MemoryRouter initialEntries={['/topics/123']}>
+      <AccountStatContext.Provider value={{ hasEdgeDevices }}>
+        <IntlProvider locale={navigator.language.slice(0, 2)}>
+          <Provider store={initStore()}>
+            <Routes>
+              <Route path="topics/:id" element={<Details />}></Route>
+            </Routes>
+          </Provider>
+        </IntlProvider>
+      </AccountStatContext.Provider>
+    </MemoryRouter>
+  );
+};
+
+beforeEach(() => {
+  cy.intercept('/api/insights/v1/topic/123/?&topicId=123', {
+    name: 'Amazon Web Services (AWS)',
+    slug: 'aws',
+    description:
+      'Increase stability of your RHEL workloads running on Amazon Web Services by applying these recommendations.',
+    tag: 'aws',
+    featured: true,
+    enabled: true,
+    impacted_systems_count: 0,
+  }).as('topic_details_call');
+  // This call is generated implicitly by using the RulesTable
+  cy.intercept(
+    '/api/insights/v1/rule/?&impacting=true&rule_status=enabled&sort=-total_risk&limit=20&offset=0',
+    {
+      data: [],
+    }
+  ).as('rules_table_call');
+  cy.intercept(
+    '/api/insights/v1/rule/?&topic=123&update_method=ostree%2Cdnfyum&impacting=true&rule_status=enabled&sort=-total_risk&limit=10&offset=0',
+    {
+      data: [],
+    }
+  ).as('rules_table_initial_call');
+});
+
+describe('Topic Details is loaded correctly for user with Edge systems', () => {
+  beforeEach(() => {
+    mountComponent(true);
+  });
+
+  it('Correct deffault filters for Recommendation table', () => {
+    cy.wait(['@rules_table_initial_call']);
+    hasChip('Status', 'Enabled');
+    hasChip('Systems impacted', '1 or more Conventional systems (RPM-DNF)');
+    hasChip('Systems impacted', '1 or more Immutable (OSTree)');
+  });
+});
+
+describe('Topic Details is loaded correctly for user without Edge systems', () => {
+  beforeEach(() => {
+    mountComponent(false);
+  });
+
+  it('Correct deffault filters for Recommendation table', () => {
+    cy.wait(['@rules_table_initial_call']);
+    hasChip('Status', 'Enabled');
+    hasChip('Systems impacted', '1 or more');
+  });
+});

--- a/src/SmartComponents/Topics/Details.js
+++ b/src/SmartComponents/Topics/Details.js
@@ -1,6 +1,6 @@
 import './_Details.scss';
 
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import {
   Text,
   TextVariants,
@@ -25,7 +25,9 @@ import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { workloadQueryBuilder } from '../../PresentationalComponents/Common/Tables';
-import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { getDefaultImpactingFilter } from '../../PresentationalComponents/RulesTable/helpers';
+import { AccountStatContext } from '../../ZeroStateWrapper';
 
 const Details = () => {
   const intl = useIntl();
@@ -39,6 +41,7 @@ const Details = () => {
   let options = selectedTags?.length && { tags: selectedTags };
   workloads &&
     (options = { ...options, ...workloadQueryBuilder(workloads, SID) });
+  const hasEdgeDevices = useContext(AccountStatContext);
 
   const {
     data: topic = {},
@@ -51,9 +54,9 @@ const Details = () => {
     const initiaRecFilters = { ...recFilters };
     dispatch(
       updateRecFilters({
-        impacting: true,
-        rule_status: 'enabled',
         topic: topicId,
+        ...getDefaultImpactingFilter(hasEdgeDevices),
+        rule_status: 'enabled',
         sort: `-total_risk`,
         limit: 10,
         offset: 0,


### PR DESCRIPTION
# Description

Associated Jira ticket: RHINENG-8792

Initial filtering of Recommendation table on Topic Details page doesn't include filtering by Systems impacted (unlike Recommendations list page). However, after resetting the filters, this missing filter is added to the initial ones, giving the impression that the page does not load to the default state.


# How to test the PR

Visit details page of any Topic and look at initial filters in Recommendation tables. Afterwards reset filters using Reset filters button and no change should be applied.

# Before the change
On page loaded:
![Screenshot from 2024-10-04 13-32-43](https://github.com/user-attachments/assets/a0c23f49-6a93-471c-a743-49b17c2b8726)
After clicking Reset fitlers:
![Screenshot from 2024-10-04 13-32-50](https://github.com/user-attachments/assets/cb82f3aa-4f9e-479b-b39c-3be56a3fe54d)




# After the change
![Screenshot from 2024-10-04 13-34-34](https://github.com/user-attachments/assets/ba188d7d-f27c-4f4c-ba81-ec1858cfd887)


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
