### PR TITLE
fix(RHINENG-19979): Default to publicPath: auto

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -3,11 +3,10 @@ const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 
 module.exports = {
   appUrl: '/insights/advisor',
-  // uncomment publicPath when working in satellite env
-  //publicPath: 'auto',
-  debug: false,
+  publicPath: process.env.PROXY ? '' : 'auto',
+  debug: true,
   useProxy: process.env.PROXY === 'true',
-  proxyVerbose: false,
+  proxyVerbose: true,
   devtool: 'hidden-source-map',
   plugins: [
     // Put the Sentry Webpack plugin after all other plugins


### PR DESCRIPTION
In the IOP environment, publicPath: auto must be set.  But apparently this is ok to use for the Hosted environment as well.  However when I tried using it in a local dev environment, the RootApp couldn't be loaded, so I set it to '' when using a local environment with the proxy.  

However I'm not sure if this is the best way to make this work.

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
