### PR TITLE
fix(SAT-38669): Fix store creation in ListWrapped component

### DIFF
--- a/src/SmartComponents/Recs/ListWrapped.js
+++ b/src/SmartComponents/Recs/ListWrapped.js
@@ -7,10 +7,12 @@ import { EnvironmentContext } from '../../App';
 import { initStore } from '../../Store';
 import ListIop from './ListIop';
 
+const dbStore = initStore();
+
 const ListWrapped = (props) => (
   <IntlProvider locale="en" messages={messages}>
     <EnvironmentContext.Provider value={IOP_ENVIRONMENT_CONTEXT}>
-      <Provider store={initStore()}>
+      <Provider store={dbStore}>
         <ListIop {...props} />
       </Provider>
     </EnvironmentContext.Provider>


### PR DESCRIPTION
# Description

Associated Jira ticket: SAT-38669

This PR fixes an issue In Satellite with IoP:
1.) Click on Recommendations in the navigation menu. Wait for the page to load.
2.) Click on Recommendations a second time. The Recommendations table refreshes but hangs in a loading "skeleton" state.

The problem is in the `ListWrapped` component, which is what Satellite / foreman_rh_cloud imports and renders. `ListWrapped` was re-initializing its Redux store each time it was rendered. This PR fixes the issue by moving the store creation out of the component, so that it's only initialized once. With this fix in place, the page does not reload at all when clicking "Recommendations" a second time, which is the expected behavior (and matches the behavior of the "Vulnerability" page).

# How to test the PR



# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
