### PR TITLE
fix PublicPath webpack option

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -27,7 +27,9 @@ module.exports = {
         ]
       : []),
   ],
-  publicPath: 'auto',
+  output: {
+    publicPath: 'auto',
+  },
   moduleFederation: {
     shared: [
       {


### PR DESCRIPTION
Was causing Sentry RootApp errors when trying to access the Advisor app:

![image (2)](https://github.com/user-attachments/assets/62160d43-dea2-41a5-9d2a-dffdea4acc97)

