### PR TITLE
Update sentry workflow to remove release var

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -9,7 +9,7 @@ on:
         default: 'master'
 
 jobs:
-  createSentryRelease:
+  uploadSourceMaps:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -17,14 +17,8 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit_hash }}
 
-      - name: Install dependencies
-        env:
-          SENTRY_RELEASE: advisor-${{ github.event.inputs.commit_hash }}
-        run: npm ci
-
       - name: Build
         env:
-          SENTRY_RELEASE: advisor-${{ github.event.inputs.commit_hash }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}


### PR DESCRIPTION
Adding this release variable is overriding the default behavior from chrome.