### PR TITLE
fix(RHINENG-13517): Fix export PDF misalignment

### DIFF
--- a/src/PresentationalComponents/Export/SystemsPdf.js
+++ b/src/PresentationalComponents/Export/SystemsPdf.js
@@ -71,8 +71,7 @@ const SystemsPdf = ({ filters }) => {
       buttonProps={{
         variant: '',
         component: 'button',
-        className:
-          'pf-v5-c-dropdown__menu-item adv-c-dropdown-systems-pdf__menu-item',
+        className: 'pf-v5-c-menu__item adv-c-dropdown-systems-pdf__menu-item',
         ...(loading ? { isDisabled: true } : null),
       }}
       reportName={`${intl.formatMessage(messages.insightsHeader)}:`}

--- a/src/PresentationalComponents/Export/_Export.scss
+++ b/src/PresentationalComponents/Export/_Export.scss
@@ -1,4 +1,5 @@
 .adv-c-dropdown-systems-pdf__menu-item {
-    text-align: left !important;
+    text-align: center !important;
     border-radius: 0 !important;
+    padding-left: 4px;
 }

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -309,7 +309,13 @@ const SystemsTable = () => {
               dispatch
             ),
           extraItems: [
-            <li key="download-pd" role="menuitem">
+            <li
+              key="download-pdf"
+              className="pf-v5-c-menu__list-item"
+              style={{ justifyContent: 'center', display: 'flex' }}
+              data-ouia-component-type="PF5/DropdownItem"
+              data-ouia-component-id="DownloadPDF"
+            >
               <SystemsPdf filters={pdfFilters} />
             </li>,
           ],


### PR DESCRIPTION
# Description

Associated Jira ticket: [RHINENG-13517](https://issues.redhat.com/browse/RHINENG-13517)

Makes spaces correct for PDF export button and corrects behavior of loading spinner & Disabled button


# How to test the PR

1. Open Advisor systems page
2. Click on export button
3. Observe PDF button spinner (placed in the center)
4. Observe PDF button has correct alignment
5. Observe "Loading..." is placed in the center when clicking on export PDF button 

# Before the change
![image](https://github.com/user-attachments/assets/49470be5-8a2d-41bc-8241-613c35fa1356)


# After the change
![image](https://github.com/user-attachments/assets/1d41340f-c8a6-4b1b-b765-f963c7653dde)


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
