### PR TITLE
fix(RHINENG-19582): Missed some renamings for new PDF generator

### DIFF
--- a/src/PresentationalComponents/ExecutiveReport/Download.js
+++ b/src/PresentationalComponents/ExecutiveReport/Download.js
@@ -11,7 +11,7 @@ import { Button } from '@patternfly/react-core';
 import { exportNotifications } from '../../AppConstants';
 import { EnvironmentContext } from '../../App';
 
-const NewDownloadExecReport = ({ isDisabled }) => {
+const DownloadExecReport = ({ isDisabled }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const envContext = useContext(EnvironmentContext);
@@ -29,7 +29,7 @@ const NewDownloadExecReport = ({ isDisabled }) => {
         payload: {
           manifestLocation: '/apps/advisor/fed-mods.json',
           scope: 'advisor',
-          module: './NewBuildExecReport',
+          module: './BuildExecReport',
           fetchDataParams: {
             limit: 3,
             sort: '-total_risk,-impacted_count',
@@ -62,8 +62,8 @@ const NewDownloadExecReport = ({ isDisabled }) => {
   );
 };
 
-NewDownloadExecReport.propTypes = {
+DownloadExecReport.propTypes = {
   isDisabled: PropTypes.bool,
 };
 
-export default NewDownloadExecReport;
+export default DownloadExecReport;

--- a/src/PresentationalComponents/Export/SystemsPdf.js
+++ b/src/PresentationalComponents/Export/SystemsPdf.js
@@ -35,7 +35,7 @@ const SystemsPdf = ({ filters }) => {
         payload: {
           manifestLocation: '/apps/advisor/fed-mods.json',
           scope: 'advisor',
-          module: './NewSystemsPdfBuild',
+          module: './SystemsPdfBuild',
           fetchDataParams: {
             filters,
             options,

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.test.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.test.js
@@ -17,7 +17,7 @@ jest.mock('../Export/SystemsPdf', () => ({
   __esModule: true,
   default: jest.fn((props) => (
     <div {...props} aria-label="systems-pdf-mock">
-      NewSystemsPdf
+      SystemsPdf
     </div>
   )),
 }));


### PR DESCRIPTION
Oops, missed renaming the federated modules within the code, so the PDF couldn't be generated.

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
