### PR TITLE
fix(RHINENG-19874): Enable Tags/Workspace filters accidentally disabled

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -536,9 +536,9 @@ const Inventory = ({
           hideFilters={{
             all: true,
             name: false,
-            tags: true,
+            tags: false,
             operatingSystem: false,
-            hostGroupFilter: true,
+            hostGroupFilter: false,
           }}
           activeFiltersConfig={activeFiltersConfig}
           columns={(defaultColumns) => createColumns(defaultColumns)}


### PR DESCRIPTION
The Tags and Workspaces filters were accidentally disabled in all the IOP shenanigans.  Stuff happens.

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

Showing the filters enabled again:
<img width="1920" height="1009" alt="Screenshot from 2025-08-05 21-16-37" src="https://github.com/user-attachments/assets/b12aaefa-9d0e-4842-acd3-ffcfb65474b1" />

