### PR TITLE
fix(RHINENG-20646): Hide buttons & fix hosts toolbar in IOP env

### DIFF
--- a/src/PresentationalComponents/Inventory/_Inventory.scss
+++ b/src/PresentationalComponents/Inventory/_Inventory.scss
@@ -17,7 +17,7 @@
 }
 // Fix the vertical position of the checkbox in the bulk select
 #tablesContainer input[type="checkbox"] {
-    margin: 1px 0 0;
+    margin: 0;
 }
 // Fix the size of the (missing) title of Operating System filter group
 #tablesContainer .pf-v5-c-menu__group-title {

--- a/src/PresentationalComponents/RulesTable/RulesTable.cy.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.cy.js
@@ -812,15 +812,25 @@ describe('Export', () => {
       },
     }).as('call');
   });
-  it(`kebab tooltip displays disabled message`, () => {
+  it(`download button not rendered if export not enabled`, () => {
     mountComponent(
       {},
       {
         isExportEnabled: false,
       },
     );
+    cy.get('button[aria-label="Export"]').should('not.exist');
+  });
+
+  it(`download button tooltip displays the correct content if enabled`, () => {
+    mountComponent(
+      {},
+      {
+        isExportEnabled: true,
+      },
+    );
     cy.get('button[aria-label="Export"]').first().trigger('mouseenter');
-    cy.contains(messages.permsAction.defaultMessage).should('be.visible');
+    cy.contains(messages.exportData.defaultMessage).should('be.visible');
   });
 
   it(`works and downloads report is enabled`, () => {

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -246,26 +246,24 @@ const RulesTable = ({ isTabActive, pathway }) => {
           },
           isCompact: true,
         }}
-        exportConfig={{
-          label: intl.formatMessage(messages.exportCsv),
-
-          label: intl.formatMessage(messages.exportJson),
-          onSelect: (_e, fileType) =>
-            downloadReport(
-              'hits',
-              fileType,
-              filterFetchBuilder(filters),
-              selectedTags,
-              workloads,
-              SID,
-              dispatch,
-              envContext.BASE_URL,
-            ),
-          isDisabled: !envContext.isExportEnabled,
-          tooltipText: envContext.isExportEnabled
-            ? intl.formatMessage(messages.exportData)
-            : intl.formatMessage(messages.permsAction),
-        }}
+        exportConfig={
+          envContext.isExportEnabled && {
+            label: intl.formatMessage(messages.exportCsv),
+            label: intl.formatMessage(messages.exportJson),
+            onSelect: (_e, fileType) =>
+              downloadReport(
+                'hits',
+                fileType,
+                filterFetchBuilder(filters),
+                selectedTags,
+                workloads,
+                SID,
+                dispatch,
+                envContext.BASE_URL,
+              ),
+            tooltipText: intl.formatMessage(messages.exportData),
+          }
+        }
         filterConfig={{
           items: [
             ...filterConfigItems(

--- a/src/SmartComponents/Recs/DetailsRules.js
+++ b/src/SmartComponents/Recs/DetailsRules.js
@@ -118,60 +118,66 @@ export const DetailsRules = ({
         >
           <Flex>
             <FlexItem align={{ default: 'alignRight' }}>
-              <Tooltip
-                trigger={!permsDisableRec ? 'mouseenter' : ''}
-                content={intl.formatMessage(messages.permsAction)}
-              >
-                <Dropdown
-                  className="adv-c-dropdown-details-actions"
-                  onSelect={() => setActionsDropdownOpen(!actionsDropdownOpen)}
-                  position="right"
-                  ouiaId="actions"
-                  toggle={
-                    <DropdownToggle
-                      isDisabled={!permsDisableRec}
-                      onToggle={(_event, actionsDropdownOpen) =>
-                        setActionsDropdownOpen(actionsDropdownOpen)
-                      }
-                      toggleIndicator={CaretDownIcon}
-                    >
-                      {intl.formatMessage(messages.actions)}
-                    </DropdownToggle>
-                  }
-                  isOpen={actionsDropdownOpen}
-                  dropdownItems={
-                    rule && rule.rule_status === 'enabled'
-                      ? [
-                          <DropdownItem
-                            key="link"
-                            ouiaId="disable"
-                            onClick={() => {
-                              handleModalToggle(true);
-                            }}
-                          >
-                            {intl.formatMessage(messages.disableRule)}
-                          </DropdownItem>,
-                        ]
-                      : [
-                          <DropdownItem
-                            key="link"
-                            ouiaId="enable"
-                            onClick={() => {
-                              enableRule(
-                                rule,
-                                refetch,
-                                intl,
-                                addNotification,
-                                handleModalToggle,
-                              );
-                            }}
-                          >
-                            {intl.formatMessage(messages.enableRule)}
-                          </DropdownItem>,
-                        ]
-                  }
-                />
-              </Tooltip>
+              {envContext.isDisableRecEnabled ? (
+                <Tooltip
+                  trigger={!permsDisableRec ? 'mouseenter' : ''}
+                  content={intl.formatMessage(messages.permsAction)}
+                >
+                  <Dropdown
+                    className="adv-c-dropdown-details-actions"
+                    onSelect={() =>
+                      setActionsDropdownOpen(!actionsDropdownOpen)
+                    }
+                    position="right"
+                    ouiaId="actions"
+                    toggle={
+                      <DropdownToggle
+                        isDisabled={!permsDisableRec}
+                        onToggle={(_event, actionsDropdownOpen) =>
+                          setActionsDropdownOpen(actionsDropdownOpen)
+                        }
+                        toggleIndicator={CaretDownIcon}
+                      >
+                        {intl.formatMessage(messages.actions)}
+                      </DropdownToggle>
+                    }
+                    isOpen={actionsDropdownOpen}
+                    dropdownItems={
+                      rule && rule.rule_status === 'enabled'
+                        ? [
+                            <DropdownItem
+                              key="link"
+                              ouiaId="disable"
+                              onClick={() => {
+                                handleModalToggle(true);
+                              }}
+                            >
+                              {intl.formatMessage(messages.disableRule)}
+                            </DropdownItem>,
+                          ]
+                        : [
+                            <DropdownItem
+                              key="link"
+                              ouiaId="enable"
+                              onClick={() => {
+                                enableRule(
+                                  rule,
+                                  refetch,
+                                  intl,
+                                  addNotification,
+                                  handleModalToggle,
+                                );
+                              }}
+                            >
+                              {intl.formatMessage(messages.enableRule)}
+                            </DropdownItem>,
+                          ]
+                    }
+                  />
+                </Tooltip>
+              ) : (
+                <></>
+              )}
             </FlexItem>
           </Flex>
         </RuleDetails>

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.cy.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.cy.js
@@ -335,7 +335,7 @@ describe('system rules table', () => {
 
     it(`Export kebab tooltip displays the correct content.`, () => {
       mountComponent(
-        { isExportEnabled: false },
+        { isExportEnabled: true },
         <Button
           variant="primary"
           isDisabled={() => console.log('test')}
@@ -345,7 +345,7 @@ describe('system rules table', () => {
         </Button>,
       );
       cy.get('button[aria-label="Export"]').first().trigger('mouseenter');
-      cy.contains(messages.permsAction.defaultMessage).should('be.visible');
+      cy.contains(messages.exportData.defaultMessage).should('be.visible');
     });
 
     it(`Critical tooltip displays the correct content.`, () => {

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -78,9 +78,6 @@ const BaseSystemAdvisor = ({
     return getSelectedItems(rows).filter((r) => r.resolution?.has_playbook);
   }, [rows]);
   const selectedItemsLength = getSelectedItems(rows).length;
-  const selectableItemsLength = rows.filter(
-    (r) => r.resolution?.has_playbook,
-  ).length;
 
   const [resolutions, setResolutions] = useState([]);
 
@@ -135,13 +132,6 @@ const BaseSystemAdvisor = ({
     !isSystemProfileLoading && systemProfile?.host_type !== 'edge'
       ? [
           <Flex key="inventory-actions">
-            {envContext.displayDownloadPlaybookButton && (
-              <DownloadPlaybookButton
-                isDisabled={selectedAnsibleRules.length === 0}
-                rules={selectedAnsibleRules.map((rule) => rule.rule)}
-                systems={[inventoryId]}
-              />
-            )}
             {IopRemediationModal ? (
               <IopRemediationModal.WrappedComponent
                 selectedIds={selectedAnsibleRules}
@@ -158,6 +148,13 @@ const BaseSystemAdvisor = ({
               >
                 Plan remediation
               </RemediationButton>
+            )}
+            {envContext.displayDownloadPlaybookButton && (
+              <DownloadPlaybookButton
+                isDisabled={selectedAnsibleRules.length === 0}
+                rules={selectedAnsibleRules.map((rule) => rule.rule)}
+                systems={[inventoryId]}
+              />
             )}
           </Flex>,
         ]
@@ -220,16 +217,11 @@ const BaseSystemAdvisor = ({
     );
   };
   const checkedStatus = () => {
-    if (selectedItemsLength === systemAdvisorRef.current.rowCount) {
-      return 1;
-    } else if (
-      selectedItemsLength > 0 ||
-      selectableItemsLength !== systemAdvisorRef.current.rowCount
-    ) {
-      return null;
-    } else {
-      return 0;
-    }
+    return selectedItemsLength > 0
+      ? selectedItemsLength === systemAdvisorRef.current.rowCount
+        ? 1
+        : null
+      : 0;
   };
 
   const bulkSelect = {
@@ -497,7 +489,10 @@ const BaseSystemAdvisor = ({
       buttonText={intl.formatMessage(messages.notConnectedButton)}
     />
   ) : (
-    <div className="ins-c-inventory-insights__overrides">
+    <div
+      id="system-advisor-table"
+      className="ins-c-inventory-insights__overrides"
+    >
       {inventoryReportFetchStatus === 'pending' ||
       entity?.insights_id === null ? (
         <Fragment />
@@ -517,27 +512,25 @@ const BaseSystemAdvisor = ({
             </Fragment>
           }
           activeFiltersConfig={activeFiltersConfig}
-          exportConfig={{
-            label: intl.formatMessage(messages.exportCsv),
-
-            label: intl.formatMessage(messages.exportJson),
-            onSelect: (_e, fileType) =>
-              downloadReport(
-                'hits',
-                fileType,
-                { ...filters, text: searchValue },
-                selectedTags,
-                workloads,
-                SID,
-                dispatch,
-                display_name,
-                envContext.BASE_URL,
-              ),
-            isDisabled: !envContext.isExportEnabled,
-            tooltipText: envContext.isExportEnabled
-              ? intl.formatMessage(messages.exportData)
-              : intl.formatMessage(messages.permsAction),
-          }}
+          exportConfig={
+            envContext.isExportEnabled && {
+              label: intl.formatMessage(messages.exportCsv),
+              label: intl.formatMessage(messages.exportJson),
+              onSelect: (_e, fileType) =>
+                downloadReport(
+                  'hits',
+                  fileType,
+                  { ...filters, text: searchValue },
+                  selectedTags,
+                  workloads,
+                  SID,
+                  dispatch,
+                  display_name,
+                  envContext.BASE_URL,
+                ),
+              tooltipText: intl.formatMessage(messages.exportData),
+            }
+          }
         />
       )}
       {inventoryReportFetchStatus === 'pending' && (

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.scss
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.scss
@@ -31,3 +31,17 @@
     text-align: center;
   }
 }
+
+// Override Satellite/Foreman styles that impact the styling of the Inventory table
+// Prevent the toolbar buttons being pushed to the end of the toolbar
+#system-advisor-table .pf-v5-c-toolbar__group {
+    flex-grow: 0;
+}
+#system-advisor-table .pf-v5-c-toolbar__group:first-child {
+    margin-right: 1rem;
+    width: auto;
+}
+// Fix the vertical position of the checkbox in the bulk select
+#system-advisor-table input[type="checkbox"] {
+    margin: 0;
+}

--- a/src/SmartComponents/Topics/Details.cy.js
+++ b/src/SmartComponents/Topics/Details.cy.js
@@ -101,12 +101,19 @@ describe('Topic Details is loaded correctly for user without Edge systems', () =
 });
 
 describe('Export', () => {
-  it(`Export kebab tooltip displays the correct content if disabled.`, () => {
+  it(`download button not rendered if export not enabled`, () => {
     mountComponent(true, {
       isExportEnabled: false,
     });
+    cy.get('button[aria-label="Export"]').should('not.exist');
+  });
+
+  it(`download button tooltip displays the correct content if enabled`, () => {
+    mountComponent(true, {
+      isExportEnabled: true,
+    });
     cy.get('button[aria-label="Export"]').first().trigger('mouseenter');
-    cy.contains(messages.permsAction.defaultMessage).should('be.visible');
+    cy.contains(messages.exportData.defaultMessage).should('be.visible');
   });
 
   it(`works and downloads report is enabled`, () => {


### PR DESCRIPTION
Removes the Action and Export buttons from the IOP environment.  Also fixes the styling of the toolbar on the Hosts page

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

Removes the Action button:
<img width="1920" height="1009" alt="Screenshot from 2025-09-10 17-10-29" src="https://github.com/user-attachments/assets/317acf39-b054-4fdd-ba8a-1c25151026d6" />


Removes the Export button and fixes the styling of the Hosts toolbar:
<img width="1920" height="1009" alt="Screenshot from 2025-09-10 17-10-08" src="https://github.com/user-attachments/assets/8d9db41b-2369-4ad4-86cb-0cc73a6aa1ad" />

