### PR TITLE
fix(RHINENG-19383): Host Insights tab populates in IoP environment

### DIFF
--- a/src/Modules/SystemDetailWrapped.js
+++ b/src/Modules/SystemDetailWrapped.js
@@ -3,18 +3,26 @@ import { EnvironmentContext } from '../App';
 import { IOP_ENVIRONMENT_CONTEXT } from '../AppConstants';
 import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
-import SystemDetail from './SystemDetail';
 import messages from '../../locales/translations.json';
 import { initStore } from '../Store';
+import SystemAdvisorWrapped from '../SmartComponents/SystemAdvisor/SystemAdvisorWrapped';
+import PropTypes from 'prop-types';
 
-export const SystemDetailWrapped = (props) => (
+const SystemDetailWrapped = (props) => (
   <IntlProvider locale="en" messages={messages}>
     <EnvironmentContext.Provider value={IOP_ENVIRONMENT_CONTEXT}>
       <Provider store={initStore()}>
-        <SystemDetail {...props} />
+        <SystemAdvisorWrapped
+          {...props}
+          IopRemediationModal={props.IopRemediationModal}
+        />
       </Provider>
     </EnvironmentContext.Provider>
   </IntlProvider>
 );
+
+SystemDetailWrapped.propTypes = {
+  IopRemediationModal: PropTypes.elementType,
+};
 
 export default SystemDetailWrapped;

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisorWrapped.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisorWrapped.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { BaseSystemAdvisor } from './SystemAdvisor';
+import PropTypes from 'prop-types';
+
+const SystemAdvisorWrapped = ({ ...props }) => {
+  const inventoryId = props.response?.insights_attributes?.uuid;
+  const entity = {
+    id: inventoryId,
+    insights_id: inventoryId,
+  };
+
+  return (
+    <BaseSystemAdvisor {...props} inventoryId={inventoryId} entity={entity} />
+  );
+};
+
+SystemAdvisorWrapped.propTypes = {
+  response: PropTypes.shape({
+    insights_attributes: PropTypes.shape({
+      uuid: PropTypes.string,
+    }),
+  }),
+};
+
+export default SystemAdvisorWrapped;


### PR DESCRIPTION
Populates the Insights tab for the Satellite IoP environment

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
