### PR TITLE
feat(iop): add temporary satellite component

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -11,20 +11,20 @@ module.exports = {
     // Put the Sentry Webpack plugin after all other plugins
     ...(process.env.ENABLE_SENTRY
       ? [
-          sentryWebpackPlugin({
-            ...(process.env.SENTRY_AUTH_TOKEN && {
-              authToken: process.env.SENTRY_AUTH_TOKEN,
-            }),
+        sentryWebpackPlugin({
+          ...(process.env.SENTRY_AUTH_TOKEN && {
+            authToken: process.env.SENTRY_AUTH_TOKEN,
+          }),
+          org: 'red-hat-it',
+          project: 'advisor-rhel',
+          moduleMetadata: ({ release }) => ({
+            dsn: `https://f8eb44de949e487e853185c09340f3cf@o490301.ingest.us.sentry.io/4505397435367424`,
             org: 'red-hat-it',
             project: 'advisor-rhel',
-            moduleMetadata: ({ release }) => ({
-              dsn: `https://f8eb44de949e487e853185c09340f3cf@o490301.ingest.us.sentry.io/4505397435367424`,
-              org: 'red-hat-it',
-              project: 'advisor-rhel',
-              release,
-            }),
+            release,
           }),
-        ]
+        }),
+      ]
       : []),
   ],
   moduleFederation: {
@@ -55,6 +55,7 @@ module.exports = {
         __dirname,
         '/src/PresentationalComponents/Export/NewSystemsPdfBuild'
       ),
+      './SatelliteDemoComponent': resolve(__dirname, './src/Temporary/SatelliteDemoComponent.js')
     },
   },
   _unstableSpdy: true,

--- a/src/Temporary/SatelliteDemoComponent.js
+++ b/src/Temporary/SatelliteDemoComponent.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import {
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  EmptyStateVariant,
+} from '@patternfly/react-core';
+import { SatelliteIcon } from '@patternfly/react-icons';
+
+export const SatelliteDemoComponent = () => (
+  <Bullseye>
+    <EmptyState variant={EmptyStateVariant.lg}>
+      <EmptyStateHeader
+        titleText="This is a demo component"
+        icon={<EmptyStateIcon icon={SatelliteIcon} size="sm" />}
+        headingLevel="h5"
+      />
+      <EmptyStateBody>
+        Demo component for Vulnerability for IoP integration.
+      </EmptyStateBody>
+    </EmptyState>
+  </Bullseye>
+);
+
+export default SatelliteDemoComponent;


### PR DESCRIPTION
Adding temp satellite component as per request from Satellite team
Example of the same thing for vuln ui
https://github.com/RedHatInsights/vulnerability-ui/commit/fedd803623a5646be4bb3dee0fb8a144db303571