### PR TITLE
fix(RHINENG-17352): Wrap long justification notes

### DIFF
--- a/src/PresentationalComponents/MessageState/MessageState.js
+++ b/src/PresentationalComponents/MessageState/MessageState.js
@@ -25,7 +25,14 @@ const MessageState = ({
       <EmptyStateIcon className={iconClass} style={iconStyle} icon={icon} />
     )}
     <EmptyStateHeader titleText={<>{title}</>} headingLevel="h5" />
-    <EmptyStateBody style={{ marginBottom: '16px' }}>{text}</EmptyStateBody>
+    <EmptyStateBody
+      style={{
+        marginBottom: '16px',
+        overflowWrap: 'anywhere',
+      }}
+    >
+      {text}
+    </EmptyStateBody>
     <EmptyStateFooter>{children}</EmptyStateFooter>
   </EmptyState>
 );

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -188,7 +188,8 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
                         {intl.formatMessage(
                           messages.ruleIsDisabledJustification
                         )}
-                        <i>
+                        &nbsp;
+                        <i className="wrap-justification-note">
                           {recAck.justification ||
                             intl.formatMessage(messages.none)}
                         </i>

--- a/src/SmartComponents/Recs/Details.scss
+++ b/src/SmartComponents/Recs/Details.scss
@@ -20,6 +20,10 @@
   margin-left: var(--pf-v5-global--spacer--md)
 }
 
+.wrap-justification-note {
+  overflow-wrap: anywhere;
+}
+
 @media only screen and (max-width: 768px) {
   .adv-c-dropdown-details-actions {
     @include all.rem('top', -55px);


### PR DESCRIPTION
Another finding from https://issues.redhat.com/browse/RHINENG-17352 was that a long justification note would overflow the containing element, as per attached screenshots.  It is unlikely a customer would do this, but still, it was raised and it was a fairly easy fix since I was already working on that part of the code.
 
- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work