### PR TITLE
fix(RHINENG-19351): Rename recs wrapper to match Satellite

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -85,9 +85,9 @@ module.exports = {
         __dirname,
         './src/SmartComponents/Recs/Details.js',
       ),
-      './RecsDetailsWrapped': resolve(
+      './RecommendationDetailsWrapped': resolve(
         __dirname,
-        './src/SmartComponents/Recs/RecsDetailsWrapped.js',
+        './src/SmartComponents/Recs/RecommendationDetailsWrapped.js',
       ),
     },
   },

--- a/src/SmartComponents/Recs/RecommendationDetailsWrapped.js
+++ b/src/SmartComponents/Recs/RecommendationDetailsWrapped.js
@@ -7,7 +7,7 @@ import { EnvironmentContext } from '../../App';
 import { initStore } from '../../Store';
 import OverviewDetails from './Details';
 
-const RecsDetailsWrapped = (props) => (
+const RecommendationDetailsWrapped = (props) => (
   <IntlProvider locale="en" messages={messages}>
     <EnvironmentContext.Provider value={IOP_ENVIRONMENT_CONTEXT}>
       <Provider store={initStore()}>
@@ -17,4 +17,4 @@ const RecsDetailsWrapped = (props) => (
   </IntlProvider>
 );
 
-export default RecsDetailsWrapped;
+export default RecommendationDetailsWrapped;


### PR DESCRIPTION
RecsDetailsWrapper is called RecommendationDetailsWrapper on the Satellite and this seems like a better name than RecsDetailsWrapper anyway.