### PR TITLE
fix(RHINENG-19960): DownloadPlaybookButton API path and CSRF header

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -530,7 +530,7 @@ export const IOP_ENVIRONMENT_CONTEXT = {
   STATS_REPORTS_FETCH_URL: `/insights_cloud/api/insights/v1/stats/reports/`,
   STATS_OVERVIEW_FETCH_URL: `/insights_cloud/api/insights/v1/stats/overview/`,
   SYSTEMS_FETCH_URL: `/insights_cloud/api/insights/v1/system/`,
-  EDGE_DEVICE_BASE_URL: '/api/edge/v1',
+  EDGE_DEVICE_BASE_URL: '/insights_cloud/api/edge/v1',
   INVENTORY_BASE_URL: '/insights_cloud/api/inventory/v1',
-  REMEDIATIONS_BASE_URL: '/api/remediations/v1',
+  REMEDIATIONS_BASE_URL: '/insights_cloud/api/remediations/v1',
 };

--- a/src/Utilities/DownloadPlaybookButton.js
+++ b/src/Utilities/DownloadPlaybookButton.js
@@ -1,23 +1,27 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Button } from '@patternfly/react-core';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import messages from '../Messages';
 import { Post } from './Api';
-import { REMEDIATIONS_BASE_URL } from '../AppConstants';
 import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/';
+import { EnvironmentContext } from '../App';
 
 const DownloadPlaybookButton = ({ isDisabled, rules, systems }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const notification = (data) => dispatch(addNotification(data));
+  const envContext = useContext(EnvironmentContext);
 
   const download = async (payload) => {
     try {
+      const csrfToken = document
+        ?.querySelector('meta[name="csrf-token"]')
+        ?.getAttribute('content');
       const response = await Post(
-        `${REMEDIATIONS_BASE_URL}/playbook`,
-        {},
+        `${envContext.REMEDIATIONS_BASE_URL}/playbook`,
+        { 'X-CSRF-Token': csrfToken },
         payload,
       );
 


### PR DESCRIPTION
The download playbook button needs a couple of changes for it to work:

* API path needs to be prefixed with /insights_cloud
* the headers need to include the CSRF token 


- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
