### PR TITLE
feat(RHINENG-18130): Correct scratch container publish

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,6 +21,5 @@ RUN universal_build.sh
 FROM scratch
 
 COPY LICENSE /licenses/
-RUN mkdir -p /srv
 COPY --from=builder /opt/app-root/src/dist /srv/dist
 COPY package.json /srv/package.json


### PR DESCRIPTION
# Description

Associated Jira ticket: # RHINENG-18130

Correct scratch container build

# How to test the PR

git clone 
podman build -t quay.io/iop/advisor-frontend:latest .

# Before the change
container build failure due to an errant ctrl-Z

# After the change
built container

# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Build:
- Remove unnecessary RUN mkdir command in Containerfile to fix scratch container build