### PR TITLE
fix(RHINENG-19776): Fix failing CSV/JSON report download

### DIFF
--- a/src/PresentationalComponents/Common/DownloadHelper.js
+++ b/src/PresentationalComponents/Common/DownloadHelper.js
@@ -22,8 +22,8 @@ const downloadHelper = async (
   workloads,
   SID,
   dispatch,
-  display_name,
   BASE_URL,
+  display_name,
 ) => {
   try {
     let options = selectedTags?.length && { tags: selectedTags };


### PR DESCRIPTION
Downloading CSV/JSON reports was failing because the display_name parameter was being populated with the BASE_URL instead of an actual display_name or being left undefined

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
