### PR TITLE
fix(RHINENG-20837): Add OUIA-ID to components, esp for IOP

### DIFF
--- a/src/PresentationalComponents/Cards/OverviewDashbarCard/OverviewDashbarCard.js
+++ b/src/PresentationalComponents/Cards/OverviewDashbarCard/OverviewDashbarCard.js
@@ -18,7 +18,7 @@ export const OverviewDashbarCard = ({
   count,
   onClickFilterByName,
 }) => (
-  <Card isFullHeight className="dashbar-item">
+  <Card isFullHeight className="dashbar-item" ouiaId="overview-dashbar-card">
     <CardBody>
       {title}
 

--- a/src/PresentationalComponents/Cards/ResolutionCard.js
+++ b/src/PresentationalComponents/Cards/ResolutionCard.js
@@ -27,6 +27,7 @@ export const ResolutionCard = ({
       isFlat
       isPlain
       className="adv-c-card-pathway adv__background--global-100 pf-v5-u-h-100 flex-row"
+      ouiaId="resolution-card"
     >
       <div className="flex-coloumn">
         <CardTitle>{intl.formatMessage(messages.resolution)}</CardTitle>

--- a/src/PresentationalComponents/Cards/TotalRiskCard.js
+++ b/src/PresentationalComponents/Cards/TotalRiskCard.js
@@ -50,6 +50,7 @@ export const TotalRiskCard = (props) => {
       isFlat
       isPlain
       className="adv-c-card-pathway adv__background--global-100 pf-v5-u-h-100"
+      ouiaId="total-risk-card"
     >
       <CardTitle>{intl.formatMessage(messages.totalRiskPathway)}</CardTitle>
       <CardBody className="body">

--- a/src/PresentationalComponents/ExecutiveReport/RecommendationCharts.js
+++ b/src/PresentationalComponents/ExecutiveReport/RecommendationCharts.js
@@ -4,7 +4,15 @@ import { POUND_OF_RECS } from '../../AppConstants';
 import { Text } from '@react-pdf/renderer';
 import { ChartPie } from '@patternfly/react-charts';
 import { Flex, FlexItem } from '@patternfly/react-core';
-import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import {
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  TableVariant,
+} from '@patternfly/react-table';
 import chart_color_red_100 from '@patternfly/react-tokens/dist/js/chart_color_red_100';
 import global_BackgroundColor_150 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_150';
 
@@ -20,7 +28,11 @@ const RecommendationCharts = ({
       <Text style={{ color: chart_color_red_100.value }}>{header}</Text>
       <Flex defaultspaceItems={{ default: 'spaceItemsLg' }}>
         <FlexItem style={{ width: '40%' }}>
-          <Table variant="compact">
+          <Table
+            aria-label={'recommendation-chart-table'}
+            ouiaId={'recommendation-chart-table'}
+            variant={TableVariant.compact}
+          >
             <Thead>
               <Tr>
                 <Th>{columnHeader}</Th>

--- a/src/PresentationalComponents/Export/TablePage.js
+++ b/src/PresentationalComponents/Export/TablePage.js
@@ -7,7 +7,15 @@ import {
 } from '../../AppConstants';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import {
+  Table,
+  TableVariant,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@patternfly/react-table';
 import global_BackgroundColor_200 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_200';
 
 export const TablePage = ({ systems, styles }) => {
@@ -102,7 +110,11 @@ export const TablePage = ({ systems, styles }) => {
   ];
 
   return (
-    <Table variant="compact">
+    <Table
+      aria-label={'export-table'}
+      ouiaId={'export-table'}
+      variant={TableVariant.compact}
+    >
       <Thead>
         {header.map((colHeader) =>
           headerBuilder({ value: colHeader.value, style: colHeader.style }),

--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -452,6 +452,7 @@ const Inventory = ({
           module="./IOPInventoryTable"
           store={store}
           id="tablesContainer"
+          ouiaId="iop-inventory-table"
           hasCheckbox
           initialLoading
           autoRefresh
@@ -519,7 +520,8 @@ const Inventory = ({
         />
       ) : (
         <InventoryTable
-          id="tablesContainer"
+          id={'tablesContainer'}
+          ouiaId={'inventory-table'}
           hasCheckbox
           initialLoading
           autoRefresh
@@ -568,7 +570,6 @@ const Inventory = ({
           exportConfig={
             permsExport && {
               label: intl.formatMessage(messages.exportCsv),
-
               label: intl.formatMessage(messages.exportJson),
               onSelect: (_e, fileType) =>
                 downloadReport(

--- a/src/PresentationalComponents/Loading/Failed.js
+++ b/src/PresentationalComponents/Loading/Failed.js
@@ -6,7 +6,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 
 const Failed = ({ message }) => (
-  <Card className="adv-c-card-empty-rule">
+  <Card className="adv-c-card-empty-rule" ouiaId="failed-card">
     <CardHeader>
       <FrownOpenIcon size="lg" />
     </CardHeader>

--- a/src/PresentationalComponents/Loading/Loading.js
+++ b/src/PresentationalComponents/Loading/Loading.js
@@ -2,7 +2,7 @@ import { Card, CardBody } from '@patternfly/react-core';
 import { List } from 'react-content-loader';
 import React from 'react';
 const Loading = () => (
-  <Card>
+  <Card ouiaId="loading-card">
     <CardBody>
       <List data-ouia-component-id="loading-skeleton" />
     </CardBody>

--- a/src/PresentationalComponents/Modals/ViewHostAcks.js
+++ b/src/PresentationalComponents/Modals/ViewHostAcks.js
@@ -110,13 +110,19 @@ const ViewHostAcks = ({
       }}
     >
       {!isFetching ? (
-        <Table aria-label="host-ack-table" rows={rows} cells={columns}>
+        <Table
+          aria-label={'host-ack-table'}
+          ouiaId={'host-ack-table'}
+          rows={rows}
+          cells={columns}
+        >
           <TableHeader />
           <TableBody />
         </Table>
       ) : (
         <Table
-          aria-label="host-ack-table"
+          aria-label={'host-ack-table'}
+          ouiaId={'host-ack-table'}
           rows={[
             {
               cells: [{ props: { colSpan: 3 }, title: <List /> }],

--- a/src/PresentationalComponents/PathwaysTable/PathwaysTable.js
+++ b/src/PresentationalComponents/PathwaysTable/PathwaysTable.js
@@ -393,6 +393,7 @@ const PathwaysTable = ({ isTabActive }) => {
       ) : (
         <Table
           aria-label={'pathways-table'}
+          ouiaId={'pathways-table'}
           variant={TableVariant.compact}
           sortBy={sortBy}
           onSort={onSort}

--- a/src/PresentationalComponents/RulesTable/RulesTable.cy.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.cy.js
@@ -113,7 +113,7 @@ const DEFAULT_FILTERS = {
   status: 'Enabled',
 };
 const TABLE_HEADERS = _.map(rulesTableColumns, (it) => it.title);
-const ROOT = 'table[aria-label=rule-table]';
+const ROOT = 'table[data-ouia-component-id=rules-table]';
 const CRITICAL_TOOLTIP_CONTENT =
   'The total risk of this remediation is critical, based on the combination of likelihood and impact to remediate.';
 const IMPORTANT_TOOLTIP_CONTENT =

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -291,7 +291,8 @@ const RulesTable = ({ isTabActive, pathway }) => {
         </Table>
       ) : (
         <Table
-          aria-label={'rule-table'}
+          aria-label={'rules-table'}
+          ouiaId={'rules-table'}
           variant={TableVariant.compact}
           actionResolver={
             envContext.isDisableRecEnabled ? actionResolver : null

--- a/src/PresentationalComponents/TopicsAdminTable/TopicsAdminTable.js
+++ b/src/PresentationalComponents/TopicsAdminTable/TopicsAdminTable.js
@@ -211,8 +211,8 @@ const TopicsAdminTable = () => {
           </PrimaryToolbar>
           {!isLoading && !isFetching && (
             <Table
-              ouiaId="adminTable"
               aria-label={'topics-admin-table'}
+              ouiaId={'topics-admin-table'}
               sortBy={sortBy}
               onSort={onSort}
               cells={cols}

--- a/src/PresentationalComponents/TopicsTable/TopicsTable.js
+++ b/src/PresentationalComponents/TopicsTable/TopicsTable.js
@@ -152,11 +152,11 @@ const TopicsTable = ({ props }) => {
           />
           <Table
             aria-label={'topics-table'}
+            ouiaId={'topics-table'}
             sortBy={sort}
             onSort={onSort}
             cells={cols}
             rows={rows}
-            ouiaId="topicTable"
             isStickyHeader
           >
             <TableHeader />

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -151,7 +151,7 @@ const OverviewDetails = (props) => {
           )}
           <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
             {(rule.hosts_acked_count > 0 || rule.rule_status !== 'enabled') && (
-              <Card className="adv-c-card-details">
+              <Card className="adv-c-card-details" ouiaId="rule-details-card">
                 <CardHeader>
                   <Title headingLevel="h4" size="xl">
                     <BellSlashIcon size="sm" />

--- a/src/SmartComponents/Recs/IopRecommendationDetails.js
+++ b/src/SmartComponents/Recs/IopRecommendationDetails.js
@@ -148,7 +148,7 @@ const IopRecommendationDetails = (props) => {
           )}
           <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
             {(rule.hosts_acked_count > 0 || rule.rule_status !== 'enabled') && (
-              <Card className="adv-c-card-details">
+              <Card className="adv-c-card-details" ouiaId="rule-details-card">
                 <CardHeader>
                   <Title headingLevel="h4" size="xl">
                     <BellSlashIcon size="sm" />

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.cy.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.cy.js
@@ -36,7 +36,7 @@ const TABLE_HEADERS = [
   'Total risk',
   'Remediation type',
 ];
-const ROOT = 'table[id=system-advisor-report-table]';
+const ROOT = 'table[data-ouia-component-id=system-advisor-table]';
 const SYSTEM_ID = '123';
 const SYSTEM_INSIGHTS_ID = '456';
 

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -498,6 +498,7 @@ const BaseSystemAdvisor = ({
         <Fragment />
       ) : (
         <PrimaryToolbar
+          ouiaId="system-advisor-table-toolbar"
           expandAll={{ isAllExpanded, onClick: onExpandAllClick }}
           actionsConfig={{ actions }}
           bulkSelect={bulkSelect}
@@ -539,8 +540,8 @@ const BaseSystemAdvisor = ({
       {inventoryReportFetchStatus === 'fulfilled' && (
         <Fragment>
           <Table
-            id={'system-advisor-report-table'}
-            aria-label={'report-table'}
+            ouiaId={'system-advisor-table'}
+            aria-label={'system-advisor-table'}
             onSelect={!(rows.length === 1 && rows[0].heightAuto) && onRowSelect}
             onCollapse={handleOnCollapse}
             rows={rows}

--- a/src/Utilities/DownloadPlaybookButton.js
+++ b/src/Utilities/DownloadPlaybookButton.js
@@ -72,6 +72,7 @@ const DownloadPlaybookButton = ({ isDisabled, rules, systems }) => {
     <Button
       id="download-playbook-button"
       key="download-playbook-button"
+      ouiaId="download-playbook-button"
       variant="secondary"
       isDisabled={isDisabled}
       onClick={() => download(preparePayload(rules, systems))}


### PR DESCRIPTION
Adds data-ouia-component-id values for components that I can, esp Table & Card patternfly components.  However for components from RedHatInsights/frontend-components, most don't take an ouiaId prop so I can't pass an ouiaId value to them.

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
