### PR TITLE
fix(RHINENG-20343): Remove updated column from immutable table

### DIFF
--- a/src/SmartComponents/HybridInventoryTabs/helpers.js
+++ b/src/SmartComponents/HybridInventoryTabs/helpers.js
@@ -146,8 +146,9 @@ export const useOnLoad = (filters) => {
 
 export const mergeAppColumns = (defaultColumns, isRecommendationDetail) => {
   return [
-    ...defaultColumns,
-    lastSeenColumn,
+    // replace 'updated' column with 'last seen'
+    ...defaultColumns.filter(({ key }) => key !== 'updated'),
+    defaultColumns.find(({ key }) => key === 'updated') && lastSeenColumn,
     isRecommendationDetail && impactedDateColumn,
   ];
 };

--- a/src/SmartComponents/HybridInventoryTabs/helpers.test.js
+++ b/src/SmartComponents/HybridInventoryTabs/helpers.test.js
@@ -348,6 +348,8 @@ describe('mergeAppColumns', () => {
   test('Should contain both Last seen and Impacted date columns', () => {
     const result = mergeAppColumns(defaultColumns, true);
 
+    const updated = result.find((column) => column.key === 'updated');
+    expect(updated).toBe(undefined); // 'updated' column should be removed
     const last_seen = result.find((column) => column.key === 'last_seen');
     expect(last_seen).toEqual({
       key: 'last_seen',


### PR DESCRIPTION
The Immutable systems tab has 2 Last seen columns because I failed to removed the original Last seen column which was incorrectly based on the 'updated' attribute

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work


Before fix there are 2 Last seen columns:
<img width="1920" height="1009" alt="Screenshot from 2025-09-03 16-07-46" src="https://github.com/user-attachments/assets/b47659b9-d171-40b4-8853-2e08edc61b08" />


After fix there is just one (the correct one!):
<img width="1920" height="1009" alt="Screenshot from 2025-09-03 16-07-52" src="https://github.com/user-attachments/assets/7c2e6480-a131-478a-ae64-b6ff300c9e5d" />
