### PR TITLE
Fix cypress test collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,11 +19,8 @@ yarn-debug.log*
 yarn-error.log*
 
 .DS_Store
-*coverage
 .nyc_output
-codecov*
 .git/
-jest-coverage/*
 
 mockData/
 
@@ -34,6 +31,10 @@ sitemap.xml
 cypress/downloads
 cypress/screenshots
 cypress/videos
+
+codecov
+coverage/*
+coverage-*
 
 # Sentry Config File
 .env.sentry-build-plugin

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ cypress/downloads
 cypress/screenshots
 cypress/videos
 
-codecov
+coverage
 coverage/*
 coverage-*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ jobs:
     - stage: Lint
       script: npm run lint
     - stage: Test
-      script: npm run test && npm run test:ct
-      after_success: npm run coverage
+      script: npm run travis:verify
+    - stage: Build
+      script: npm run build
 env:
   global:
     - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}

--- a/config/cypress.webpack.config.js
+++ b/config/cypress.webpack.config.js
@@ -35,4 +35,15 @@ webpackConfig.module.rules.push({
 module.exports = {
   ...webpackConfig,
   plugins,
+  module: {
+    ...webpackConfig.module,
+    rules: [
+      ...webpackConfig.module.rules,
+      {
+        test: /\.(?:js|mjs|cjs)$/,
+        exclude: /(node_modules|bower_components)/i,
+        use: ['babel-loader'],
+      },
+    ],
+  },
 };

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,18 +1,62 @@
-#!/bin/sh -ex
+#!/bin/bash
+#
+# Merges coverage reports from cypress and jest tests
+# and generates an HTML report to view and json report to submit to codecov
+#
+# For jest coverage to be collected and submitted correctly
+#  * Ensure the *coverageDirectory* is set to "coverage-jest" in packages.json
+#  * Ensure there is a npm "test" script
+#
+# For cypress collection to work correctly
+#  * Ensure "babel" (and dependencies) are at the latest (possible) version (aligned with frontend-components preferably)
+#  * Ensure the babel "istanbul" plugin is included and configured in babel.config.js
+#  * Ensure "nyc" is configuerd to output to "coverage-cypress"
+#  * Ensure there is a npm "test:ct" script
+#
+case $(uname) in
+Darwin)
+	export CODECOV_BIN="https://uploader.codecov.io/latest/macos/codecov"
+	;;
+Linux)
+	export CODECOV_BIN="https://uploader.codecov.io/latest/linux/codecov"
+	;;
+esac
 
-# Merge coverage reports from cypress and jest tests
-mkdir -p reports
-cp cypress-coverage/coverage-final.json reports/from-cypress.json
-cp jest-coverage/coverage-final.json reports/from-jest.json
+rm -rf ./nyc_output
+rm -rf ./coverage-jest
+rm -rf ./coverage-cypress
+rm -rf ./coverage
 
-npx nyc merge reports .nyc_output/out.json
-npx nyc report --reporter json --report-dir coverage
+mkdir -p coverage/src
+npm run test
+cp ./coverage-jest/coverage-final.json ./coverage/src/jest.json
 
-# Upload the final coverage report to codecov https://docs.codecov.com/docs/codecov-uploader
-curl -Os https://uploader.codecov.io/latest/linux/codecov
-chmod +x codecov
+if [ -f cypress.config.js ]; then
+	npm run test:ct
+	cp ./coverage-cypress/coverage-final.json ./coverage/src/cypress.json
+else
+	echo "No cypress config found!"
+fi
 
-# Workaround for https://github.com/codecov/uploader/issues/475
-unset NODE_OPTIONS
+npx nyc merge ./coverage/src ./coverage/coverage-final.json
+npx nyc report -t ./coverage --reporter html --report-dir ./coverage/html
 
-./codecov -t ${CODECOV_TOKEN} -f "coverage/coverage-final.json"
+if [ -z "${TRAVIS}" ]; then
+	echo "Not on travis..."
+else
+	# Workaround for https://github.com/codecov/uploader/issues/475
+	unset NODE_OPTIONS
+	echo "Downloading codecov binary from $CODECOV_BIN"
+
+	curl -Os "$CODECOV_BIN"
+	chmod +x codecov
+
+	echo "Uploading to codecov"
+
+	./codecov --verbose -F "combined" -t "$CODECOV_TOKEN" -f ./coverage/coverage-final.json
+	./codecov --verbose -F "jest" -t "$CODECOV_TOKEN" -f ./coverage-jest/coverage-final.json
+
+	if [ -f cypress.config.js ]; then
+		./codecov --verbose -F "cypress" -t "$CODECOV_TOKEN" -f ./coverage-cypress/coverage-final.json
+	fi
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "axios": "^1.7.4",
         "babel-eslint": "10.1.0",
         "babel-jest": "^29.7.0",
+        "babel-loader": "^9.2.1",
         "babel-plugin-istanbul": "^7.0.0",
         "babel-plugin-lodash": "3.3.4",
         "cypress": "^13.10.0",
@@ -9935,7 +9936,6 @@
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-9.2.1.tgz",
       "integrity": "sha512-fqe8naHt46e0yIdkjUZYqddSXfej3AHajX+CSO5X7oy0EmPc6o5Xh+RClNoHjnieWz9AW4kZxW9yyFMhVB1QLA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "find-cache-dir": "^4.0.0",
         "schema-utils": "^4.0.0"
@@ -9953,7 +9953,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9970,7 +9969,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -9982,15 +9980,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/babel-loader/node_modules/schema-utils": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
       "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -11034,8 +11030,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
       "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/common-tags": {
       "version": "1.8.2",
@@ -14110,7 +14105,6 @@
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-4.0.0.tgz",
       "integrity": "sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "common-path-prefix": "^3.0.0",
         "pkg-dir": "^7.0.0"
@@ -14127,7 +14121,6 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
       "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "locate-path": "^7.1.0",
         "path-exists": "^5.0.0"
@@ -19469,7 +19462,6 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
       "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "p-locate": "^6.0.0"
       },
@@ -21618,7 +21610,6 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
       "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "p-limit": "^4.0.0"
       },
@@ -21634,7 +21625,6 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
       "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -21650,7 +21640,6 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
       "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -21828,7 +21817,6 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
       "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -21987,7 +21975,6 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
       "integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "find-up": "^6.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:coverage": "./coverage.sh",
     "test:jest": "TZ=UTC jest --verbose --passWithNoTests --env=jsdom",
     "test:local": "TZ=UTC jest --verbose --collectCoverage=false --passWithNoTests --env=jsdom",
-    "test:ct": "BABEL_ENV=component cypress run --component",
+    "test:ct": "BABEL_ENV=componentTest cypress run --component",
     "test:openct": "cypress open --component",
     "translations": "npm-run-all translations:*",
     "translations:extract": "npx formatjs extract ./src/*.js --out-file ./build/messages/src/Messages.json",

--- a/package.json
+++ b/package.json
@@ -15,31 +15,30 @@
     "lint:js:fix": "eslint config src --fix",
     "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
     "nightly": "npm run travis:verify",
+    "postinstall": "ts-patch install",
     "server:ctr": "node src/server/generateServerKey.js",
     "start": "fec dev",
     "start:proxy": "PROXY=true fec dev",
     "static": "fec static",
-    "test": "npm run test:jest",
-    "test:local": "TZ=UTC jest --verbose --collectCoverage=false --passWithNoTests --env=jsdom",
+    "test": "jest --passWithNoTests",
+    "test:coverage": "./coverage.sh",
     "test:jest": "TZ=UTC jest --verbose --passWithNoTests --env=jsdom",
+    "test:local": "TZ=UTC jest --verbose --collectCoverage=false --passWithNoTests --env=jsdom",
     "test:ct": "BABEL_ENV=component cypress run --component",
     "test:openct": "cypress open --component",
     "translations": "npm-run-all translations:*",
     "translations:extract": "npx formatjs extract ./src/*.js --out-file ./build/messages/src/Messages.json",
     "translations:compile": "npx formatjs compile ./build/messages/src/Messages.json --out-file ./locales/translations.json",
-    "travis:verify": "npm-run-all build lint test",
+    "travis:verify": "npm run test:coverage",
     "verify": "npm-run-all build lint test",
-    "verify:local": "npm-run-all build lint test:local test:ct",
-    "coverage:clean": "rm -rf .nyc_output coverage reports",
-    "coverage": "bash coverage.sh && npm run coverage:clean",
-    "postinstall": "ts-patch install"
+    "verify:local": "npm-run-all build lint test:local test:ct"
   },
   "sassIncludes": {
     "patternfly": "node_modules/patternfly/dist/sass"
   },
   "jest": {
     "testEnvironment": "jsdom",
-    "coverageDirectory": "./jest-coverage",
+    "coverageDirectory": "coverage-jest",
     "collectCoverage": true,
     "collectCoverageFrom": [
       "!src/**/stories/*",
@@ -118,6 +117,7 @@
     "axios": "^1.7.4",
     "babel-eslint": "10.1.0",
     "babel-jest": "^29.7.0",
+    "babel-loader": "^9.2.1",
     "babel-plugin-istanbul": "^7.0.0",
     "babel-plugin-lodash": "3.3.4",
     "cypress": "^13.10.0",
@@ -146,9 +146,9 @@
     "appname": "advisor"
   },
   "nyc": {
-    "report-dir": "cypress-coverage",
+    "report-dir": "coverage-cypress",
     "include": [
-      "src/**/*"
+      "src/**/*.{js,jsx}"
     ],
     "exclude": [
       "src/**/*.spec.ct.js",


### PR DESCRIPTION
Fix code coverage scripts and collection so that we have a cypress report generated for codecov.

Review steps:
- npm i
- npm run travis:verify
- check that the coverage-cypress/lcov.info is not empty
- check that the coverage-jest/lcov.info is not empty
- check that .nyc_output/out.json is not empty