### PR TITLE
fix(RHINENG-17091): Remove 'Disable recommendation' kebab for read-only users

### DIFF
--- a/src/SmartComponents/HybridInventoryTabs/ConventionalSystems/RecommendationSystems.js
+++ b/src/SmartComponents/HybridInventoryTabs/ConventionalSystems/RecommendationSystems.js
@@ -11,6 +11,7 @@ const ConventionalSystems = ({ rule, afterDisableFn, handleModalToggle }) => {
   const workloads = useSelector(({ filters }) => filters.workloads);
   const SID = useSelector(({ filters }) => filters.SID);
   const permsExport = usePermissions('advisor', PERMS.export).hasAccess;
+  const permsDisableRec = usePermissions('advisor', PERMS.disableRec).hasAccess;
 
   const actionResolver = useActionResolver(handleModalToggle);
 
@@ -18,7 +19,7 @@ const ConventionalSystems = ({ rule, afterDisableFn, handleModalToggle }) => {
     <Inventory
       tableProps={{
         canSelectAll: false,
-        actionResolver,
+        ...(permsDisableRec && { actionResolver }),
         isStickyHeader: true,
       }}
       rule={rule}


### PR DESCRIPTION
Resolves RHINENG-17091.  Users with read-only permissions are able to click on the button to disable a recommendation for a particular system.  However because they are read-only they shouldn't have such permissions.  Indeed they get a 403 error from the API indicating they don't have permission, but the UI should prevent them from even sending the disable recommendation request to the API.  

This PR removes the 'Disable recommendation' kebab from each row when the user has read-only permissions, as per the screenshots.

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
