### PR TITLE
feat(RHINENG-3020): Update Exec Report Template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5555,10 +5555,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config-utilities": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-4.1.4.tgz",
-      "integrity": "sha512-J0/4xPzEXtCxwvRQ5P20v/dGUjD7/I1ORr33gTSp/kK8bMHHz9rbzgUdJvNvWCZCA6KmgtV9g4yWISlSopbAcg==",
-      "license": "Apache-2.0",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-4.1.6.tgz",
+      "integrity": "sha512-cO9ssCR9lpbT4PuPPwD5Ug96O/d0FyA5lPuouWUxwwdHr+DeZU8ejeCW/PaslHwv/9hfEkbckEcRn9lk0Q8lhw==",
       "dependencies": {
         "@openshift/dynamic-plugin-sdk-webpack": "^4.0.1",
         "ajv": "^8.17.1",

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -41,6 +41,41 @@ export const SEVERITY_MAP = {
   'medium-risk': 2,
   'low-risk': 1,
 };
+export const SEVERITY = 'Severity';
+export const TOTAL_RISK_CONSTANTS = {
+  LOW: 'Low',
+  MODERATE: 'Moderate',
+  IMPORTANT: 'Important',
+  CRITICAL: 'Critical',
+};
+export const CATEGORY_CONSTANTS = {
+  AVAILABILITY: 'Availability',
+  PERFORMANCE: 'Performance',
+  STABILITY: 'Stability',
+  SECURITY: 'Security',
+};
+export const POUND_OF_RECS = '# of recommendations';
+export const REC_NUM_AND_PERCENTAGE = (count, total) =>
+  `${count} (${total}% of total)`;
+export const CATEGORY = 'Category';
+export const CATEGORY_HEADER =
+  'Recently identified recommendations by category';
+export const TOP_THREE_RULES_HEADER =
+  'Top 3 recommendations in your infrastructure';
+export const INSIGHTS_HEADER = 'Advisor';
+export const EXEC_REPORT_HEADER = (systems, risks) =>
+  `This report is an executive summary of recommendations that may impact your Red Hat Enterprise Linux servers. Red Hat Advisor service is analyzing ${systems} and has identified ${risks} that impact 1 or more of these systems.`;
+export const EXEC_REPORT_HEADER_SYSTEMS = (systemsCount) => {
+  const sys = systemsCount <= 1 ? 'system' : 'systems';
+  return `${systemsCount} RHEL ${sys}`;
+};
+export const EXEC_REPORT_HEADER_RISKS = (risksCount) => {
+  const risk = risksCount <= 1 ? 'Risk' : 'Risks';
+  return `${risksCount} ${risk}`;
+};
+export const SEVERITY_HEADER = 'Identified recommendations by severity';
+export const SYSTEMS_EXPOSED = 'Systems exposed';
+export const TOTAL_RISK = 'Total risk';
 
 // Recommendations OverviewDashbarCards titles
 export const PATHWAYS = 'Pathways';

--- a/src/PresentationalComponents/ExecutiveReport/BuildExecReport.js
+++ b/src/PresentationalComponents/ExecutiveReport/BuildExecReport.js
@@ -51,7 +51,6 @@ const BuildExecReport = ({
   topActiveRec,
   intl,
 }) => {
-  console.log('here test');
   const calcPercent = (value, total) =>
     Math.round(Number((value / total) * 100));
   const severityPie = [

--- a/src/PresentationalComponents/ExecutiveReport/Download.js
+++ b/src/PresentationalComponents/ExecutiveReport/Download.js
@@ -2,6 +2,7 @@
 import './_Download.scss';
 import PropTypes from 'prop-types';
 import {
+  INSIGHTS_HEADER,
   RULES_FETCH_URL,
   STATS_REPORTS_FETCH_URL,
   STATS_SYSTEMS_FETCH_URL,
@@ -80,7 +81,7 @@ const DownloadExecReport = ({ isDisabled }) => {
         isAriaDisabled: isDisabled,
         ...(loading ? { isDisabled: true } : null),
       }}
-      type={intl.formatMessage(messages.insightsHeader)}
+      type={INSIGHTS_HEADER}
       fileName={`Advisor-Executive-Report--${new Date()
         .toUTCString()
         .replace(/ /g, '-')}.pdf`}

--- a/src/PresentationalComponents/ExecutiveReport/NewBuildExecReport.js
+++ b/src/PresentationalComponents/ExecutiveReport/NewBuildExecReport.js
@@ -1,60 +1,232 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-
-import { RULES_FETCH_URL } from '../../AppConstants';
+import React from 'react';
+import {
+  CATEGORY,
+  CATEGORY_CONSTANTS,
+  CATEGORY_HEADER,
+  EXEC_REPORT_HEADER,
+  EXEC_REPORT_HEADER_RISKS,
+  EXEC_REPORT_HEADER_SYSTEMS,
+  INSIGHTS_HEADER,
+  REC_NUM_AND_PERCENTAGE,
+  RULES_FETCH_URL,
+  SEVERITY,
+  SEVERITY_HEADER,
+  STATS_SYSTEMS_FETCH_URL,
+  STATS_REPORTS_FETCH_URL,
+  SYSTEMS_EXPOSED,
+  TOP_THREE_RULES_HEADER,
+  TOTAL_RISK,
+  TOTAL_RISK_CONSTANTS,
+  TOTAL_RISK_LABEL,
+} from '../../AppConstants';
+import { truncate } from 'lodash';
+import { Text } from '@react-pdf/renderer';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import chart_color_red_100 from '@patternfly/react-tokens/dist/js/chart_color_red_100';
+import { InsightsLabel } from '@redhat-cloud-services/frontend-components/InsightsLabel';
+import global_Color_dark_200 from '@patternfly/react-tokens/dist/js/global_Color_dark_200';
+import RecommendationCharts from './RecommendationCharts';
 
 /**
- * @type {FetchData}
+ * fetchData must remain in the same file as the template per pdf-generator
  */
 export const fetchData = async (createAsyncRequest) => {
   const statsReports = createAsyncRequest('advisor-backend', {
     method: 'GET',
-    url: RULES_FETCH_URL,
+    url: STATS_REPORTS_FETCH_URL,
+  });
+  const statsSystems = createAsyncRequest('advisor-backend', {
+    method: 'GET',
+    url: STATS_SYSTEMS_FETCH_URL,
   });
 
-  const data = await Promise.all([statsReports]);
+  const topActiveRec = createAsyncRequest('advisor-backend', {
+    method: 'GET',
+    url: RULES_FETCH_URL,
+    params: {
+      limit: 3,
+      sort: '-total_risk,-impacted_count',
+      impacting: true,
+    },
+  });
 
+  const data = await Promise.all([statsReports, statsSystems, topActiveRec]);
   return data;
 };
 
 const NewBuildExecReport = ({ asyncData }) => {
-  const { data } = asyncData;
+  const [statsReports, statsSystems, topActiveRec] = asyncData.data;
+  const calcPercent = (value, total) =>
+    Math.round(Number((value / total) * 100));
+  const severityPie = [
+    {
+      x: TOTAL_RISK_CONSTANTS.CRITICAL,
+      y: calcPercent(statsReports.total_risk[4], statsReports.total),
+    },
+    {
+      x: TOTAL_RISK_CONSTANTS.IMPORTANT,
+      y: calcPercent(statsReports.total_risk[3], statsReports.total),
+    },
+    {
+      x: TOTAL_RISK_CONSTANTS.MODERATE,
+      y: calcPercent(statsReports.total_risk[2], statsReports.total),
+    },
+    {
+      x: TOTAL_RISK_CONSTANTS.LOW,
+      y: calcPercent(statsReports.total_risk[1], statsReports.total),
+    },
+  ];
+
+  const severityLegend = [
+    {
+      name: `${TOTAL_RISK_CONSTANTS.CRITICAL}`,
+    },
+    {
+      name: `${TOTAL_RISK_CONSTANTS.IMPORTANT}`,
+    },
+    {
+      name: `${TOTAL_RISK_CONSTANTS.MODERATE}`,
+    },
+    {
+      name: `${TOTAL_RISK_CONSTANTS.LOW}`,
+    },
+  ];
+
+  const severityRows = Object.entries(statsReports.total_risk)
+    .map(([key, value]) => [
+      TOTAL_RISK_LABEL[key].props.children,
+      REC_NUM_AND_PERCENTAGE(value, calcPercent(value, statsReports.total)),
+    ])
+    .reverse();
+
+  const categoryPie = [
+    {
+      x: CATEGORY_CONSTANTS.AVAILABILITY,
+      y: calcPercent(statsReports.category.Availability, statsReports.total),
+    },
+    {
+      x: CATEGORY_CONSTANTS.PERFORMANCE,
+      y: calcPercent(statsReports.category.Performance, statsReports.total),
+    },
+    {
+      x: CATEGORY_CONSTANTS.SECURITY,
+      y: calcPercent(statsReports.category.Security, statsReports.total),
+    },
+    {
+      x: CATEGORY_CONSTANTS.STABILITY,
+      y: calcPercent(statsReports.category.Stability, statsReports.total),
+    },
+  ];
+
+  const categoryLegend = [
+    {
+      name: `${CATEGORY_CONSTANTS.AVAILABILITY}`,
+    },
+    {
+      name: `${CATEGORY_CONSTANTS.PERFORMANCE}`,
+    },
+    {
+      name: `${CATEGORY_CONSTANTS.SECURITY}`,
+    },
+    {
+      name: `${CATEGORY_CONSTANTS.STABILITY}`,
+    },
+  ];
+
+  const categoryRows = Object.entries(statsReports.category).map(
+    ([key, value]) => [
+      key,
+      REC_NUM_AND_PERCENTAGE(value, calcPercent(value, statsReports.total)),
+    ]
+  );
+
+  const rulesDesc = (rule) => (
+    <Text>
+      <Text style={{ fontWeight: 700 }}> {rule.description}</Text>&nbsp;
+      {truncate(rule.summary, { length: 280 })}
+    </Text>
+  );
 
   return (
-    <>
-      <Table aria-label="Simple Table" variant="compact">
-        <Thead>
-          <Tr>
-            <Th>System</Th>
-            <Th>Report</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {data
-            ? data.map((row, index) => (
-                <Tr key={index}>
-                  <Td>{row[0].description}</Td>
-                  <Td>{row[1].description}</Td>
-                </Tr>
-              ))
-            : 'No data, this is a test'}
-        </Tbody>
-      </Table>
-    </>
+    <div
+      style={{ paddingTop: '24px', paddingLeft: '32px', paddingRight: '32px' }}
+    >
+      <span style={{ fontSize: '24px', color: chart_color_red_100.value }}>
+        Red Hat Insights
+      </span>
+      <br />
+      <span style={{ fontSize: '32px', color: chart_color_red_100.value }}>
+        {`Executive report: ${INSIGHTS_HEADER}`}
+      </span>
+      <br />
+      <Text style={{ fontSize: '12px' }}>
+        {EXEC_REPORT_HEADER(
+          EXEC_REPORT_HEADER_SYSTEMS(statsSystems.total),
+          EXEC_REPORT_HEADER_RISKS(statsReports.total)
+        )}
+      </Text>
+      <br />
+      <br />
+      <RecommendationCharts
+        columnHeader={SEVERITY}
+        header={SEVERITY_HEADER}
+        pieChart={severityPie}
+        pieLegend={severityLegend}
+        rows={severityRows}
+      />
+      <RecommendationCharts
+        columnHeader={CATEGORY}
+        header={CATEGORY_HEADER}
+        pieChart={categoryPie}
+        pieLegend={categoryLegend}
+        rows={categoryRows}
+      />
+      <Text style={{ color: chart_color_red_100.value }}>
+        {TOP_THREE_RULES_HEADER}
+      </Text>
+      {topActiveRec.data.map((rule, key) => (
+        <Flex style={{ paddingTop: '24px' }} key={key}>
+          <Flex direction={{ default: 'column' }}>
+            <FlexItem
+              style={{
+                fontSize: '12px',
+                color: global_Color_dark_200.value,
+              }}
+            >
+              {SYSTEMS_EXPOSED}
+            </FlexItem>
+            <FlexItem style={{ fontSize: '32px' }}>
+              {rule.impacted_systems_count}
+            </FlexItem>
+          </Flex>
+          <Flex direction={{ default: 'column' }}>
+            <FlexItem
+              style={{
+                fontSize: '12px',
+                color: global_Color_dark_200.value,
+              }}
+            >
+              {TOTAL_RISK}
+            </FlexItem>
+            <FlexItem style={{ paddingTop: '8px' }}>
+              <InsightsLabel value={rule.total_risk} />
+            </FlexItem>
+          </Flex>
+          <Flex
+            flex={{ default: 'flex_1' }}
+            alignSelf={{ default: 'alignSelfStretch' }}
+          >
+            <FlexItem style={{ fontSize: '12px' }}>{rulesDesc(rule)}</FlexItem>
+          </Flex>
+        </Flex>
+      ))}
+    </div>
   );
 };
 
 NewBuildExecReport.propTypes = {
-  asyncData: PropTypes.shape({
-    data: PropTypes.arrayOf(
-      PropTypes.arrayOf(
-        PropTypes.shape({
-          description: PropTypes.string.isRequired,
-        })
-      )
-    ),
-  }).isRequired,
+  asyncData: PropTypes.object,
 };
 
 export default NewBuildExecReport;

--- a/src/PresentationalComponents/ExecutiveReport/NewDownload.js
+++ b/src/PresentationalComponents/ExecutiveReport/NewDownload.js
@@ -13,7 +13,6 @@ import { exportNotifications } from '../../AppConstants';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const NewDownloadExecReport = ({ isDisabled }) => {
-  console.log('new test');
   const intl = useIntl();
   const dispatch = useDispatch();
   const { requestPdf } = useChrome();
@@ -34,7 +33,7 @@ const NewDownloadExecReport = ({ isDisabled }) => {
           module: './NewBuildExecReport',
           fetchDataParams: {
             limit: 3,
-            sort: '-total_risk, -impacted_count',
+            sort: '-total_risk,-impacted_count',
             impacting: true,
           },
         },

--- a/src/PresentationalComponents/ExecutiveReport/RecommendationCharts.js
+++ b/src/PresentationalComponents/ExecutiveReport/RecommendationCharts.js
@@ -1,0 +1,80 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { POUND_OF_RECS } from '../../AppConstants';
+import { Text } from '@react-pdf/renderer';
+import { ChartPie } from '@patternfly/react-charts';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import chart_color_red_100 from '@patternfly/react-tokens/dist/js/chart_color_red_100';
+import global_BackgroundColor_150 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_150';
+
+const RecommendationCharts = ({
+  columnHeader,
+  header,
+  pieChart,
+  pieLegend,
+  rows,
+}) => {
+  return (
+    <React.Fragment>
+      <Text style={{ color: chart_color_red_100.value }}>{header}</Text>
+      <Flex defaultspaceItems={{ default: 'spaceItemsLg' }}>
+        <FlexItem style={{ width: '40%' }}>
+          <Table variant="compact">
+            <Thead>
+              <Tr>
+                <Th>{columnHeader}</Th>
+                <Th>{POUND_OF_RECS}</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {rows.map((item, index) => (
+                <Tr
+                  key={`${columnHeader}-row-${index}`}
+                  style={{
+                    backgroundColor:
+                      (index + 1) % 2 && global_BackgroundColor_150.var,
+                    fontSize: '12px',
+                  }}
+                >
+                  <Td style={{ fontSize: '12px' }}>{item[0]}</Td>
+                  <Td style={{ fontSize: '12px' }}>{item[1]}</Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        </FlexItem>
+        <FlexItem
+          alignSelf={{ default: 'alignSelfStretch' }}
+          align={{ default: 'alignRight' }}
+        >
+          <ChartPie
+            colorScale={['#C9190B', '#EC7A08', '#F0AB00', '#06C']}
+            data={pieChart}
+            legendData={pieLegend}
+            legendOrientation="vertical"
+            legendPosition="right"
+            height={200}
+            width={350}
+            padding={{
+              bottom: 20,
+              left: 20,
+              right: 140, // Adjusted to accommodate legend
+              top: 20,
+            }}
+          />
+        </FlexItem>
+      </Flex>
+    </React.Fragment>
+  );
+};
+
+RecommendationCharts.propTypes = {
+  columnHeader: PropTypes.string,
+  header: PropTypes.string,
+  pieChart: PropTypes.array,
+  pieLegend: PropTypes.array,
+  rows: PropTypes.array,
+};
+
+export default RecommendationCharts;


### PR DESCRIPTION
This PR updates the template for the Executive Report PDF. To test:

- navigate to Advisor -> Recommendations
- click "Download executive report"

This should render a PDF that looks similar to the previous PDF in layout, but different in design. The data should be the same as the previous PDF.

This feature should be hidden behind a feature flag.