### PR TITLE
feat(RHINENG-13681): status filter to single select type & bump fec

### DIFF
--- a/cypress/rulestablesconsts.js
+++ b/cypress/rulestablesconsts.js
@@ -12,7 +12,7 @@ const CATEGORIES_MAP = {
   Stability: 3,
   Performance: 4,
 };
-const STATUS = ['All', 'Enabled', 'Disabled'];
+const STATUS = ['Enabled', 'Disabled', 'Red Hat Disabled'];
 const INCIDENT = { Incident: 'true', 'Non-incident': 'false' };
 const REMEDIATION = { 'Ansible playbook': true, Manual: false };
 const REBOOT = { Required: true, 'Not required': false };
@@ -109,10 +109,9 @@ const filtersConf = {
   status: {
     selectorText: 'Status',
     values: STATUS,
-    type: 'radio',
+    type: 'singleSelect',
     filterFunc: (it, value) => {
-      if (value === 'All') return true;
-      else return it.disabled === (value === 'Disabled');
+      return it.disabled === (value === 'Disabled');
     },
     urlParam: 'rule_status',
     urlValue: (it) => it.toLowerCase(),

--- a/cypress/utils/table.js
+++ b/cypress/utils/table.js
@@ -73,6 +73,14 @@ function cypressApplyFilters(filters, filtersConf) {
         .parent()
         .find('input[type=radio]')
         .check();
+    } else if (item.type === 'singleSelect') {
+      cy.get('[class*=pf-v5-c-menu-toggle][aria-label="Options menu"]').click();
+      cy.get('ul[class=pf-v5-c-menu__list]')
+        .find('span')
+        .contains(value)
+        .parent()
+        .parent()
+        .click();
     } else {
       throw `${item.type} not recognized`;
     }
@@ -98,17 +106,14 @@ function selectConditionalFilterOption(option) {
   cy.get(PT_CONDITIONAL_FILTER_LIST).contains(option).click();
 }
 
-function selectRandomEnabledRows({
-  rows,
-  numberOfRowsToSelect,
-}) {
-  const enabledRows = Array.from(rows).filter(row => {
+function selectRandomEnabledRows({ rows, numberOfRowsToSelect }) {
+  const enabledRows = Array.from(rows).filter((row) => {
     const checkbox = row.querySelector('input[type="checkbox"]');
-    if(!checkbox.hasAttribute('disabled')){
+    if (!checkbox.hasAttribute('disabled')) {
       return true;
     }
-  })
-  const rowCount = enabledRows.length
+  });
+  const rowCount = enabledRows.length;
 
   const randomIndices = [];
   while (randomIndices.length < numberOfRowsToSelect) {
@@ -118,9 +123,15 @@ function selectRandomEnabledRows({
     }
   }
 
-  randomIndices.forEach(index => {
+  randomIndices.forEach((index) => {
     enabledRows[index].querySelector('input[type="checkbox"]').click();
   });
 }
 
-export { checkSorting, cypressApplyFilters, cumulativeCombinations, selectRandomEnabledRows, selectConditionalFilterOption };
+export {
+  checkSorting,
+  cypressApplyFilters,
+  cumulativeCombinations,
+  selectRandomEnabledRows,
+  selectConditionalFilterOption,
+};

--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -18,22 +18,6 @@ objects:
         paths:
           - /apps/advisor
       image: ${IMAGE}:${IMAGE_TAG}
-      navItems:
-        - title: "Advisor"
-          expandable: true
-          routes:
-            - appId: "advisor"
-              title: "Recommendations"
-              href: "/insights/advisor/recommendations"
-              product: "Red Hat Insights"
-            - appId: "advisor"
-              title: "Systems"
-              href: "/insights/advisor/systems"
-              product: "Red Hat Insights"
-            - appId: "advisor"
-              title: "Topics"
-              href: "/insights/advisor/topics"
-              product: "Red Hat Insights"
       module:
         manifestLocation: "/apps/advisor/fed-mods.json"
         modules:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@patternfly/react-table": "^5.3.3",
         "@patternfly/react-tokens": "^5.1.2",
         "@react-pdf/renderer": "^3.4.4",
-        "@redhat-cloud-services/frontend-components": "^5.2.6",
+        "@redhat-cloud-services/frontend-components": "^5.2.7",
         "@redhat-cloud-services/frontend-components-advisor-components": "^2.0.16",
         "@redhat-cloud-services/frontend-components-charts": "3.2.6",
         "@redhat-cloud-services/frontend-components-config": "^6.4.5",
@@ -4376,9 +4376,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-5.2.6.tgz",
-      "integrity": "sha512-YhA6tQ5KlkVoRfkIzRXQa/cvhQ6sbe6jsYt3QrX8SwJ1ojq0ekqHZDbcaPxS3U34MXnsW6877bjyAya5se+2ug==",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-5.2.7.tgz",
+      "integrity": "sha512-RS6fB4N2R6HsFc/Xp5wi46xwvruiVAuYCSX8ZrGnxM/kl7Ze575zzf0eD+tCXfXXyVLBo7Tbbw8y2GcHvTZzVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-component-groups": "^5.5.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5180,6 +5180,7 @@
       "version": "2.88.12",
       "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
       "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -5209,6 +5210,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -5243,16 +5245,11 @@
         "react-router-dom": "^5.0.0 || ^6.0.0"
       }
     },
-    "node_modules/@redhat-cloud-services/frontend-components-charts/node_modules/@types/node": {
-      "version": "16.18.96",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.96.tgz",
-      "integrity": "sha512-84iSqGXoO+Ha16j8pRZ/L90vDMKX04QTYMTfYeE1WrjWaZXuchBehGUZEpNgx7JnmlrIHdnABmpjrQjhCnNldQ==",
-      "peer": true
-    },
     "node_modules/@redhat-cloud-services/frontend-components-charts/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5277,6 +5274,7 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/@redhat-cloud-services/frontend-components-charts/node_modules/buffer": {
@@ -5297,6 +5295,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
@@ -5307,6 +5306,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -5323,6 +5323,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5340,6 +5341,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5352,6 +5354,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/@redhat-cloud-services/frontend-components-charts/node_modules/cypress": {
@@ -5359,6 +5362,7 @@
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
       "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@cypress/request": "2.88.12",
@@ -5416,6 +5420,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 6"
@@ -5438,27 +5443,17 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-charts/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "peer": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-charts/node_modules/qs": {
       "version": "6.10.4",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
       "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
+      "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
         "side-channel": "^1.0.4"
@@ -5471,13 +5466,11 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-charts/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
       "peer": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5489,6 +5482,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5499,12 +5493,6 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-charts/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "peer": true
     },
     "node_modules/@redhat-cloud-services/frontend-components-config": {
       "version": "6.4.5",
@@ -5734,13 +5722,14 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config/node_modules/@swc/helpers": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.11.tgz",
-      "integrity": "sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config/node_modules/@types/retry": {
@@ -7905,10 +7894,11 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.1.0.tgz",
-      "integrity": "sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -7929,6 +7919,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -7945,6 +7936,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -7962,6 +7954,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -7975,6 +7968,7 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/@testing-library/dom/node_modules/has-flag": {
@@ -7982,6 +7976,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -7992,6 +7987,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -8172,6 +8168,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/@types/babel__core": {
@@ -8484,9 +8481,10 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
+      "version": "16.18.126",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "license": "MIT"
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.11",
@@ -8531,9 +8529,10 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.18.tgz",
       "integrity": "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==",
       "devOptional": true,
+      "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "@types/react": "*"
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/retry": {
@@ -12685,6 +12684,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/dom-converter": {
@@ -19718,6 +19718,7 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
@@ -22279,6 +22280,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
@@ -22294,6 +22296,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -22307,6 +22310,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/process": {
@@ -25050,6 +25054,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/tiny-inflate": {
@@ -25410,9 +25415,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -25803,9 +25808,10 @@
       }
     },
     "node_modules/unleash-proxy-client": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-3.4.0.tgz",
-      "integrity": "sha512-ivCzm//z+S2T3gSBSZY7HN+5GfoLXZIovMyH6lIZRe2/vCicEdXtXD6cnLTQ2LAiXGV7DpoSM1m8WZGoiLRzkw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-3.7.3.tgz",
+      "integrity": "sha512-Cd7ovrhAIpwveNFdtpzs7HO0WeArC2fbjIVGL2Cjza8bHD+jJ1JbSuy3tFuKvvUkbVKq/EGV0RgosEa/3UVLgg==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "tiny-emitter": "^2.1.0",
@@ -25820,6 +25826,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@patternfly/react-table": "^5.3.3",
     "@patternfly/react-tokens": "^5.1.2",
     "@react-pdf/renderer": "^3.4.4",
-    "@redhat-cloud-services/frontend-components": "^5.2.6",
+    "@redhat-cloud-services/frontend-components": "^5.2.7",
     "@redhat-cloud-services/frontend-components-advisor-components": "^2.0.16",
     "@redhat-cloud-services/frontend-components-charts": "3.2.6",
     "@redhat-cloud-services/frontend-components-config": "^6.4.5",

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -335,14 +335,10 @@ export const FILTER_CATEGORIES = {
     ],
   },
   rule_status: {
-    type: conditionalFilterType.radio,
+    type: conditionalFilterType.singleSelect,
     title: 'status',
     urlParam: 'rule_status',
     values: [
-      {
-        label: intlHelper(intl.formatMessage(messages.all), intlSettings),
-        value: 'all',
-      },
       {
         label: intlHelper(intl.formatMessage(messages.enabled), intlSettings),
         value: 'enabled',

--- a/src/PresentationalComponents/PathwaysTable/PathwaysTable.js
+++ b/src/PresentationalComponents/PathwaysTable/PathwaysTable.js
@@ -246,7 +246,6 @@ const PathwaysTable = ({ isTabActive }) => {
       id: FC.category.urlParam,
       value: `checkbox-${FC.category.urlParam}`,
       filterValues: {
-        key: `${FC.category.urlParam}-filter`,
         onChange: (_event, values) =>
           addFilterParam(FC.category.urlParam, values),
         value: filters.category,
@@ -259,7 +258,6 @@ const PathwaysTable = ({ isTabActive }) => {
       id: PFC.has_incident.urlParam,
       value: `checkbox-${PFC.has_incident.urlParam}`,
       filterValues: {
-        key: `${PFC.has_incident.urlParam}-filter`,
         onChange: (_event, values) =>
           addFilterParam(PFC.has_incident.urlParam, values),
         value: filters.has_incident,
@@ -272,7 +270,6 @@ const PathwaysTable = ({ isTabActive }) => {
       id: PFC.reboot_required.urlParam,
       value: `checkbox-${PFC.reboot_required.urlParam}`,
       filterValues: {
-        key: `${PFC.reboot_required.urlParam}-filter`,
         onChange: (_event, values) =>
           addFilterParam(PFC.reboot_required.urlParam, values),
         value: filters.reboot_required,

--- a/src/PresentationalComponents/RulesTable/RulesTable.cy.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.cy.js
@@ -321,6 +321,12 @@ describe('making request based on filters', () => {
         ...fixtures,
       },
     }).as('rule_status=all');
+    cy.intercept('**rule_status=disabled**', {
+      statusCode: 201,
+      body: {
+        ...fixtures,
+      },
+    }).as('rule_status=disabled');
     cy.intercept('**has_playbook=true**', {
       statusCode: 201,
       body: {
@@ -333,19 +339,20 @@ describe('making request based on filters', () => {
   Object.entries(filtersConf).forEach(([key, config]) => {
     const { urlParam, values, urlValue, selectorText } = config;
 
-    it(`apply ${selectorText} filter`, () => {
+    it.only(`apply ${selectorText} filter`, () => {
       removeAllChips();
       cy.get('button').contains('Reset filters').click();
       if (selectorText === 'Systems impacted') {
         cy.wait(['@call']);
         cy.wait(['@call']);
-      }
-      if (selectorText !== 'Systems impacted') {
-        filterApply({ [key]: values[0] });
+      } else {
+        // Status = Enabled is a default value, so testing the second value instead
+        const testValue = selectorText !== 'Status' ? values[0] : values[1];
+        filterApply({ [key]: testValue });
         cy.wait(['@call']);
-        cy.wait([`@${urlParam}=${urlValue(values[0])}`])
+        cy.wait([`@${urlParam}=${urlValue(testValue)}`])
           .its('request.url')
-          .should('include', `${urlParam}=${urlValue(values[0])}`);
+          .should('include', `${urlParam}=${urlValue(testValue)}`);
       }
     });
   });

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -322,9 +322,9 @@ export const filterConfigItems = (
     },
     {
       label: FC.rule_status.title,
-      type: conditionalFilterType.radio,
+      type: FC.rule_status.type,
       id: FC.rule_status.urlParam,
-      value: `radio-${FC.rule_status.urlParam}`,
+      value: `single_select-${FC.rule_status.urlParam}`,
       filterValues: {
         onChange: (_event, value) => toggleRulesDisabled(value),
         value: `${filters.rule_status}`,

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -230,7 +230,6 @@ export const filterConfigItems = (
       id: FC.total_risk.urlParam,
       value: `checkbox-${FC.total_risk.urlParam}`,
       filterValues: {
-        key: `${FC.total_risk.urlParam}-filter`,
         onChange: (_event, values) =>
           addFilterParam(FC.total_risk.urlParam, values),
         value: filters.total_risk,
@@ -243,7 +242,6 @@ export const filterConfigItems = (
       id: FC.res_risk.urlParam,
       value: `checkbox-${FC.res_risk.urlParam}`,
       filterValues: {
-        key: `${FC.res_risk.urlParam}-filter`,
         onChange: (_event, values) =>
           addFilterParam(FC.res_risk.urlParam, values),
         value: filters.res_risk,
@@ -256,7 +254,6 @@ export const filterConfigItems = (
       id: FC.impact.urlParam,
       value: `checkbox-${FC.impact.urlParam}`,
       filterValues: {
-        key: `${FC.impact.urlParam}-filter`,
         onChange: (_event, values) =>
           addFilterParam(FC.impact.urlParam, values),
         value: filters.impact,
@@ -269,7 +266,6 @@ export const filterConfigItems = (
       id: FC.likelihood.urlParam,
       value: `checkbox-${FC.likelihood.urlParam}`,
       filterValues: {
-        key: `${FC.likelihood.urlParam}-filter`,
         onChange: (_event, values) =>
           addFilterParam(FC.likelihood.urlParam, values),
         value: filters.likelihood,
@@ -282,7 +278,6 @@ export const filterConfigItems = (
       id: FC.category.urlParam,
       value: `checkbox-${FC.category.urlParam}`,
       filterValues: {
-        key: `${FC.category.urlParam}-filter`,
         onChange: (_event, values) =>
           addFilterParam(FC.category.urlParam, values),
         value: filters.category,
@@ -295,7 +290,6 @@ export const filterConfigItems = (
       id: FC.incident.urlParam,
       value: `checkbox-${FC.incident.urlParam}`,
       filterValues: {
-        key: `${FC.incident.urlParam}-filter`,
         onChange: (_event, values) =>
           addFilterParam(FC.incident.urlParam, values),
         value: filters.incident,
@@ -308,7 +302,6 @@ export const filterConfigItems = (
       id: FC.has_playbook.urlParam,
       value: `checkbox-${FC.has_playbook.urlParam}`,
       filterValues: {
-        key: `${FC.has_playbook.urlParam}-filter`,
         onChange: (_event, values) =>
           addFilterParam(FC.has_playbook.urlParam, values),
         value: filters.has_playbook,
@@ -321,7 +314,6 @@ export const filterConfigItems = (
       id: FC.reboot.urlParam,
       value: `checkbox-${FC.reboot.urlParam}`,
       filterValues: {
-        key: `${FC.reboot.urlParam}-filter`,
         onChange: (_event, values) =>
           addFilterParam(FC.reboot.urlParam, values),
         value: filters.reboot,
@@ -334,7 +326,6 @@ export const filterConfigItems = (
       id: FC.rule_status.urlParam,
       value: `radio-${FC.rule_status.urlParam}`,
       filterValues: {
-        key: `${FC.rule_status.urlParam}-filter`,
         onChange: (_event, value) => toggleRulesDisabled(value),
         value: `${filters.rule_status}`,
         items: FC.rule_status.values,

--- a/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
+++ b/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
@@ -39,7 +39,7 @@ const HybridInventory = ({
   ) : (
     <AsynComponent
       key="hybridInventory"
-      appName="inventory"
+      scope="inventory"
       module="./HybridInventoryTabs"
       ConventionalSystemsTab={
         <Suspense

--- a/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
+++ b/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.js
@@ -101,7 +101,7 @@ const ImmutableDevices = ({
 
   return (
     <AsynComponent
-      appName="inventory"
+      scope="inventory"
       module="./ImmutableDevices"
       fallback={<div />}
       store={store}

--- a/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.test.js
+++ b/src/SmartComponents/HybridInventoryTabs/ImmutableDevices.test.js
@@ -72,7 +72,7 @@ describe('ImmutableDevices', () => {
 
     expect(AsynComponent).toHaveBeenCalledWith(
       expect.objectContaining({
-        appName: 'inventory',
+        scope: 'inventory',
         module: './ImmutableDevices',
       }),
       {}
@@ -84,7 +84,7 @@ describe('ImmutableDevices', () => {
 
     expect(AsynComponent).toHaveBeenCalledWith(
       expect.objectContaining({
-        appName: 'inventory',
+        scope: 'inventory',
         module: './ImmutableDevices',
       }),
       {}

--- a/src/ZeroStateWrapper.js
+++ b/src/ZeroStateWrapper.js
@@ -80,7 +80,6 @@ export const ZeroStateWrapper = ({ children }) => {
         >
           <AsynComponent
             appId={'advisor_zero_state'}
-            appName="dashboard"
             module="./AppZeroState"
             scope="dashboard"
             ErrorComponent={<ErrorState />}


### PR DESCRIPTION
# Description

FEC packages had to be updated

Associated Jira ticket: [RHINENG-13681](https://issues.redhat.com/browse/RHINENG-13681)

Change Status filter to use new "Single select" filter type instead of radio selection

Keys had to be removed as part of the package upgrade

# How to test the PR

FEC packages were upgraded, so go through the app to see if anything broke
eg I had to remove `key`s from filters so the filters would work

### 1. Advisor > Recommendations 
Select the Status filter, and open the "Filter by status" filter dropdown. 
New filter type as shown below should be visible

### 2. Advisor > Topics > Topic detail
Select the Status filter, and open the "Filter by status" filter dropdown. 
New filter type as shown below should be visible

# Before
![image](https://github.com/user-attachments/assets/d0960eb8-0e45-43ab-827a-aa0e52830131)

# After
![image](https://github.com/user-attachments/assets/515e1075-516b-4f76-afa3-f43d3c5dd3e3)

# Dependent work link

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
