### PR TITLE
fix(RHINENG-23894): Hacky FE workaround for BE issue RHINENG-24023

### DIFF
--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -262,6 +262,13 @@ const SystemsTable = () => {
             await Get(envContext.SYSTEMS_FETCH_URL, {}, options)
           )?.data;
 
+          // Hack to remove systems without a last_seen value from the table,
+          // because it's likely this system was deleted from Inventory, but
+          // Advisor didn't get the notification (RHINENG-24023)
+          fetchedSystems.data = fetchedSystems.data.filter(
+            (system) => system.last_seen !== null,
+          );
+
           handleRefresh(options);
           const results = await defaultGetEntities(
             // additional request to fetch hosts' operating system values


### PR DESCRIPTION
Not proud of this PR but at least it allows the SystemsTable to load in the FE.  It removes systems that don't have a last_seen value, which is an indication that the system only exists in Advisor but not in Inventory.  Thus we don't query Inventory for these systems because Inventory would return a 404 error instead of a list of systems.

I would hope this is just a temporary workaround until Advisor BE issue RHINENG-24023 is resolved (could be a while tho)

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

Before the fix - in prod as insights-qa and sorting on the Last Seen column:
<img width="1920" height="1009" alt="Screenshot from 2026-02-11 17-22-20" src="https://github.com/user-attachments/assets/846ef483-7d21-4789-bffc-e3faeec6ba60" />

After workaround, the table displays but with a smaller number of systems than a full page:
<img width="1920" height="1009" alt="Screenshot from 2026-02-11 17-23-38" src="https://github.com/user-attachments/assets/ead7c42f-a1f1-4f44-9a5a-a9a0f1961e1b" />

