### PR TITLE
fix(RHINENG-19870): Disable Remediate button for manual recommendations

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -419,6 +419,7 @@ const Inventory = ({
           <IopRemediationModal.WrappedComponent
             selectedIds={selectedIds}
             iopData={resolutions}
+            isDisabled={isRemediationButtonDisabled}
           />
         ) : (
           <RemediationButton

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -146,6 +146,7 @@ const BaseSystemAdvisor = ({
               <IopRemediationModal.WrappedComponent
                 selectedIds={selectedAnsibleRules}
                 iopData={resolutions}
+                isDisabled={selectedAnsibleRules.length === 0}
               />
             ) : (
               <RemediationButton


### PR DESCRIPTION
User shouldn't be able to remediate recommendations without playbooks.  Select a manual remediation and select systems affected by that rule, the Remediate button shouldn't activate.  See screenshot.

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

This PR is in conjunction with Foreman PR: https://github.com/theforeman/foreman_rh_cloud/pull/1061

<img width="1920" height="1042" alt="Screenshot from 2025-08-05 20-41-03" src="https://github.com/user-attachments/assets/f784272d-695c-4e96-8a59-a1b9cdb73252" />

