### PR TITLE
fix(RHINENG-17352): Show justification note for disabled rules

### DIFF
--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -469,13 +469,15 @@ export const buildRows = (
                   isDetailsPage={false}
                   showViewAffected
                   ViewAffectedLink={
-                    <Link to={`/recommendations/${value.rule_id}`}>
-                      {value.impacted_systems_count === 0
-                        ? ''
-                        : intl.formatMessage(messages.viewAffectedSystems, {
-                            systems: value.impacted_systems_count,
-                          })}
-                    </Link>
+                    value.rule_status === 'enabled' && (
+                      <Link to={`/recommendations/${value.rule_id}`}>
+                        {value.impacted_systems_count === 0
+                          ? ''
+                          : intl.formatMessage(messages.viewAffectedSystems, {
+                              systems: value.impacted_systems_count,
+                            })}
+                      </Link>
+                    )
                   }
                   knowledgebaseUrl={
                     value.node_id

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -53,12 +53,7 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
     data: recAck = {},
     isFetching: recAckIsFetching,
     refetch: recAckRefetch,
-  } = useGetRecAcksQuery(
-    { ruleId },
-    {
-      skip: !!ruleId,
-    }
-  );
+  } = useGetRecAcksQuery({ ruleId });
 
   const { data: topics = [], isFetching: topicIsFetching } =
     useGetTopicsQuery();
@@ -199,7 +194,7 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
                         </i>
                         {recAck.updated_at && (
                           <span>
-                            &nbsp;
+                            &nbsp;on&nbsp;
                             <DateFormat
                               date={new Date(recAck.updated_at)}
                               type="onlyDate"


### PR DESCRIPTION
As reported in RHINENG-17352, the justification note was not being displayed for disabled rules.  I'm not sure why Muslimjon changed the RecAckQuery like he did, but basically I rolled back his changes to it and it works again now.

I also piggybacked another change in that systems for disabled rules are not displayed, so I removed the link to the systems for a disabled rules, because there are no systems to see anyway for the disabled rule.

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
