### PR TITLE
fix(RHINENG-19077): Check if IopRemediationModal is an element

### DIFF
--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -109,8 +109,8 @@ const BaseSystemAdvisor = ({ entity, inventoryId, IopRemediationModal }) => {
     !isSystemProfileLoading && systemProfile?.host_type !== 'edge'
       ? [
           <Flex key="inventory-actions">
-            {IopRemediationModal ? (
-              IopRemediationModal
+            {React.isValidElement(IopRemediationModal) ? (
+              <IopRemediationModal />
             ) : (
               <RemediationButton
                 key="remediation-button"
@@ -512,7 +512,7 @@ BaseSystemAdvisor.propTypes = {
   IopRemediationModal: PropTypes.element,
 };
 
-const SystemAdvisor = ({ ...props }) => {
+const SystemAdvisor = ({ ...props }, IopRemediationModal) => {
   const entity = useSelector(({ entityDetails }) => entityDetails.entity);
 
   return (


### PR DESCRIPTION
Fixes RHINENG-19077, but not sure it displays an IopRemediationModal correctly

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

Before MR:
![Screenshot from 2025-07-01 20-20-21](https://github.com/user-attachments/assets/c1a0c86d-4085-424a-a218-3361b90619ac)

After MR:
![Screenshot from 2025-07-01 20-43-55](https://github.com/user-attachments/assets/536545e9-454e-42e5-a256-706e03cad832)

