### PR TITLE
feat(RHINENG-17893): replaced chrome with context chrome

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,6 @@ const App = () => {
   const envContext = useContext(EnvironmentContext);
 
   useEffect(() => {
-    envContext.identifyApp('advisor');
     envContext?.globalFilterScope?.('insights');
     if (envContext?.globalFilterScope) {
       envContext.on('GLOBAL_FILTER_UPDATE', ({ data }) => {

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,6 @@ import './App.scss';
 import React, { useEffect, useContext, createContext } from 'react';
 import { batch, useDispatch } from 'react-redux';
 import { updateSID, updateTags, updateWorkloads } from './Services/Filters';
-import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import MessageState from './PresentationalComponents/MessageState/MessageState';
 import { AdvisorRoutes } from './Routes';
 import messages from './Messages';
@@ -16,16 +15,15 @@ export const EnvironmentContext = createContext({});
 const App = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const chrome = useChrome();
   const envContext = useContext(EnvironmentContext);
 
   useEffect(() => {
-    chrome.identifyApp('advisor');
-    chrome?.globalFilterScope?.('insights');
-    if (chrome?.globalFilterScope) {
-      chrome.on('GLOBAL_FILTER_UPDATE', ({ data }) => {
+    envContext.identifyApp('advisor');
+    envContext?.globalFilterScope?.('insights');
+    if (envContext?.globalFilterScope) {
+      envContext.on('GLOBAL_FILTER_UPDATE', ({ data }) => {
         const [workloads, SID, selectedTags] =
-          chrome?.mapGlobalFilter?.(data, false, true) || [];
+          envContext?.mapGlobalFilter?.(data, false, true) || [];
         batch(() => {
           dispatch(updateWorkloads(workloads));
           dispatch(updateTags(selectedTags));

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -513,7 +513,6 @@ export const IOP_ENVIRONMENT_CONTEXT = {
   hideGlobalFilter: () => {},
   mapGlobalFilter: () => {},
   globalFilterScope: () => {},
-  requestPdf: () => {},
+  requestPdf: () => Promise.resolve(),
   isProd: false,
-  identifyApp: () => {},
 };

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -501,3 +501,19 @@ export const PERMISSIONS = {
   disableRec: 'advisor:disable-recommendations:write',
   viewRecs: 'advisor:recommendation-results:read',
 };
+
+export const IOP_ENVIRONMENT_CONTEXT = {
+  isLoading: false,
+  isExportEnabled: false,
+  isDisableRecEnabled: false,
+  isAllowedToViewRec: true,
+  updateDocumentTitle: (name) => (document.title = name),
+  getUser: () => '',
+  on: () => {},
+  hideGlobalFilter: () => {},
+  mapGlobalFilter: () => {},
+  globalFilterScope: () => {},
+  requestPdf: () => {},
+  isProd: false,
+  identifyApp: () => {},
+};

--- a/src/PresentationalComponents/ExecutiveReport/NewDownload.js
+++ b/src/PresentationalComponents/ExecutiveReport/NewDownload.js
@@ -1,6 +1,6 @@
 /* eslint-disable rulesdir/disallow-fec-relative-imports */
 import './_Download.scss';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux/actions/notifications';
@@ -10,12 +10,12 @@ import messages from '../../Messages';
 import { useIntl } from 'react-intl';
 import { Button } from '@patternfly/react-core';
 import { exportNotifications } from '../../AppConstants';
-import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { EnvironmentContext } from '../../App';
 
 const NewDownloadExecReport = ({ isDisabled }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const { requestPdf } = useChrome();
+  const envContext = useContext(EnvironmentContext);
   const [loading, setLoading] = useState(false);
 
   const dataFetch = async () => {
@@ -23,7 +23,7 @@ const NewDownloadExecReport = ({ isDisabled }) => {
     dispatch(addNotification(exportNotifications.pending));
 
     try {
-      await requestPdf({
+      await envContext.requestPdf({
         filename: `Advisor-Executive-Report--${new Date()
           .toUTCString()
           .replace(/ /g, '-')}.pdf`,

--- a/src/PresentationalComponents/Export/NewSystemsPdf.js
+++ b/src/PresentationalComponents/Export/NewSystemsPdf.js
@@ -1,14 +1,14 @@
 import './_Export.scss';
 
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { Button } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { workloadQueryBuilder } from '../Common/Tables';
 import { exportNotifications } from '../../AppConstants';
-import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux/actions/notifications';
+import { EnvironmentContext } from '../../App';
 
 const NewSystemsPdf = ({ filters }) => {
   const dispatch = useDispatch();
@@ -18,7 +18,7 @@ const NewSystemsPdf = ({ filters }) => {
   );
   const workloads = useSelector(({ AdvisorStore }) => AdvisorStore?.workloads);
   const SID = useSelector(({ AdvisorStore }) => AdvisorStore?.SID);
-  const { requestPdf } = useChrome();
+  const envContext = useContext(EnvironmentContext);
 
   const dataFetch = async () => {
     setLoading(true);
@@ -28,7 +28,7 @@ const NewSystemsPdf = ({ filters }) => {
     workloads &&
       (options = { ...options, ...workloadQueryBuilder(workloads, SID) });
     try {
-      await requestPdf({
+      await envContext.requestPdf({
         filename: `Advisor_systems--${new Date()
           .toUTCString()
           .replace(/ /g, '-')}.pdf`,

--- a/src/PresentationalComponents/Inventory/InventoryDetails.js
+++ b/src/PresentationalComponents/Inventory/InventoryDetails.js
@@ -6,7 +6,7 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core/dist/esm/layouts/Grid/index';
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { connect, useStore } from 'react-redux';
 import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
 import Breadcrumbs from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
@@ -18,8 +18,8 @@ import { updateReducers } from '../../Store';
 import { useIntl } from 'react-intl';
 import SystemAdvisor from '../../SmartComponents/SystemAdvisor';
 import { useParams } from 'react-router-dom';
-import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { Skeleton } from '@patternfly/react-core';
+import { EnvironmentContext } from '../../App';
 
 const InventoryHeadFallback = () => {
   return (
@@ -38,14 +38,14 @@ const InventoryDetails = ({ entity }) => {
   const intl = useIntl();
   const store = useStore();
   const { inventoryId } = useParams();
-  const chrome = useChrome();
+  const envContext = useContext(EnvironmentContext);
   useEffect(() => {
     if (entity && (entity.display_name || entity.id)) {
-      chrome.updateDocumentTitle(
+      envContext.updateDocumentTitle(
         `${entity.display_name || entity.id} - Systems - Advisor`
       );
     }
-  }, [entity, chrome]);
+  }, [envContext, entity]);
 
   return (
     <DetailWrapper

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -29,7 +29,6 @@ import { useGetRecQuery } from '../../Services/Recs';
 import { useGetTopicsQuery } from '../../Services/Topics';
 import { enableRule, bulkHostActions, edgeSystemsCheck } from './helpers';
 import { DetailsRules } from './DetailsRules';
-import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import HybridInventory from '../HybridInventoryTabs/HybridInventoryTabs';
 import { AccountStatContext } from '../../ZeroStateWrapper.js';
 import DetailsTitle from './DetailsTitle.js';
@@ -40,7 +39,6 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
   const dispatch = useDispatch();
   const ruleId = useParams().id;
   const addNotification = (data) => dispatch(notification(data));
-  const chrome = useChrome();
   const {
     data: rule = {},
     isFetching,
@@ -92,11 +90,11 @@ const OverviewDetails = ({ isImmutableTabOpen }) => {
     }
 
     if (rule?.description) {
-      chrome.updateDocumentTitle(
+      envContext.updateDocumentTitle(
         `${rule.description} - Recommendations - Advisor`
       );
     }
-  }, [chrome, rule.description, ruleId]);
+  }, [envContext, rule.description, ruleId]);
 
   useEffect(() => {
     edgeSystemsCheck(

--- a/src/SmartComponents/Recs/DetailsPathways.js
+++ b/src/SmartComponents/Recs/DetailsPathways.js
@@ -9,7 +9,7 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-import React, { Suspense, lazy, useEffect, useState } from 'react';
+import React, { Suspense, lazy, useContext, useEffect, useState } from 'react';
 import { TotalRiskCard } from '../../PresentationalComponents/Cards/TotalRiskCard';
 import { ResolutionCard } from '../../PresentationalComponents/Cards/ResolutionCard';
 import {
@@ -31,9 +31,9 @@ import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import { workloadQueryBuilder } from '../../PresentationalComponents/Common/Tables';
 import { useLocation } from 'react-router-dom';
-import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import HybridInventory from '../HybridInventoryTabs/HybridInventoryTabs';
 import { edgeSystemsCheck } from './helpers';
+import { EnvironmentContext } from '../../App';
 
 const RulesTable = lazy(() =>
   import(
@@ -45,7 +45,7 @@ const PathwayDetails = ({ isImmutableTabOpen }) => {
   const intl = useIntl();
   const pathwayName = useParams().id;
   const dispatch = useDispatch();
-
+  const envContext = useContext(EnvironmentContext);
   const selectedTags = useSelector(({ filters }) => filters.selectedTags);
   const workloads = useSelector(({ filters }) => filters.workloads);
   const SID = useSelector(({ filters }) => filters.SID);
@@ -73,14 +73,13 @@ const PathwayDetails = ({ isImmutableTabOpen }) => {
   const [activeTab, setActiveTab] = useState(
     pathname.includes('/recommendations/pathways/systems/') ? 1 : 0
   );
-  const chrome = useChrome();
   useEffect(() => {
     pathway &&
       !isFetching &&
-      chrome.updateDocumentTitle(
+      envContext.updateDocumentTitle(
         `${pathway.name} - ${messages.pathways.defaultMessage} - Advisor`
       );
-  }, [chrome, pathway, pathname, isFetching]);
+  }, [envContext, pathway, pathname, isFetching]);
 
   const waitForElm = (selector) => {
     return new Promise((resolve) => {

--- a/src/SmartComponents/Recs/List.js
+++ b/src/SmartComponents/Recs/List.js
@@ -11,7 +11,6 @@ import { QuestionTooltip } from '../../PresentationalComponents/Common/Common';
 import messages from '../../Messages';
 import OverviewDashbar from '../../PresentationalComponents/OverviewDashbar/OverviewDashbar';
 import RulesTable from '../../PresentationalComponents/RulesTable/RulesTable';
-import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import {
   Tab,
   TabTitleText,
@@ -48,12 +47,11 @@ const List = () => {
   const { pathname } = useLocation();
   const navigate = useInsightsNavigate();
   const isPDFGeneratorEnabled = useFeatureFlag('advisor.pdf_generator');
-  const chrome = useChrome();
   const envContext = useContext(EnvironmentContext);
 
   useEffect(() => {
-    chrome.updateDocumentTitle('Recommendations - Advisor');
-  }, [chrome]);
+    envContext.updateDocumentTitle('Recommendations - Advisor');
+  }, [envContext]);
 
   const [activeTab, setActiveTab] = useState(
     pathname === '/insights/advisor/recommendations/pathways'

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -38,7 +38,6 @@ import {
 } from './SystemAdvisorAssets';
 import downloadReport from '../../PresentationalComponents/Common/DownloadHelper';
 import { useParams } from 'react-router-dom';
-import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { SkeletonTable } from '@patternfly/react-component-groups';
 import { EnvironmentContext } from '../../App';
 
@@ -49,8 +48,6 @@ const BaseSystemAdvisor = ({ entity, inventoryId }) => {
   });
   const dispatch = useDispatch();
   const addNotification = (data) => dispatch(addNotificationAction(data));
-  const { isProd } = useChrome();
-
   const { id: ruleIdParam } = useParams();
 
   const [inventoryReportFetchStatus, setInventoryReportFetchStatus] =
@@ -146,7 +143,7 @@ const BaseSystemAdvisor = ({ entity, inventoryId }) => {
     systemAdvisorRef,
     entity,
     inventoryReportFetchStatus,
-    isProd
+    envContext.isProd
   );
   const onRowSelect = (_e, isSelected, rowId) =>
     setRows(

--- a/src/SmartComponents/Systems/List.js
+++ b/src/SmartComponents/Systems/List.js
@@ -2,17 +2,17 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import SystemsTable from '../../PresentationalComponents/SystemsTable/SystemsTable';
 import messages from '../../Messages';
-import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import EdgeSystemsBanner from './EdgeSystemsBanner';
+import { EnvironmentContext } from '../../App';
 
 const List = () => {
-  const chrome = useChrome();
+  const envContext = useContext(EnvironmentContext);
   useEffect(() => {
-    chrome.updateDocumentTitle('Systems - Advisor');
-  }, [chrome]);
+    envContext.updateDocumentTitle('Systems - Advisor');
+  }, [envContext]);
 
   return (
     <React.Fragment>

--- a/src/SmartComponents/Topics/Details.cy.js
+++ b/src/SmartComponents/Topics/Details.cy.js
@@ -8,19 +8,26 @@ import { AccountStatContext } from '../../ZeroStateWrapper';
 //eslint-disable-next-line rulesdir/disallow-fec-relative-imports
 import { hasChip } from '@redhat-cloud-services/frontend-components-utilities';
 import messages from '../../Messages';
+import { EnvironmentContext } from '../../App';
 
 const mountComponent = (hasEdgeDevices) => {
+  const mockEnvContext = {
+    updateDocumentTitle: cy.stub(), // mock function to prevent error
+  };
+
   cy.mount(
     <MemoryRouter initialEntries={['/topics/123']}>
-      <AccountStatContext.Provider value={{ hasEdgeDevices }}>
-        <IntlProvider locale={navigator.language.slice(0, 2)}>
-          <Provider store={initStore()}>
-            <Routes>
-              <Route path="topics/:id" element={<Details />}></Route>
-            </Routes>
-          </Provider>
-        </IntlProvider>
-      </AccountStatContext.Provider>
+      <EnvironmentContext.Provider value={mockEnvContext}>
+        <AccountStatContext.Provider value={{ hasEdgeDevices }}>
+          <IntlProvider locale={navigator.language.slice(0, 2)}>
+            <Provider store={initStore()}>
+              <Routes>
+                <Route path="topics/:id" element={<Details />} />
+              </Routes>
+            </Provider>
+          </IntlProvider>
+        </AccountStatContext.Provider>
+      </EnvironmentContext.Provider>
     </MemoryRouter>
   );
 };

--- a/src/SmartComponents/Topics/Details.js
+++ b/src/SmartComponents/Topics/Details.js
@@ -25,14 +25,14 @@ import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { workloadQueryBuilder } from '../../PresentationalComponents/Common/Tables';
-import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { getDefaultImpactingFilter } from '../../PresentationalComponents/RulesTable/helpers';
 import { AccountStatContext } from '../../ZeroStateWrapper';
+import { EnvironmentContext } from '../../App';
 
 const Details = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
-
+  const envContext = useContext(EnvironmentContext);
   const selectedTags = useSelector(({ filters }) => filters.selectedTags);
   const workloads = useSelector(({ filters }) => filters.workloads);
   const SID = useSelector(({ filters }) => filters.SID);
@@ -66,13 +66,12 @@ const Details = () => {
     return () => dispatch(updateRecFilters(initiaRecFilters));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  const chrome = useChrome();
 
   useEffect(() => {
     if (topic && topic.name) {
-      chrome.updateDocumentTitle(`${topic.name} - Topics - Advisor`);
+      envContext.updateDocumentTitle(`${topic.name} - Topics - Advisor`);
     }
-  }, [chrome, topic]);
+  }, [envContext, topic]);
 
   return (
     <React.Fragment>

--- a/src/SmartComponents/Topics/List.js
+++ b/src/SmartComponents/Topics/List.js
@@ -3,23 +3,23 @@ import {
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
 
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import TopicsTable from '../../PresentationalComponents/TopicsTable/TopicsTable';
 import messages from '../../Messages';
 import { useGetTopicsQuery } from '../../Services/Topics';
 import { useSelector } from 'react-redux';
 import { workloadQueryBuilder } from '../../PresentationalComponents/Common/Tables';
-import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import { EnvironmentContext } from '../../App';
 
 const List = () => {
   const selectedTags = useSelector(({ filters }) => filters.selectedTags);
   const workloads = useSelector(({ filters }) => filters.workloads);
   const SID = useSelector(({ filters }) => filters.SID);
-  const chrome = useChrome();
+  const envContext = useContext(EnvironmentContext);
 
   useEffect(() => {
-    chrome.updateDocumentTitle('Topics - Advisor');
-  }, [chrome]);
+    envContext.updateDocumentTitle('Topics - Advisor');
+  }, [envContext]);
 
   let options = selectedTags?.length && { tags: selectedTags };
   workloads &&

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -79,6 +79,5 @@ export const useHccEnvironmentContext = () => {
     globalFilterScope: chrome.globalFilterScope,
     requestPdf: chrome.requestPdf,
     isProd: chrome.isProd,
-    identifyApp: chrome.identifyApp,
   };
 };

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -79,5 +79,6 @@ export const useHccEnvironmentContext = () => {
     globalFilterScope: chrome.globalFilterScope,
     requestPdf: chrome.requestPdf,
     isProd: chrome.isProd,
+    identifyApp: chrome.identifyApp,
   };
 };

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -9,7 +9,7 @@ export const useFeatureFlag = (flag) => {
   return flagsReady ? isFlagEnabled : false;
 };
 
-const matchPermissions = (permissionA, permissionB) => {
+export const matchPermissions = (permissionA, permissionB) => {
   const segmentsA = permissionA.split(':');
   const segmentsB = permissionB.split(':');
 

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -76,5 +76,8 @@ export const useHccEnvironmentContext = () => {
     on: chrome.on,
     hideGlobalFilter: chrome.hideGlobalFilter,
     mapGlobalFilter: chrome.mapGlobalFilter,
+    globalFilterScope: chrome.globalFilterScope,
+    requestPdf: chrome.requestPdf,
+    isProd: chrome.isProd,
   };
 };

--- a/src/Utilities/Hooks.test.js
+++ b/src/Utilities/Hooks.test.js
@@ -1,0 +1,103 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useRbac, useHccEnvironmentContext } from './Hooks';
+import { PERMISSIONS } from '../AppConstants';
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('useRbac', () => {
+  const mockPermissions = [
+    { permission: 'advisor:export' },
+    { permission: 'advisor:disableRec' },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return correct permission booleans once loaded', async () => {
+    useChrome.mockReturnValue({
+      getUserPermissions: () => Promise.resolve(mockPermissions),
+    });
+
+    const { result } = renderHook(() =>
+      useRbac([
+        PERMISSIONS.export,
+        PERMISSIONS.disableRec,
+        PERMISSIONS.viewRecs,
+      ])
+    );
+
+    await waitFor(() => {
+      expect(result.current[1]).toBe(false);
+    });
+
+    expect(result.current[0]).toEqual([false, false, false]);
+  });
+
+  it('should show loading initially', () => {
+    useChrome.mockReturnValue({
+      getUserPermissions: () => new Promise(() => {}),
+    });
+
+    const { result } = renderHook(() =>
+      useRbac([
+        PERMISSIONS.export,
+        PERMISSIONS.disableRec,
+        PERMISSIONS.viewRecs,
+      ])
+    );
+
+    expect(result.current[1]).toBe(true);
+    expect(result.current[0]).toEqual([[], [], []]);
+  });
+});
+
+describe('useHccEnvironmentContext', () => {
+  const mockChrome = {
+    getUserPermissions: () =>
+      Promise.resolve([
+        { permission: 'advisor:export' },
+        { permission: 'advisor:viewRecs' },
+      ]),
+    updateDocumentTitle: jest.fn(),
+    auth: { getUser: jest.fn() },
+    on: jest.fn(),
+    hideGlobalFilter: jest.fn(),
+    mapGlobalFilter: jest.fn(),
+    globalFilterScope: 'global',
+    requestPdf: jest.fn(),
+    isProd: true,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useChrome.mockReturnValue(mockChrome);
+  });
+
+  it('returns expected environment context values', async () => {
+    const { result } = renderHook(() => useHccEnvironmentContext());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current).toEqual({
+      isLoading: false,
+      isExportEnabled: false,
+      isDisableRecEnabled: false,
+      isAllowedToViewRec: false,
+      updateDocumentTitle: mockChrome.updateDocumentTitle,
+      getUser: mockChrome.auth.getUser,
+      on: mockChrome.on,
+      hideGlobalFilter: mockChrome.hideGlobalFilter,
+      mapGlobalFilter: mockChrome.mapGlobalFilter,
+      globalFilterScope: mockChrome.globalFilterScope,
+      requestPdf: mockChrome.requestPdf,
+      isProd: true,
+    });
+  });
+});

--- a/src/Utilities/TestingUtilities.js
+++ b/src/Utilities/TestingUtilities.js
@@ -4,6 +4,22 @@ import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { IntlProvider } from 'react-intl';
+import { EnvironmentContext } from '../App';
+
+export const DEFAULT_TEST_ENVIRONMENT_CONTEXT = {
+  isLoading: false,
+  isExportEnabled: true,
+  isDisableRecEnabled: true,
+  isAllowedToViewRec: true,
+  updateDocumentTitle: () => {},
+  getUser: () => '',
+  on: () => {},
+  hideGlobalFilter: () => {},
+  mapGlobalFilter: () => {},
+  globalFilterScope: () => {},
+  requestPdf: () => {},
+  isProd: () => {},
+};
 
 export const ComponentWithContext = ({
   Component,
@@ -13,25 +29,31 @@ export const ComponentWithContext = ({
   contextValue = {},
 }) => {
   const mockStore = configureStore();
+  const mergedEnvContext = {
+    ...DEFAULT_TEST_ENVIRONMENT_CONTEXT,
+    ...EnvironmentContext,
+  };
 
   return (
-    <IntlProvider locale="en">
-      <Provider store={renderOptions?.store || mockStore()}>
-        <MemoryRouter initialEntries={renderOptions?.initialEntries || ['/']}>
-          <Context.Provider value={contextValue}>
-            {renderOptions?.componentPath ? (
-              <Routes>
-                <Route>
-                  <Component {...componentProps} />
-                </Route>
-              </Routes>
-            ) : (
-              <Component {...componentProps} />
-            )}
-          </Context.Provider>
-        </MemoryRouter>
-      </Provider>
-    </IntlProvider>
+    <EnvironmentContext.Provider value={mergedEnvContext}>
+      <IntlProvider locale="en">
+        <Provider store={renderOptions?.store || mockStore()}>
+          <MemoryRouter initialEntries={renderOptions?.initialEntries || ['/']}>
+            <Context.Provider value={contextValue}>
+              {renderOptions?.componentPath ? (
+                <Routes>
+                  <Route>
+                    <Component {...componentProps} />
+                  </Route>
+                </Routes>
+              ) : (
+                <Component {...componentProps} />
+              )}
+            </Context.Provider>
+          </MemoryRouter>
+        </Provider>
+      </IntlProvider>
+    </EnvironmentContext.Provider>
   );
 };
 

--- a/src/Utilities/TestingUtilities.js
+++ b/src/Utilities/TestingUtilities.js
@@ -1,4 +1,4 @@
-import React, { createContext } from 'react';
+import React, { createContext, useContext } from 'react';
 import PropTypes from 'prop-types';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
@@ -29,11 +29,12 @@ export const ComponentWithContext = ({
   contextValue = {},
 }) => {
   const mockStore = configureStore();
+  const envContext = useContext(EnvironmentContext);
+
   const mergedEnvContext = {
     ...DEFAULT_TEST_ENVIRONMENT_CONTEXT,
-    ...EnvironmentContext,
+    ...envContext,
   };
-
   return (
     <EnvironmentContext.Provider value={mergedEnvContext}>
       <IntlProvider locale="en">

--- a/src/Utilities/unitTestingUtilities.js
+++ b/src/Utilities/unitTestingUtilities.js
@@ -10,7 +10,6 @@ export const initMocks = () => {
     chrome: {
       appNavClick: () => {},
       init: jest.fn(),
-      identifyApp: () => {},
       navigation: () => {},
       on: () => {
         return () => {};


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)
https://issues.redhat.com/browse/RHINENG-17893
Please include a summary of the change, what this fixes/creates/improves.
Replaced direct calls to useChrome functions with the ones that are passed through useContext

# How to test the PR
1)Check that updateDocumentTitle works correctly in the components that were affected
2)Check that global filter and tag filter works as expected
3)Replace useHccEnvironmentContext in App js with IOP_ENVIRONMENT_CONTEXT to test the app "without" chrome functions.

## Summary by Sourcery

Migrate all direct calls to the useChrome hook to a context-based EnvironmentContext and extend its underlying hook to expose additional Chrome APIs.

Enhancements:
- Replace all useChrome hook invocations with useContext(EnvironmentContext) to access Chrome methods across components
- Extend the useHccEnvironmentContext hook to include globalFilterScope, requestPdf, and isProd attributes
- Update App initialization and component logic to use envContext for identifyApp, updateDocumentTitle, global filter mapping, and PDF requests