### PR TITLE
feat(RHINENG-18088): remove is edge parity feature flag

### DIFF
--- a/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
+++ b/src/SmartComponents/HybridInventoryTabs/HybridInventoryTabs.js
@@ -1,7 +1,6 @@
 import React, { Suspense, lazy, useContext } from 'react';
 import propTypes from 'prop-types';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
-import { useFeatureFlag } from '../../Utilities/Hooks';
 import { AccountStatContext } from '../../ZeroStateWrapper';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
@@ -29,7 +28,6 @@ const HybridInventory = ({
   tabPathname,
   ...tabProps
 }) => {
-  const isEdgeParityEnabled = useFeatureFlag('advisor.edge_parity');
   const { hasEdgeDevices } = useContext(AccountStatContext);
 
   return areCountsLoading ? (
@@ -71,7 +69,6 @@ const HybridInventory = ({
       isImmutableTabOpen={isImmutableTabOpen}
       fallback={<div />}
       columns
-      isEdgeParityEnabled={isEdgeParityEnabled}
       accountHasEdgeImages={hasEdgeDevices}
       hasConventionalSystems={
         conventionalSystemsCount > 0 || edgeSystemsCount <= 0

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -33,7 +33,6 @@ import { DetailsRules } from './DetailsRules';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import HybridInventory from '../HybridInventoryTabs/HybridInventoryTabs';
 import { AccountStatContext } from '../../ZeroStateWrapper.js';
-import { useFeatureFlag } from '../../Utilities/Hooks.js';
 import DetailsTitle from './DetailsTitle.js';
 
 const OverviewDetails = ({ isImmutableTabOpen }) => {
@@ -68,7 +67,6 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
   const [conventionalSystemsCount, setConventionalSystemsCount] = useState(0);
   const [areCountsLoading, setCountsLoading] = useState(true);
   const { hasEdgeDevices } = useContext(AccountStatContext);
-  const isEdgeParityEnabled = useFeatureFlag('advisor.edge_parity');
 
   const handleModalToggle = (disableRuleModalOpen, host = undefined) => {
     setDisableRuleModalOpen(disableRuleModalOpen);
@@ -101,16 +99,14 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
   }, [chrome, rule.description, ruleId]);
 
   useEffect(() => {
-    isEdgeParityEnabled
-      ? edgeSystemsCheck(
-          ruleId,
-          setSystemsCount,
-          setEdgeSystemsCount,
-          setConventionalSystemsCount,
-          setCountsLoading
-        )
-      : setCountsLoading(false);
-  }, [isEdgeParityEnabled, ruleId]);
+    edgeSystemsCheck(
+      ruleId,
+      setSystemsCount,
+      setEdgeSystemsCount,
+      setConventionalSystemsCount,
+      setCountsLoading
+    );
+  }, [ruleId]);
 
   return (
     <React.Fragment>

--- a/src/SmartComponents/Recs/DetailsPathways.js
+++ b/src/SmartComponents/Recs/DetailsPathways.js
@@ -33,7 +33,6 @@ import { workloadQueryBuilder } from '../../PresentationalComponents/Common/Tabl
 import { useLocation } from 'react-router-dom';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import HybridInventory from '../HybridInventoryTabs/HybridInventoryTabs';
-import { useFeatureFlag } from '../../Utilities/Hooks';
 import { edgeSystemsCheck } from './helpers';
 
 const RulesTable = lazy(() =>
@@ -53,7 +52,6 @@ const PathwayDetails = ({ isImmutableTabOpen }) => {
   const recFilters = useSelector(({ filters }) => filters.recState);
   const sysFilters = useSelector(({ filters }) => filters.sysState);
 
-  const isEdgeParityEnabled = useFeatureFlag('advisor.edge_parity');
   const [edgeSystemsCount, setEdgeSystemsCount] = useState(0);
   const [conventionalSystemsCount, setConventionalSystemsCount] = useState(0);
   const [areCountsLoading, setCountsLoading] = useState(true);
@@ -136,16 +134,15 @@ const PathwayDetails = ({ isImmutableTabOpen }) => {
   }, []);
 
   useEffect(() => {
-    isEdgeParityEnabled &&
-      edgeSystemsCheck(
-        undefined,
-        undefined,
-        setEdgeSystemsCount,
-        setConventionalSystemsCount,
-        setCountsLoading,
-        pathwayName
-      );
-  }, [isEdgeParityEnabled, pathwayName]);
+    edgeSystemsCheck(
+      undefined,
+      undefined,
+      setEdgeSystemsCount,
+      setConventionalSystemsCount,
+      setCountsLoading,
+      pathwayName
+    );
+  }, [pathwayName]);
 
   return (
     <React.Fragment>

--- a/src/SmartComponents/Recs/DetailsTitle.js
+++ b/src/SmartComponents/Recs/DetailsTitle.js
@@ -1,18 +1,13 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { Skeleton } from '@patternfly/react-core';
-import { useFeatureFlag } from '../../Utilities/Hooks';
 
 const DetailsTitle = ({ areCountsLoading, hasEdgeDevices, systemsCount }) => {
-  const isEdgeParityEnabled = useFeatureFlag('advisor.edge_parity');
-
   if (areCountsLoading) {
     return <Skeleton width="25%" aria-label="Table title skeleton" />;
   }
 
-  return hasEdgeDevices && isEdgeParityEnabled
-    ? `${systemsCount} Total Systems`
-    : 'Affected Systems';
+  return hasEdgeDevices ? `${systemsCount} Total Systems` : 'Affected Systems';
 };
 
 DetailsTitle.propTypes = {

--- a/src/SmartComponents/Systems/List.js
+++ b/src/SmartComponents/Systems/List.js
@@ -7,11 +7,9 @@ import SystemsTable from '../../PresentationalComponents/SystemsTable/SystemsTab
 import messages from '../../Messages';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import EdgeSystemsBanner from './EdgeSystemsBanner';
-import { useFeatureFlag } from '../../Utilities/Hooks';
 
 const List = () => {
   const chrome = useChrome();
-  const edgeParityFFlag = useFeatureFlag('advisor.edge_parity');
   useEffect(() => {
     chrome.updateDocumentTitle('Systems - Advisor');
   }, [chrome]);
@@ -22,7 +20,7 @@ const List = () => {
         <PageHeaderTitle title={`${messages.systems.defaultMessage}`} />
       </PageHeader>
       <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
-        {edgeParityFFlag ? <EdgeSystemsBanner /> : null}
+        <EdgeSystemsBanner />
         <SystemsTable />
       </section>
     </React.Fragment>

--- a/src/ZeroStateWrapper.js
+++ b/src/ZeroStateWrapper.js
@@ -7,7 +7,6 @@ import { addNotification } from '@redhat-cloud-services/frontend-components-noti
 import { useDispatch } from 'react-redux';
 import { useIntl } from 'react-intl';
 import messages from './Messages';
-import { useFeatureFlag } from './Utilities/Hooks';
 import {
   useGetEdgeDevicesQuery,
   useGetConventionalDevicesQuery,
@@ -21,7 +20,6 @@ export const AccountStatContext = createContext({
 export const ZeroStateWrapper = ({ children }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const isEdgeParityEnabled = useFeatureFlag('advisor.edge_parity');
   const [hasConventionalSystems, setHasConventionalSystems] = useState(true);
   const [hasEdgeDevices, setHasEdgeDevices] = useState(true);
   const {
@@ -58,9 +56,7 @@ export const ZeroStateWrapper = ({ children }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [edgeError, conventionalError]);
 
-  const hasSystems = isEdgeParityEnabled
-    ? hasEdgeDevices || hasConventionalSystems
-    : hasConventionalSystems;
+  const hasSystems = hasEdgeDevices || hasConventionalSystems;
 
   return (
     <Suspense

--- a/src/ZeroStateWrapper.test.js
+++ b/src/ZeroStateWrapper.test.js
@@ -2,7 +2,10 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { screen, render } from '@testing-library/react';
 import { ZeroStateWrapper } from './ZeroStateWrapper';
-import { useGetConventionalDevicesQuery } from './Services/SystemVariety';
+import {
+  useGetConventionalDevicesQuery,
+  useGetEdgeDevicesQuery,
+} from './Services/SystemVariety';
 import { ComponentWithContext } from './Utilities/TestingUtilities';
 
 jest.mock('./Utilities/Hooks', () => ({
@@ -58,6 +61,13 @@ describe('ZeroStateWrapper', () => {
 
   it('Should render ZeroState with no systems', () => {
     useGetConventionalDevicesQuery.mockReturnValue(noConvSystems);
+    useGetEdgeDevicesQuery.mockReturnValue({
+      data: {
+        total: 0,
+      },
+      isSuccess: true,
+      isError: false,
+    });
     render(
       <ComponentWithContext
         Component={ZeroStateWrapper}


### PR DESCRIPTION
Remove edge parity feature flag, this is required before we introduce more changes for IOP

## Summary by Sourcery

Remove the advisor.edge_parity feature flag and streamline related UI and logic to always include edge parity functionality.

Enhancements:
- Remove useFeatureFlag imports and references for edge parity across multiple components
- Always execute edgeSystemsCheck and consistently update system counts without gating
- Always render EdgeSystemsBanner and simplify hybrid inventory tab logic without feature flag checks
- Update DetailsTitle to derive system count label based solely on hasEdgeDevices
- Simplify ZeroStateWrapper hasSystems logic to always consider both edge and conventional systems