### PR TITLE
feat(RHINENG-18130): Build upstream image to quay.io

### DIFF
--- a/.github/workflows/container-publish.yaml
+++ b/.github/workflows/container-publish.yaml
@@ -1,0 +1,106 @@
+name: Container image build and publish
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: [ "master" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: quay.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: "iop/advisor-frontend"
+
+
+jobs:
+  build:
+    if: github.event_name == 'push'
+    concurrency:
+      group: "${{ github.workflow }}-${{ github.ref }}"
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_IOP_BUILD_USERNAME }}
+          password: ${{ secrets.QUAY_IOP_BUILD_PASSWORD }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          file: ./Containerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,26 @@
+FROM registry.access.redhat.com/ubi9/nodejs-22:latest as builder
+
+USER root
+
+RUN dnf install jq -y
+
+USER default
+
+RUN npm i -g yarn
+
+RUN mkdir -p /opt/app-root/bin/
+COPY  ./build-tools/universal_build.sh /opt/app-root/bin/universal_build.sh
+COPY ./build-tools/build_app_info.sh /opt/app-root/bin/build_app_info.sh
+COPY ./build-tools/server_config_gen.sh /opt/app-root/bin/server_config_gen.sh
+
+COPY --chown=default . .
+
+ARG NPM_BUILD_SCRIPT=""
+RUN universal_build.sh
+
+FROM scratch
+
+COPY LICENSE /licenses/
+RUN mkdir -p /srv
+COPY --from=builder /opt/app-root/src/dist /srv/dist
+COPY package.json /srv/package.json


### PR DESCRIPTION
# Description
Build upstream image to quay.io

Associated Jira ticket: # RHINENG-18130

Please include a summary of the change, what this fixes/creates/improves.

This adds a simple Containerfile that utilizes the latest build scripts from the frontend builder in order to create a simple content only image.

# How to test the PR

Please include steps to test your PR.
Run `podman build -t quay.io/iop/advisor-frontend:latest .`
Note the successful build. Check the contents of the build by running `podman run -it quay.io/iop/advisor-frontend:latest bash` and looking at the contents in the `dist` directory.  The image should also be built with a GitHub action following the merge to master.

# Before the change
No local Containerfile to generate content only image.

# After the change
Containerfile to generate content only image and publish workflow

# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Add a Containerfile and a GitHub Actions workflow to build and publish a content-only advisor-frontend image to quay.io with multi-platform support and automatic signing.

New Features:
- Introduce a Containerfile for generating a content-only advisor-frontend image.
- Add a GitHub Actions workflow to build and publish the container image to quay.io.

Enhancements:
- Use universal build scripts fetched from insights-frontend-builder-common for consistency.
- Enable multi-platform builds (amd64 and arm64) with Buildx and cache support.
- Integrate cosign for automated image signing and metadata extraction.

CI:
- Trigger builds on pushes to master and semver tag releases.
- Set up Docker Buildx, registry login, metadata extraction, and concurrency controls in CI workflow.