### PR TITLE
fix(RHINENG-23894): fix the case with last seen null for systems

### DIFF
--- a/src/PresentationalComponents/Inventory/InventoryDetails.js
+++ b/src/PresentationalComponents/Inventory/InventoryDetails.js
@@ -6,7 +6,7 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core/dist/esm/layouts/Grid/index';
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { connect, useStore } from 'react-redux';
 import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
 import Breadcrumbs from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
@@ -18,8 +18,12 @@ import { updateReducers } from '../../Store';
 import { useIntl } from 'react-intl';
 import SystemAdvisor from '../../SmartComponents/SystemAdvisor';
 import { useParams } from 'react-router-dom';
-import { Skeleton } from '@patternfly/react-core';
+import { Skeleton, Bullseye } from '@patternfly/react-core';
 import { EnvironmentContext } from '../../App';
+import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import MessageState from '../MessageState/MessageState';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/';
 
 const InventoryHeadFallback = () => {
   return (
@@ -39,6 +43,55 @@ const InventoryDetails = ({ entity }) => {
   const store = useStore();
   const { inventoryId } = useParams();
   const envContext = useContext(EnvironmentContext);
+  const axios = useAxiosWithPlatformInterceptors();
+  const addNotification = useAddNotification();
+  const [systemExists, setSystemExists] = useState(true);
+  const [checking, setChecking] = useState(true);
+
+  /**
+   * Check if the system exists in Advisor and has a valid last_seen value.
+   * Systems with last_seen: null don't exist in Inventory and will cause
+   * DetailWrapper to throw a 404 error. This check prevents that by validating
+   * the system before attempting to render the DetailWrapper component.
+   */
+  useEffect(() => {
+    const checkSystem = async () => {
+      try {
+        const response = await axios.get(
+          `${envContext.BASE_URL}/system/?system_uuid=${inventoryId}`,
+        );
+        const system = response.data?.data?.[0];
+        if (!system || system.last_seen === null) {
+          setSystemExists(false);
+        }
+      } catch (error) {
+        if (error.response?.status === 404) {
+          setSystemExists(false);
+        }
+      } finally {
+        setChecking(false);
+      }
+    };
+
+    checkSystem();
+  }, [inventoryId, axios, envContext.BASE_URL]);
+
+  /**
+   * Display a notification when a non-existent system is detected.
+   * This runs after the check completes to inform the user why they're
+   * seeing an empty state instead of system details.
+   */
+  useEffect(() => {
+    if (!checking && !systemExists) {
+      addNotification({
+        variant: 'warning',
+        title: 'System not available',
+        description:
+          'This system no longer exists in your inventory and cannot be displayed.',
+      });
+    }
+  }, [checking, systemExists, addNotification]);
+
   useEffect(() => {
     if (entity && (entity.display_name || entity.id)) {
       envContext.updateDocumentTitle(
@@ -46,6 +99,33 @@ const InventoryDetails = ({ entity }) => {
       );
     }
   }, [envContext, entity]);
+
+  if (checking) {
+    return (
+      <PageHeader className="pf-m-light ins-inventory-detail">
+        <InventoryHeadFallback />
+      </PageHeader>
+    );
+  }
+
+  if (!systemExists) {
+    return (
+      <>
+        <PageHeader className="pf-m-light ins-inventory-detail">
+          <Breadcrumbs current="System not found" />
+        </PageHeader>
+        <section className="pf-v6-l-page__main-section pf-v6-c-page__main-section">
+          <Bullseye>
+            <MessageState
+              icon={ExclamationCircleIcon}
+              title="System not available"
+              text="This system no longer exists in your inventory."
+            />
+          </Bullseye>
+        </section>
+      </>
+    );
+  }
 
   return (
     <DetailWrapper

--- a/src/PresentationalComponents/Inventory/helpers.js
+++ b/src/PresentationalComponents/Inventory/helpers.js
@@ -98,19 +98,55 @@ export const getEntities =
     };
     setFullFilters(allDetails);
     const fetchedSystems = await paginatedRequestHelper(allDetails);
-    const results = await defaultGetEntities(
-      fetchedSystems.data.map((system) => system.system_uuid),
-      {
-        per_page,
-        hasItems: true,
-        fields: { system_profile: ['operating_system'] },
-      },
-      showTags,
+
+    /**
+     * Filter out systems that don't exist in Inventory.
+     * Systems with last_seen: null exist in Advisor but not in Inventory,
+     * which causes 404 errors when querying the Inventory API.
+     */
+    const systemsInInventory = fetchedSystems.data.filter(
+      (system) => system.last_seen !== null,
     );
-    setCurPageIds(fetchedSystems.data.map((system) => system.system_uuid));
-    setTotal(fetchedSystems.meta.count);
+
+    /**
+     * Adjust the total count to account for filtered systems.
+     * The backend returns a count that includes systems with last_seen: null,
+     * but we filter those out on the frontend to prevent 404 errors when
+     * querying the Inventory API. We subtract the number of filtered systems
+     * from this page to keep the count approximately accurate for pagination.
+     */
+    const filteredOutCount =
+      fetchedSystems.data.length - systemsInInventory.length;
+
+    let results = { results: [] };
+    if (systemsInInventory.length > 0) {
+      try {
+        results = await defaultGetEntities(
+          systemsInInventory.map((system) => system.system_uuid),
+          {
+            per_page,
+            hasItems: true,
+            fields: { system_profile: ['operating_system'] },
+          },
+          showTags,
+        );
+      } catch (inventoryError) {
+        /**
+         * Handle 404 errors gracefully in case systems are missing from Inventory.
+         * This is a safety net - the filtering above should prevent most 404s.
+         */
+        if (inventoryError.response?.status === 404) {
+          results = { results: [] };
+        } else {
+          throw inventoryError;
+        }
+      }
+    }
+
+    setCurPageIds(systemsInInventory.map((system) => system.system_uuid));
+    setTotal(Math.max(0, fetchedSystems.meta.count - filteredOutCount));
     return Promise.resolve({
-      results: mergeArraysByDiffKeys(fetchedSystems.data, results.results).map(
+      results: mergeArraysByDiffKeys(systemsInInventory, results.results).map(
         (item) => {
           return {
             ...item,
@@ -118,7 +154,7 @@ export const getEntities =
           };
         },
       ),
-      total: fetchedSystems.meta.count,
+      total: Math.max(0, fetchedSystems.meta.count - filteredOutCount),
     });
   };
 

--- a/src/PresentationalComponents/Inventory/helpers.test.js
+++ b/src/PresentationalComponents/Inventory/helpers.test.js
@@ -490,6 +490,203 @@ describe('Inventory helpers', () => {
         true,
       );
     });
+
+    describe('last_seen null filtering', () => {
+      it('filters out systems with last_seen null', async () => {
+        const mockFetchedSystems = {
+          data: [
+            { system_uuid: 'uuid-1', last_seen: '2026-04-14T10:00:00Z' },
+            { system_uuid: 'uuid-2', last_seen: null },
+            { system_uuid: 'uuid-3', last_seen: '2026-04-13T10:00:00Z' },
+          ],
+          meta: { count: 3 },
+        };
+        const mockDefaultEntities = {
+          results: [{ id: 'uuid-1' }, { id: 'uuid-3' }],
+        };
+
+        mockAxiosGet.mockResolvedValue(mockFetchedSystems);
+        mockDefaultGetEntities.mockResolvedValue(mockDefaultEntities);
+
+        const fetchEntities = getEntities(
+          mockHandleRefresh,
+          null,
+          mockSetCurPageIds,
+          mockSetTotal,
+          [],
+          mockSetFullFilters,
+          {},
+          rule,
+          RULES_FETCH_URL,
+          SYSTEMS_FETCH_URL,
+          mockAxios,
+        );
+
+        const result = await fetchEntities(
+          [],
+          config,
+          true,
+          mockDefaultGetEntities,
+        );
+
+        expect(mockDefaultGetEntities).toHaveBeenCalledWith(
+          ['uuid-1', 'uuid-3'],
+          expect.any(Object),
+          true,
+        );
+        expect(mockSetCurPageIds).toHaveBeenCalledWith(['uuid-1', 'uuid-3']);
+        expect(result.results).toHaveLength(2);
+      });
+
+      it('adjusts total count when filtering systems', async () => {
+        const mockFetchedSystems = {
+          data: [
+            { system_uuid: 'uuid-1', last_seen: '2026-04-14T10:00:00Z' },
+            { system_uuid: 'uuid-2', last_seen: null },
+            { system_uuid: 'uuid-3', last_seen: null },
+          ],
+          meta: { count: 100 },
+        };
+        const mockDefaultEntities = {
+          results: [{ id: 'uuid-1' }],
+        };
+
+        mockAxiosGet.mockResolvedValue(mockFetchedSystems);
+        mockDefaultGetEntities.mockResolvedValue(mockDefaultEntities);
+
+        const fetchEntities = getEntities(
+          mockHandleRefresh,
+          null,
+          mockSetCurPageIds,
+          mockSetTotal,
+          [],
+          mockSetFullFilters,
+          {},
+          rule,
+          RULES_FETCH_URL,
+          SYSTEMS_FETCH_URL,
+          mockAxios,
+        );
+
+        const result = await fetchEntities(
+          [],
+          config,
+          true,
+          mockDefaultGetEntities,
+        );
+
+        expect(mockSetTotal).toHaveBeenCalledWith(98);
+        expect(result.total).toBe(98);
+      });
+
+      it('skips Inventory API call when all systems have last_seen null', async () => {
+        const mockFetchedSystems = {
+          data: [
+            { system_uuid: 'uuid-1', last_seen: null },
+            { system_uuid: 'uuid-2', last_seen: null },
+          ],
+          meta: { count: 2 },
+        };
+
+        mockAxiosGet.mockResolvedValue(mockFetchedSystems);
+
+        const fetchEntities = getEntities(
+          mockHandleRefresh,
+          null,
+          mockSetCurPageIds,
+          mockSetTotal,
+          [],
+          mockSetFullFilters,
+          {},
+          rule,
+          RULES_FETCH_URL,
+          SYSTEMS_FETCH_URL,
+          mockAxios,
+        );
+
+        const result = await fetchEntities(
+          [],
+          config,
+          true,
+          mockDefaultGetEntities,
+        );
+
+        expect(mockDefaultGetEntities).not.toHaveBeenCalled();
+        expect(mockSetCurPageIds).toHaveBeenCalledWith([]);
+        expect(mockSetTotal).toHaveBeenCalledWith(0);
+        expect(result.results).toHaveLength(0);
+        expect(result.total).toBe(0);
+      });
+
+      it('handles 404 errors from Inventory API gracefully', async () => {
+        const mockFetchedSystems = {
+          data: [{ system_uuid: 'uuid-1', last_seen: '2026-04-14T10:00:00Z' }],
+          meta: { count: 1 },
+        };
+
+        mockAxiosGet.mockResolvedValue(mockFetchedSystems);
+        mockDefaultGetEntities.mockRejectedValue({
+          response: { status: 404 },
+          message: 'Not found',
+        });
+
+        const fetchEntities = getEntities(
+          mockHandleRefresh,
+          null,
+          mockSetCurPageIds,
+          mockSetTotal,
+          [],
+          mockSetFullFilters,
+          {},
+          rule,
+          RULES_FETCH_URL,
+          SYSTEMS_FETCH_URL,
+          mockAxios,
+        );
+
+        const result = await fetchEntities(
+          [],
+          config,
+          true,
+          mockDefaultGetEntities,
+        );
+
+        expect(result.results).toHaveLength(1);
+        expect(result.total).toBe(1);
+      });
+
+      it('rethrows non-404 errors from Inventory API', async () => {
+        const mockFetchedSystems = {
+          data: [{ system_uuid: 'uuid-1', last_seen: '2026-04-14T10:00:00Z' }],
+          meta: { count: 1 },
+        };
+        const serverError = {
+          response: { status: 500 },
+          message: 'Internal server error',
+        };
+
+        mockAxiosGet.mockResolvedValue(mockFetchedSystems);
+        mockDefaultGetEntities.mockRejectedValue(serverError);
+
+        const fetchEntities = getEntities(
+          mockHandleRefresh,
+          null,
+          mockSetCurPageIds,
+          mockSetTotal,
+          [],
+          mockSetFullFilters,
+          {},
+          rule,
+          RULES_FETCH_URL,
+          SYSTEMS_FETCH_URL,
+          mockAxios,
+        );
+
+        await expect(
+          fetchEntities([], config, true, mockDefaultGetEntities),
+        ).rejects.toEqual(serverError);
+      });
+    });
   });
 
   describe('allCurrentSystemIds', () => {

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -307,32 +307,54 @@ const SystemsTable = () => {
 
           handleRefresh(options);
 
-          // Filter systems that exist in inventory (have last_seen)
-          // Systems with last_seen: null don't exist in inventory and cause 404
+          /**
+           * Filter out systems that don't exist in Inventory.
+           * Systems with last_seen: null exist in Advisor but not in Inventory,
+           * which causes 404 errors when querying the Inventory API.
+           */
           const systemsInInventory = fetchedSystems.data.filter(
             (system) => system.last_seen !== null,
           );
 
+          /**
+           * Adjust the total count to account for filtered systems.
+           * When backend returns a count that includes systems with last_seen: null,
+           * we filter those out on the frontend to prevent 404 errors when
+           * querying the Inventory API. We subtract the number of filtered systems
+           * from this page to keep the count approximately accurate for pagination.
+           */
+          const filteredOutCount =
+            fetchedSystems.data.length - systemsInInventory.length;
+
           let results = { results: [] };
           if (systemsInInventory.length > 0) {
-            results = await defaultGetEntities(
-              // additional request to fetch hosts' operating system values
-              systemsInInventory.map((system) => system.system_uuid),
-              {
-                per_page,
-                hasItems: true,
-                fields: { system_profile: ['operating_system'] },
-              },
-              showTags,
-            );
+            try {
+              results = await defaultGetEntities(
+                // additional request to fetch hosts' operating system values
+                systemsInInventory.map((system) => system.system_uuid),
+                {
+                  per_page,
+                  hasItems: true,
+                  fields: { system_profile: ['operating_system'] },
+                },
+                showTags,
+              );
+            } catch (inventoryError) {
+              /**
+               * Handle 404 errors gracefully in case systems are missing from Inventory.
+               * This is a safety net - the filtering above should prevent most 404s.
+               */
+              if (inventoryError.response?.status === 404) {
+                results = { results: [] };
+              } else {
+                throw inventoryError;
+              }
+            }
           }
 
           return Promise.resolve({
-            results: mergeArraysByDiffKeys(
-              fetchedSystems.data,
-              results.results,
-            ),
-            total: fetchedSystems.meta.count,
+            results: mergeArraysByDiffKeys(systemsInInventory, results.results),
+            total: Math.max(0, fetchedSystems.meta.count - filteredOutCount),
           });
         }}
         tableProps={{

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -306,16 +306,26 @@ const SystemsTable = () => {
           }
 
           handleRefresh(options);
-          const results = await defaultGetEntities(
-            // additional request to fetch hosts' operating system values
-            fetchedSystems.data.map((system) => system.system_uuid),
-            {
-              per_page,
-              hasItems: true,
-              fields: { system_profile: ['operating_system'] },
-            },
-            showTags,
+
+          // Filter systems that exist in inventory (have last_seen)
+          // Systems with last_seen: null don't exist in inventory and cause 404
+          const systemsInInventory = fetchedSystems.data.filter(
+            (system) => system.last_seen !== null,
           );
+
+          let results = { results: [] };
+          if (systemsInInventory.length > 0) {
+            results = await defaultGetEntities(
+              // additional request to fetch hosts' operating system values
+              systemsInInventory.map((system) => system.system_uuid),
+              {
+                per_page,
+                hasItems: true,
+                fields: { system_profile: ['operating_system'] },
+              },
+              showTags,
+            );
+          }
 
           return Promise.resolve({
             results: mergeArraysByDiffKeys(

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.test.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.test.js
@@ -614,4 +614,142 @@ describe('Systems', () => {
       });
     });
   });
+
+  describe('Systems with last_seen null filtering', () => {
+    it('filters out systems with last_seen null', async () => {
+      const mockData = createMockSystemsResponse({
+        count: 3,
+        total: 3,
+        customizer: (sys, index) => ({
+          ...sys,
+          last_seen: index === 1 ? null : sys.last_seen,
+        }),
+      });
+      mockAxiosGet.mockResolvedValue(mockData);
+
+      render(<ComponentWithContext Component={SystemsTable} />);
+      const inventoryTableProps = InventoryTable.mock.calls[0][0];
+      const mockDefaultGetEntities = jest.fn().mockResolvedValue({
+        results: [
+          { id: mockData.data[0].system_uuid },
+          { id: mockData.data[2].system_uuid },
+        ],
+        total: 2,
+      });
+
+      const result = await inventoryTableProps.getEntities(
+        [],
+        mockGetEntitiesConfig,
+        true,
+        mockDefaultGetEntities,
+      );
+
+      expect(mockDefaultGetEntities).toHaveBeenCalledWith(
+        [mockData.data[0].system_uuid, mockData.data[2].system_uuid],
+        expect.any(Object),
+        true,
+      );
+      expect(result.results).toHaveLength(2);
+      expect(result.total).toBe(2);
+    });
+
+    it('adjusts total count when filtering systems', async () => {
+      const mockData = createMockSystemsResponse({
+        count: 5,
+        total: 100,
+        customizer: (sys, index) => ({
+          ...sys,
+          last_seen: index < 2 ? null : sys.last_seen,
+        }),
+      });
+      mockAxiosGet.mockResolvedValue(mockData);
+
+      render(<ComponentWithContext Component={SystemsTable} />);
+      const inventoryTableProps = InventoryTable.mock.calls[0][0];
+      const mockDefaultGetEntities = jest.fn().mockResolvedValue({
+        results: [],
+        total: 0,
+      });
+
+      const result = await inventoryTableProps.getEntities(
+        [],
+        mockGetEntitiesConfig,
+        true,
+        mockDefaultGetEntities,
+      );
+
+      expect(result.total).toBe(98);
+    });
+
+    it('skips Inventory API call when all systems have last_seen null', async () => {
+      const mockData = createMockSystemsResponse({
+        count: 3,
+        total: 3,
+        customizer: (sys) => ({
+          ...sys,
+          last_seen: null,
+        }),
+      });
+      mockAxiosGet.mockResolvedValue(mockData);
+
+      render(<ComponentWithContext Component={SystemsTable} />);
+      const inventoryTableProps = InventoryTable.mock.calls[0][0];
+      const mockDefaultGetEntities = jest.fn();
+
+      const result = await inventoryTableProps.getEntities(
+        [],
+        mockGetEntitiesConfig,
+        true,
+        mockDefaultGetEntities,
+      );
+
+      expect(mockDefaultGetEntities).not.toHaveBeenCalled();
+      expect(result.results).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+
+    it('handles 404 errors from Inventory API gracefully', async () => {
+      const mockData = mockScenarios.allSystems();
+      mockAxiosGet.mockResolvedValue(mockData);
+
+      render(<ComponentWithContext Component={SystemsTable} />);
+      const inventoryTableProps = InventoryTable.mock.calls[0][0];
+      const mockDefaultGetEntities = jest.fn().mockRejectedValue({
+        response: { status: 404 },
+        message: 'Not found',
+      });
+
+      const result = await inventoryTableProps.getEntities(
+        [],
+        mockGetEntitiesConfig,
+        true,
+        mockDefaultGetEntities,
+      );
+
+      expect(result.results).toHaveLength(mockData.data.length);
+      expect(result.total).toBe(mockData.meta.count);
+    });
+
+    it('rethrows non-404 errors from Inventory API', async () => {
+      const mockData = mockScenarios.allSystems();
+      mockAxiosGet.mockResolvedValue(mockData);
+
+      render(<ComponentWithContext Component={SystemsTable} />);
+      const inventoryTableProps = InventoryTable.mock.calls[0][0];
+      const serverError = {
+        response: { status: 500 },
+        message: 'Internal server error',
+      };
+      const mockDefaultGetEntities = jest.fn().mockRejectedValue(serverError);
+
+      await expect(
+        inventoryTableProps.getEntities(
+          [],
+          mockGetEntitiesConfig,
+          true,
+          mockDefaultGetEntities,
+        ),
+      ).rejects.toEqual(serverError);
+    });
+  });
 });


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)
https://issues.redhat.com/browse/RHINENG-23894


Systems with last_seen: null exist in the Advisor API but not in the Inventory
   API. When the frontend attempts to fetch these systems from Inventory, it
  receives 404 errors that break the UI and prevent users from viewing system   
  tables and details.

  Solution                                                                      
   
  Implemented frontend filtering and error handling across three key areas to   
  prevent 404 errors while maintaining accurate pagination counts.
                                                                                
  Changes Made                                                                  
   
  1. Systems List Page (SystemsTable.js)                                        
                  
  What it fixes: Main systems list at /insights/advisor/systems                 
                  
  Implementation:                                                               
  - Filters systems where last_seen !== null before querying Inventory API
  - Adjusts total count by subtracting filtered systems from current page       
  - Wraps Inventory API call in try/catch to gracefully handle any 404s  
  - Skips Inventory API call entirely if all systems are filtered out           
                                                                                
  2. Recommendation Details - Affected Systems (Inventory/helpers.js)           
                                                                                
  What it fixes: Affected systems tables on recommendation detail pages at      
  /insights/advisor/recommendations/:ruleId/                                    
                                                                                
  Implementation: 
  - Applies identical filtering logic to affected systems tables
  - Prevents users from seeing or clicking on non-existent systems              
  - Adjusts counts and handles errors consistently with SystemsTable
                                                                                
  3. System Detail Pages (InventoryDetails.js)                                  
                                                                                
  What it fixes: Direct navigation to system detail pages at                    
  /insights/advisor/recommendations/:ruleId/:systemId/                          
                                                                                
  Implementation: 
  - Checks if system exists in Advisor API and has valid last_seen before
  rendering                                                                     
  - Shows loading skeleton during validation
  - Displays user-friendly empty state if system doesn't exist                  
  - Shows warning notification explaining why system cannot be displayed        
  - Prevents DetailWrapper component from attempting to load non-existent system
   (which would cause 404)