### PR TITLE
chore(deps): redux version update so it won't crash container build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "react-markdown": "9.0.1",
         "react-redux": "^8.1.3",
         "react-router-dom": "^6.23.1",
-        "redux": "^5.0.1",
+        "redux": "^4.2.1",
         "redux-logger": "3.0.6",
         "redux-mock-store": "^1.5.4",
         "redux-promise-middleware": "6.2.0",
@@ -7139,6 +7139,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "node_modules/@reduxjs/toolkit/node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -23192,9 +23197,12 @@
       }
     },
     "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
     },
     "node_modules/redux-logger": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "react-markdown": "9.0.1",
     "react-redux": "^8.1.3",
     "react-router-dom": "^6.23.1",
-    "redux": "^5.0.1",
+    "redux": "^4.2.1",
     "redux-logger": "3.0.6",
     "redux-mock-store": "^1.5.4",
     "redux-promise-middleware": "6.2.0",


### PR DESCRIPTION
Redux 5.0.1 version that was updated today is causing a container build to fail, I am reverting it back to the old value