### PR TITLE
fix(sentry): Update Sentry Flow

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -1,12 +1,15 @@
-name: uploadSourceMaps
+name: sentryInit
 
 on:
+  push:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       commit_hash:
         description: 'The commit hash (or branch/tag) to build'
-        required: true
-        default: 'master'
+        required: false
+        default: ''
 
 jobs:
   createSentryRelease:
@@ -15,17 +18,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.commit_hash }}
+          ref: ${{ github.event.inputs.commit_hash || 'refs/heads/master' }}
 
       - name: Install dependencies
         env:
-          SENTRY_RELEASE: ${{ github.event.inputs.commit_hash }}
+          SENTRY_RELEASE: ${{ github.event.inputs.commit_hash || github.sha }}
         run: npm ci
 
       - name: Build
         env:
-          SENTRY_RELEASE: ${{ github.event.inputs.commit_hash }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_RELEASE: ${{ github.event.inputs.commit_hash || github.sha }}
+          SENTRY_AUTH_TOKEN: ${{ github.event.inputs.commit_hash && secrets.SENTRY_AUTH_TOKEN || 'null' }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-        run: npm run build --if-present
+        run: |
+          if [[ -z "${{ secrets.SENTRY_AUTH_TOKEN }}" ]]; then
+            echo "Building without SENTRY_AUTH_TOKEN"
+            npm run build --if-present
+          else
+            echo "Building with SENTRY_AUTH_TOKEN"
+            npm run build --if-present
+          fi

--- a/fec.config.js
+++ b/fec.config.js
@@ -8,33 +8,22 @@ module.exports = {
   proxyVerbose: false,
   devtool: 'hidden-source-map',
   plugins: [
-    ...(process.env.SENTRY_AUTH_TOKEN
-      ? [
-          sentryWebpackPlugin({
-            authToken: process.env.SENTRY_AUTH_TOKEN,
-            org: 'red-hat-it',
-            project: 'advisor-rhel',
-            moduleMetadata: ({ release }) => ({
-              dsn: 'https://f8eb44de949e487e853185c09340f3cf@o490301.ingest.us.sentry.io/4505397435367424',
-              release,
-              org: 'red-hat-it',
-              project: 'advisor-rhel',
-            }),
-          }),
-        ]
-      : [
-          // Justs injects the debug ids
-          sentryWebpackPlugin({
-            org: 'red-hat-it',
-            project: 'advisor-rhel',
-            moduleMetadata: ({ release }) => ({
-              dsn: 'https://f8eb44de949e487e853185c09340f3cf@o490301.ingest.us.sentry.io/4505397435367424',
-              release,
-              org: 'red-hat-it',
-              project: 'advisor-rhel',
-            }),
-          }),
-        ]),
+    //Sentry Plugin should be at the end
+    process.env.ENABLE_SENTRY && [
+      sentryWebpackPlugin({
+        ...(process.env.SENTRY_AUTH_TOKEN && {
+          authToken: process.env.SENTRY_AUTH_TOKEN,
+        }),
+        org: 'red-hat-it',
+        project: 'advisor-rhel',
+        moduleMetadata: ({ release }) => ({
+          dsn: `https://f8eb44de949e487e853185c09340f3cf@o490301.ingest.us.sentry.io/4505397435367424`,
+          org: 'red-hat-it',
+          project: 'advisor-rhel',
+          release,
+        }),
+      }),
+    ],
   ],
   moduleFederation: {
     shared: [


### PR DESCRIPTION
This also removes the issue where the plugin is initialized locally and sends up debugIDs for local env on every build
**Workflow Behavior:**

**Locally (without variables):**
The Sentry plugin won't build as SENTRY_AUTH_TOKEN is not defined.

**GitHub push to master (automatic trigger):**
The plugin won't include the authToken because commit_hash is not provided in push events.

**Manually triggered with commit_hash:**
The plugin includes the authToken and tracks the build with Sentry.