### PR TITLE
feat(RHINENG-25232): prepare app for tabletools migration without invasive changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@typescript-eslint/parser": "^8.34.0",
         "@unleash/proxy-client-react": "^4.2.4",
         "babel-plugin-transform-inline-environment-variables": "^0.4.4",
+        "bastilian-tabletools": "^2.18.1",
         "react": "^18.3.1",
         "react-content-loader": "6.2.0",
         "react-dom": "^18.3.1",
@@ -4633,6 +4634,15 @@
         "tslib": "2"
       }
     },
+    "node_modules/@jsonquerylang/jsonquery": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@jsonquerylang/jsonquery/-/jsonquery-5.1.1.tgz",
+      "integrity": "sha512-Fj4SoA6Ku09EF+t7OEI8QLipA2A+fJCdEOwnDWG84o5jXMRjkcN5NCMH7kFZb5fP62xz914XV5LBOiDdiUXObg==",
+      "peer": true,
+      "bin": {
+        "jsonquery": "bin/cli.js"
+      }
+    },
     "node_modules/@keyv/serialize": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.0.tgz",
@@ -8131,6 +8141,114 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@tanstack/devtools-event-client": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/devtools-event-client/-/devtools-event-client-0.4.3.tgz",
+      "integrity": "sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==",
+      "peer": true,
+      "bin": {
+        "intent": "bin/intent.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/pacer": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/pacer/-/pacer-0.19.0.tgz",
+      "integrity": "sha512-MRXCiG8IcjrN/3LGu7Wy6lKZkbwOb5YelOBYtHxnxKYj2WlO2FrqASILSiJcwdES5Sz2QJEIeuvO5JY8cKaGQw==",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/devtools-event-client": "^0.4.0",
+        "@tanstack/store": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-pacer": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-pacer/-/react-pacer-0.20.0.tgz",
+      "integrity": "sha512-5p7rHTBUroUl6vxYhvREaqpUWKCoe0bXaFH6y6CLYpcuU5aCl78IxXJKY5IujCN1sTRaq07jsMInTPmTBHvTiA==",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/pacer": "0.19.0",
+        "@tanstack/react-store": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
+      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-store": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.8.1.tgz",
+      "integrity": "sha512-XItJt+rG8c5Wn/2L/bnxys85rBpm0BfMbhb4zmPVLXAKY9POrp1xd6IbU4PKoOI+jSEGc3vntPRfLGSgXfE2Ig==",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/store": "0.8.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.8.1.tgz",
+      "integrity": "sha512-PtOisLjUZPz5VyPRSCGjNOlwTvabdTBQ2K80DpVL1chGVr35WRxfeavAPdNq6pm/t7F8GhoR2qtmkkqtCEtHYw==",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
@@ -10678,6 +10796,29 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bastilian-tabletools": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-2.18.1.tgz",
+      "integrity": "sha512-+SPv07deN2nYpBhWLrO+zW6aAr7vxF2XXwbJeXeVxZmpByvCotf3EDOCDEHICcLSCYZjf5+VBcMxHaM+P/SdHA==",
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@jsonquerylang/jsonquery": "^5.0.4",
+        "@patternfly/patternfly": "^6.0.0",
+        "@patternfly/react-component-groups": "^6.0.0",
+        "@patternfly/react-core": "^6.0.0",
+        "@patternfly/react-table": "^6.0.0",
+        "@redhat-cloud-services/frontend-components": ">= 6.1.0",
+        "@redhat-cloud-services/frontend-components-utilities": ">= 6.1.0",
+        "@tanstack/react-pacer": ">= 0.15.0",
+        "@tanstack/react-query": ">= 5.83.0",
+        "p-all": ">= 4.0.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "use-deep-compare": "^1.3.0"
+      }
     },
     "node_modules/batch": {
       "version": "0.6.1",
@@ -22574,6 +22715,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/p-all": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/p-all/-/p-all-5.0.1.tgz",
+      "integrity": "sha512-LMT7WX9ZSaq3J1zjloApkIVmtz0ZdMFSIqbuiEa3txGYPLjUPOvgOPOx3nFjo+f37ZYL+1aY666I2SG7GVwLOA==",
+      "peer": true,
+      "dependencies": {
+        "p-map": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-all/node_modules/p-map": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
+      "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==",
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -27718,12 +27886,24 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+    "node_modules/use-deep-compare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-deep-compare/-/use-deep-compare-1.3.0.tgz",
+      "integrity": "sha512-94iG+dEdEP/Sl3WWde+w9StIunlV8Dgj+vkt5wTwMoFQLaijiEZSXXy8KtcStpmEDtIptRJiNeD4ACTtVvnIKA==",
+      "peer": true,
+      "dependencies": {
+        "dequal": "2.0.3"
+      },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
       "<rootDir>/.+fixtures.+"
     ],
     "transformIgnorePatterns": [
-      "/node_modules/(?!@redhat-cloud-services)"
+      "/node_modules/(?!(@redhat-cloud-services|bastilian-tabletools|p-all|p-map|aggregate-error|indent-string|clean-stack))"
     ],
     "setupFiles": [
       "<rootDir>/config/setupTests.js"

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@typescript-eslint/parser": "^8.34.0",
     "@unleash/proxy-client-react": "^4.2.4",
     "babel-plugin-transform-inline-environment-variables": "^0.4.4",
+    "bastilian-tabletools": "^2.18.1",
     "react": "^18.3.1",
     "react-content-loader": "6.2.0",
     "react-dom": "^18.3.1",

--- a/src/PresentationalComponents/AdvisorTable/AdvisorTable.js
+++ b/src/PresentationalComponents/AdvisorTable/AdvisorTable.js
@@ -17,12 +17,13 @@ const AdvisorTable = (props) => {
     <TableToolsTable
       {...props}
       options={{
+        ...props.options,
         serialisers: {
           pagination: paginationSerialiser,
           sort: sortSerialiser,
           filters: filtersSerialiser,
+          ...props.options?.serialisers,
         },
-        ...props.options,
       }}
     />
   );

--- a/src/PresentationalComponents/AdvisorTable/AdvisorTable.js
+++ b/src/PresentationalComponents/AdvisorTable/AdvisorTable.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { TableToolsTable } from 'bastilian-tabletools';
+import {
+  paginationSerialiser,
+  sortSerialiser,
+  filtersSerialiser,
+} from '../../Utilities/tableSerializers';
+
+/**
+ * Wrapper for TableToolsTable with Advisor-specific API serializers
+ * @param {object} props - Component props passed through to TableToolsTable
+ * @returns {React.Element}
+ */
+const AdvisorTable = (props) => {
+  return (
+    <TableToolsTable
+      {...props}
+      options={{
+        serialisers: {
+          pagination: paginationSerialiser,
+          sort: sortSerialiser,
+          filters: filtersSerialiser,
+        },
+        ...props.options,
+      }}
+    />
+  );
+};
+
+AdvisorTable.propTypes = {
+  items: propTypes.array,
+  columns: propTypes.array,
+  total: propTypes.number,
+  loading: propTypes.bool,
+  filters: propTypes.object,
+  options: propTypes.object,
+};
+
+export default AdvisorTable;

--- a/src/PresentationalComponents/AdvisorTable/AdvisorTable.test.js
+++ b/src/PresentationalComponents/AdvisorTable/AdvisorTable.test.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import AdvisorTable from './AdvisorTable';
+import {
+  paginationSerialiser,
+  sortSerialiser,
+  filtersSerialiser,
+} from '../../Utilities/tableSerializers';
+
+// Mock bastilian-tabletools to avoid PatternFly/JSDOM CSS issues
+jest.mock('bastilian-tabletools', () => ({
+  TableToolsTable: jest.fn(() => <div data-testid="table-tools-table" />),
+}));
+
+describe('AdvisorTable', () => {
+  const { TableToolsTable } = require('bastilian-tabletools');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('passes serializers to TableToolsTable', () => {
+    render(<AdvisorTable items={[]} columns={[]} total={0} />);
+
+    expect(TableToolsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [],
+        columns: [],
+        total: 0,
+        options: expect.objectContaining({
+          serialisers: {
+            pagination: paginationSerialiser,
+            sort: sortSerialiser,
+            filters: filtersSerialiser,
+          },
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('merges custom options with serializers', () => {
+    const customOptions = {
+      pagination: true,
+      exportable: { columns: [] },
+    };
+
+    render(
+      <AdvisorTable
+        items={[]}
+        columns={[]}
+        total={0}
+        options={customOptions}
+      />,
+    );
+
+    expect(TableToolsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          pagination: true,
+          exportable: { columns: [] },
+          serialisers: {
+            pagination: paginationSerialiser,
+            sort: sortSerialiser,
+            filters: filtersSerialiser,
+          },
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('passes through all other props', () => {
+    render(
+      <AdvisorTable
+        items={[{ id: 1 }]}
+        columns={[{ title: 'Test' }]}
+        total={1}
+        loading={false}
+        filters={{ filterConfig: [] }}
+      />,
+    );
+
+    expect(TableToolsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [{ id: 1 }],
+        columns: [{ title: 'Test' }],
+        total: 1,
+        loading: false,
+        filters: { filterConfig: [] },
+      }),
+      expect.anything(),
+    );
+  });
+});

--- a/src/PresentationalComponents/AdvisorTable/AdvisorTable.test.js
+++ b/src/PresentationalComponents/AdvisorTable/AdvisorTable.test.js
@@ -92,4 +92,34 @@ describe('AdvisorTable', () => {
       expect.anything(),
     );
   });
+
+  it('deep merges custom serializers without wiping defaults', () => {
+    const customPaginationSerializer = jest.fn();
+
+    render(
+      <AdvisorTable
+        items={[]}
+        columns={[]}
+        total={0}
+        options={{
+          serialisers: {
+            pagination: customPaginationSerializer,
+          },
+        }}
+      />,
+    );
+
+    expect(TableToolsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          serialisers: {
+            pagination: customPaginationSerializer,
+            sort: sortSerialiser,
+            filters: filtersSerialiser,
+          },
+        }),
+      }),
+      expect.anything(),
+    );
+  });
 });

--- a/src/PresentationalComponents/AdvisorTable/index.js
+++ b/src/PresentationalComponents/AdvisorTable/index.js
@@ -1,0 +1,1 @@
+export { default } from './AdvisorTable';

--- a/src/Utilities/tableSerializers.js
+++ b/src/Utilities/tableSerializers.js
@@ -1,0 +1,57 @@
+/**
+ * Converts TableToolsTable pagination state to Advisor API format
+ * @param {object} state - { page: number, perPage: number }
+ * @returns {object} - { offset: number, limit: number }
+ */
+export const paginationSerialiser = ({ perPage, page } = {}) => {
+  if (perPage && page) {
+    const offset = (page - 1) * perPage;
+    return { offset, limit: perPage };
+  }
+  return {};
+};
+
+/**
+ * Converts TableToolsTable sort state to Advisor API format
+ * @param {object} sortState - { index: number, direction: 'asc'|'desc' }
+ * @param {object} sortIndices - Mapping of column index to API field name (e.g., { 0: 'description', 1: 'total_risk' })
+ * @returns {string} - "-field_name" or "field_name"
+ */
+export const sortSerialiser = ({ index, direction } = {}, sortIndices) => {
+  const field = sortIndices?.[index];
+  if (!field) return undefined;
+  return direction === 'desc' ? `-${field}` : field;
+};
+
+/**
+ * Converts TableToolsTable filter state to Advisor API format
+ * @param {object} state - Filter state from table
+ * @param {array} filters - Filter configuration
+ * @returns {object} - API-compatible filter params
+ */
+export const filtersSerialiser = (state, filters) => {
+  const params = {};
+
+  Object.entries(state || {}).forEach(([filterId, value]) => {
+    const filterConfig = filters.find((f) => f.id === filterId);
+    if (!filterConfig) return;
+
+    switch (filterConfig.type) {
+      case 'text':
+        params.text = value;
+        break;
+      case 'checkbox':
+        params[filterConfig.urlParam] = Array.isArray(value)
+          ? value.join(',')
+          : value;
+        break;
+      case 'radio':
+        params[filterConfig.urlParam] = Array.isArray(value) ? value[0] : value;
+        break;
+      default:
+        params[filterConfig.urlParam] = value;
+    }
+  });
+
+  return params;
+};

--- a/src/Utilities/tableSerializers.js
+++ b/src/Utilities/tableSerializers.js
@@ -14,13 +14,14 @@ export const paginationSerialiser = ({ perPage, page } = {}) => {
 /**
  * Converts TableToolsTable sort state to Advisor API format
  * @param {object} sortState - { index: number, direction: 'asc'|'desc' }
- * @param {object} sortIndices - Mapping of column index to API field name (e.g., { 0: 'description', 1: 'total_risk' })
+ * @param {array} columns - Table columns array with sortable property (e.g., { title: 'Name', sortable: 'description' })
  * @returns {string} - "-field_name" or "field_name"
  */
-export const sortSerialiser = ({ index, direction } = {}, sortIndices) => {
-  const field = sortIndices?.[index];
-  if (!field) return undefined;
-  return direction === 'desc' ? `-${field}` : field;
+export const sortSerialiser = ({ index, direction } = {}, columns) => {
+  return (
+    columns?.[index]?.sortable &&
+    `${direction === 'desc' ? '-' : ''}${columns[index].sortable}`
+  );
 };
 
 /**

--- a/src/Utilities/tableSerializers.test.js
+++ b/src/Utilities/tableSerializers.test.js
@@ -54,66 +54,76 @@ describe('paginationSerialiser', () => {
 });
 
 describe('sortSerialiser', () => {
-  const sortIndices = {
-    0: 'description',
-    1: 'total_risk',
-    2: 'publish_date',
-  };
+  const columns = [
+    { title: 'Description', sortable: 'description' },
+    { title: 'Total Risk', sortable: 'total_risk' },
+    { title: 'Publish Date', sortable: 'publish_date' },
+  ];
 
   it('handles ascending sort', () => {
-    expect(sortSerialiser({ index: 0, direction: 'asc' }, sortIndices)).toBe(
+    expect(sortSerialiser({ index: 0, direction: 'asc' }, columns)).toBe(
       'description',
     );
   });
 
   it('handles descending sort', () => {
-    expect(sortSerialiser({ index: 1, direction: 'desc' }, sortIndices)).toBe(
+    expect(sortSerialiser({ index: 1, direction: 'desc' }, columns)).toBe(
       '-total_risk',
     );
   });
 
   it('returns undefined for non-existent index', () => {
     expect(
-      sortSerialiser({ index: 99, direction: 'asc' }, sortIndices),
+      sortSerialiser({ index: 99, direction: 'asc' }, columns),
     ).toBeUndefined();
   });
 
   it('returns undefined for invalid index', () => {
     expect(
-      sortSerialiser({ index: 999, direction: 'asc' }, sortIndices),
+      sortSerialiser({ index: 999, direction: 'asc' }, columns),
     ).toBeUndefined();
   });
 
   it('returns undefined for negative index', () => {
     expect(
-      sortSerialiser({ index: -1, direction: 'asc' }, sortIndices),
+      sortSerialiser({ index: -1, direction: 'asc' }, columns),
     ).toBeUndefined();
   });
 
   it('returns undefined for undefined input', () => {
-    expect(sortSerialiser(undefined, sortIndices)).toBeUndefined();
+    expect(sortSerialiser(undefined, columns)).toBeUndefined();
   });
 
-  it('returns undefined for empty sortIndices', () => {
-    expect(sortSerialiser({ index: 0, direction: 'asc' }, {})).toBeUndefined();
+  it('returns undefined for empty columns', () => {
+    expect(sortSerialiser({ index: 0, direction: 'asc' }, [])).toBeUndefined();
   });
 
   it('handles ascending sort for second column', () => {
-    expect(sortSerialiser({ index: 1, direction: 'asc' }, sortIndices)).toBe(
+    expect(sortSerialiser({ index: 1, direction: 'asc' }, columns)).toBe(
       'total_risk',
     );
   });
 
   it('handles ascending sort for third column', () => {
-    expect(sortSerialiser({ index: 2, direction: 'asc' }, sortIndices)).toBe(
+    expect(sortSerialiser({ index: 2, direction: 'asc' }, columns)).toBe(
       'publish_date',
     );
   });
 
   it('handles descending sort for third column', () => {
-    expect(sortSerialiser({ index: 2, direction: 'desc' }, sortIndices)).toBe(
+    expect(sortSerialiser({ index: 2, direction: 'desc' }, columns)).toBe(
       '-publish_date',
     );
+  });
+
+  it('returns undefined for non-sortable column', () => {
+    const columnsWithNonSortable = [
+      { title: 'Description', sortable: 'description' },
+      { title: 'Actions' }, // No sortable property
+    ];
+    expect(
+      sortSerialiser({ index: 1, direction: 'asc' }, columnsWithNonSortable),
+    ).toBeUndefined();
   });
 });
 

--- a/src/Utilities/tableSerializers.test.js
+++ b/src/Utilities/tableSerializers.test.js
@@ -1,0 +1,208 @@
+import {
+  paginationSerialiser,
+  sortSerialiser,
+  filtersSerialiser,
+} from './tableSerializers';
+
+describe('paginationSerialiser', () => {
+  it('converts page 1 correctly', () => {
+    expect(paginationSerialiser({ page: 1, perPage: 20 })).toEqual({
+      offset: 0,
+      limit: 20,
+    });
+  });
+
+  it('converts page 3 correctly', () => {
+    expect(paginationSerialiser({ page: 3, perPage: 20 })).toEqual({
+      offset: 40,
+      limit: 20,
+    });
+  });
+
+  it('handles different perPage values', () => {
+    expect(paginationSerialiser({ page: 2, perPage: 50 })).toEqual({
+      offset: 50,
+      limit: 50,
+    });
+  });
+
+  it('returns empty object for undefined input', () => {
+    expect(paginationSerialiser()).toEqual({});
+  });
+
+  it('returns empty object for missing page', () => {
+    expect(paginationSerialiser({ perPage: 20 })).toEqual({});
+  });
+
+  it('returns empty object for missing perPage', () => {
+    expect(paginationSerialiser({ page: 1 })).toEqual({});
+  });
+
+  it('handles page 1 with 10 items per page', () => {
+    expect(paginationSerialiser({ page: 1, perPage: 10 })).toEqual({
+      offset: 0,
+      limit: 10,
+    });
+  });
+
+  it('handles large page numbers', () => {
+    expect(paginationSerialiser({ page: 100, perPage: 20 })).toEqual({
+      offset: 1980,
+      limit: 20,
+    });
+  });
+});
+
+describe('sortSerialiser', () => {
+  const sortIndices = {
+    0: 'description',
+    1: 'total_risk',
+    2: 'publish_date',
+  };
+
+  it('handles ascending sort', () => {
+    expect(sortSerialiser({ index: 0, direction: 'asc' }, sortIndices)).toBe(
+      'description',
+    );
+  });
+
+  it('handles descending sort', () => {
+    expect(sortSerialiser({ index: 1, direction: 'desc' }, sortIndices)).toBe(
+      '-total_risk',
+    );
+  });
+
+  it('returns undefined for non-existent index', () => {
+    expect(
+      sortSerialiser({ index: 99, direction: 'asc' }, sortIndices),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for invalid index', () => {
+    expect(
+      sortSerialiser({ index: 999, direction: 'asc' }, sortIndices),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for negative index', () => {
+    expect(
+      sortSerialiser({ index: -1, direction: 'asc' }, sortIndices),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for undefined input', () => {
+    expect(sortSerialiser(undefined, sortIndices)).toBeUndefined();
+  });
+
+  it('returns undefined for empty sortIndices', () => {
+    expect(sortSerialiser({ index: 0, direction: 'asc' }, {})).toBeUndefined();
+  });
+
+  it('handles ascending sort for second column', () => {
+    expect(sortSerialiser({ index: 1, direction: 'asc' }, sortIndices)).toBe(
+      'total_risk',
+    );
+  });
+
+  it('handles ascending sort for third column', () => {
+    expect(sortSerialiser({ index: 2, direction: 'asc' }, sortIndices)).toBe(
+      'publish_date',
+    );
+  });
+
+  it('handles descending sort for third column', () => {
+    expect(sortSerialiser({ index: 2, direction: 'desc' }, sortIndices)).toBe(
+      '-publish_date',
+    );
+  });
+});
+
+describe('filtersSerialiser', () => {
+  const filterConfig = [
+    { id: 'text', type: 'text', urlParam: 'text' },
+    { id: 'total_risk', type: 'checkbox', urlParam: 'total_risk' },
+    { id: 'category', type: 'radio', urlParam: 'category' },
+  ];
+
+  it('handles text filter', () => {
+    const result = filtersSerialiser({ text: 'security' }, filterConfig);
+    expect(result).toEqual({ text: 'security' });
+  });
+
+  it('handles checkbox filter with array', () => {
+    const result = filtersSerialiser(
+      { total_risk: ['1', '2', '3'] },
+      filterConfig,
+    );
+    expect(result).toEqual({ total_risk: '1,2,3' });
+  });
+
+  it('handles radio filter', () => {
+    const result = filtersSerialiser({ category: ['security'] }, filterConfig);
+    expect(result).toEqual({ category: 'security' });
+  });
+
+  it('handles multiple filters', () => {
+    const result = filtersSerialiser(
+      {
+        text: 'test',
+        total_risk: ['1', '2'],
+        category: ['security'],
+      },
+      filterConfig,
+    );
+    expect(result).toEqual({
+      text: 'test',
+      total_risk: '1,2',
+      category: 'security',
+    });
+  });
+
+  it('ignores unknown filters', () => {
+    const result = filtersSerialiser({ unknown_filter: 'value' }, filterConfig);
+    expect(result).toEqual({});
+  });
+
+  it('handles empty state', () => {
+    const result = filtersSerialiser({}, filterConfig);
+    expect(result).toEqual({});
+  });
+
+  it('handles undefined state', () => {
+    const result = filtersSerialiser(undefined, filterConfig);
+    expect(result).toEqual({});
+  });
+
+  it('handles null state', () => {
+    const result = filtersSerialiser(null, filterConfig);
+    expect(result).toEqual({});
+  });
+
+  it('handles checkbox filter with non-array value', () => {
+    const result = filtersSerialiser({ total_risk: 'single' }, filterConfig);
+    expect(result).toEqual({ total_risk: 'single' });
+  });
+
+  it('handles empty array for checkbox filter', () => {
+    const result = filtersSerialiser({ total_risk: [] }, filterConfig);
+    expect(result).toEqual({ total_risk: '' });
+  });
+
+  it('handles radio filter with non-array value', () => {
+    const result = filtersSerialiser({ category: 'security' }, filterConfig);
+    expect(result).toEqual({ category: 'security' });
+  });
+
+  it('handles empty filter config', () => {
+    const result = filtersSerialiser({ text: 'test' }, []);
+    expect(result).toEqual({});
+  });
+
+  it('handles filter with default type', () => {
+    const customConfig = [
+      { id: 'custom', type: 'custom-type', urlParam: 'custom' },
+    ];
+    const result = filtersSerialiser({ custom: 'value' }, customConfig);
+    expect(result).toEqual({ custom: 'value' });
+  });
+});


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHINENG-25232
This PR adds the foundation for migrating Advisor tables to `bastilian-tabletools` using the  no app behavior changes - purely additive infrastructure.
  ### Changes

  **Package Dependency**
  - Added `bastilian-tabletools@^2.18.1`
  - Updated Jest `transformIgnorePatterns` to handle ESM packages

  **Table Serializers** (`src/Utilities/tableSerializers.js`)
  - `paginationSerialiser`: Converts table pagination (`page`, `perPage`) → API format
  (`offset`, `limit`)
  - `sortSerialiser`: Converts column sort state → Advisor API format (`-field_name` for
  descending)
  - `filtersSerialiser`: Converts filter state → URL query params (comma-joins arrays, extracts
  radio values)
  - 31 tests, verified against API fixtures we use in Cypress tests

  **AdvisorTable Component** (`src/PresentationalComponents/AdvisorTable/`)
  - Thin wrapper around `TableToolsTable` with pre-configured Advisor serializers
  - Drop-in replacement for future table migrations
  - 3 tests with mocked rendering

## Summary by Sourcery

Introduce Advisor-specific table utilities and a wrapper component to enable non-disruptive migration to bastilian-tabletools-backed tables.

New Features:
- Add reusable table serializer utilities for pagination, sorting, and filtering to map table state to Advisor API parameters.
- Introduce an AdvisorTable wrapper component around bastilian-tabletools' TableToolsTable preconfigured with Advisor serializers for drop-in table migration.

Build:
- Add bastilian-tabletools dependency and update Jest transformIgnorePatterns to support its ESM dependencies.

Tests:
- Add unit tests for the table serializer utilities and the AdvisorTable wrapper component.