### PR TITLE
fix(RHINENG-17315): Show disabled recommendations and systems counts

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -35,7 +35,7 @@ export default defineMessages({
   totalRisk: {
     id: 'totalRisk',
     description:
-      'Recommendation table column title, recommendationdetails label',
+      'Recommendation table column title, recommendation details label',
     defaultMessage: 'Total risk',
   },
   systems: {
@@ -71,7 +71,7 @@ export default defineMessages({
   },
   notAvailable: {
     id: 'notAvailable',
-    description: 'Not availabl table cell text',
+    description: 'Not available table cell text',
     defaultMessage: 'N/A',
   },
   rulesTableHideReportsErrorEnabled: {
@@ -89,7 +89,7 @@ export default defineMessages({
   disableRuleForSystems: {
     id: 'disableRuleForSystems',
     description:
-      'Recommendationdetail system table, action text for disabling reporting of a recommendationfor a system',
+      'Recommendation detail system table, action text for disabling reporting of a recommendation for a system',
     defaultMessage: 'Disable recommendation for selected systems',
   },
   disableRuleBody: {
@@ -100,12 +100,12 @@ export default defineMessages({
   disableRuleSingleSystem: {
     id: 'disableRuleSingleSystem',
     description:
-      'Explaining the action of disabling a recommendationfor a single system',
+      'Explaining the action of disabling a recommendation for a single system',
     defaultMessage: 'Disable only for this system',
   },
   ruleIsDisabled: {
     id: 'ruleIsDisabled',
-    description: 'Exclaiming that the recommendationis disabled',
+    description: 'Exclaiming that the recommendation is disabled',
     defaultMessage: 'Recommendation is disabled',
   },
   recSuccessfullyDisabled: {
@@ -132,38 +132,38 @@ export default defineMessages({
   },
   ruleIsDisabledBodyWithJustification: {
     id: 'ruleIsDisabledBodyWithJustification',
-    description: 'Explaining that the recommendationis disabled',
+    description: 'Explaining that the recommendation is disabled',
     defaultMessage:
       'This recommendation has been disabled because {reason} and has no results.',
   },
   ruleIsDisabledJustification: {
     id: 'ruleIsDisabledJustification',
     description:
-      'Explaining that the recommendationis disabled with following justification',
+      'Explaining that the recommendation is disabled with following justification',
     defaultMessage:
       'This recommendation has been disabled for all systems for the following reason: ',
   },
   ruleIsDisabledForSystems: {
     id: 'ruleIsDisabledForSystems',
-    description: 'Exclaiming that the recommendationis disabled for systems',
+    description: 'Exclaiming that the recommendation is disabled for systems',
     defaultMessage: 'Recommendation is disabled for some systems',
   },
   ruleIsDisabledForAllSystems: {
     id: 'ruleIsDisabledForAllSystems',
     description:
-      'Exclaiming that the recommendationis disabled for all systems',
+      'Exclaiming that the recommendation is disabled for all systems',
     defaultMessage: 'Recommendation is disabled for all systems',
   },
   ruleIsDisabledForSystemsBody: {
     id: 'ruleIsDisabledForSystemsBody',
     description:
-      'Exclaiming that the recommendationis disabled for systems (system count)',
+      'Exclaiming that the recommendation is disabled for systems (system count)',
     defaultMessage:
       'Recommendation is disabled for {systems, plural, one {# system} other {# systems}}',
   },
   enableRuleForSystems: {
     id: 'enableRuleForSystems',
-    description: 'Enable this recommendationfor all systems',
+    description: 'Enable this recommendation for all systems',
     defaultMessage: 'Enable this recommendation for all systems',
   },
   viewSystems: {
@@ -247,7 +247,7 @@ export default defineMessages({
   },
   nA: {
     id: 'nA',
-    description: 'Abreviated as N/A, text equivelent, not applicable',
+    description: 'Abbreviated as N/A, text equivalent, Not Applicable',
     defaultMessage: 'N/A',
   },
   rulesTableFilterInputText: {

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -126,7 +126,6 @@ const RulesTable = ({ isTabActive, pathway }) => {
       ...filters,
       rule_status,
       offset: 0,
-      ...(rule_status !== 'enabled' && { impacting: ['false'] }),
     });
   };
 

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -396,14 +396,8 @@ export const buildRows = (
         },
         {
           title:
-            value.rule_status === 'rhdisabled' ? (
-              <Tooltip
-                content={intl.formatMessage(messages.byEnabling, {
-                  systems: value.impacted_systems_count,
-                })}
-              >
-                <span>{intl.formatMessage(messages.nA)}</span>
-              </Tooltip>
+            value.rule_status !== 'enabled' ? (
+              <span>{value.impacted_systems_count}</span>
             ) : (
               <Link key={key} to={`/recommendations/${value.rule_id}`}>
                 {`${value.impacted_systems_count.toLocaleString()}`}


### PR DESCRIPTION
As discovered in https://issues.redhat.com/browse/RHINENG-17315, when filtering disabled rules, the impacting=false URL parameter was being applied unnecessarily and causing the results to be incorrect.  The Advisor API backend has recently changed how it displays disabled rules, removing the need for impacting=false.

Also, Red Hat disabled rules should show how many systems are being impacted, so I removed the N/A string and tooltip and directly show how many systems are affected.  As per the attached screenshots.

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
