### PR TITLE
fix(chore): update commitlint to include pr title checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: ['master']
 jobs:
   validate-pr-title:
-    if: github.event_name == 'pull_request' && github.event.action == 'edited'
+    if: github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.title
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,21 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches: ['master']
 jobs:
+  validate-pr-title:
+    if: github.event_name == 'pull_request' && github.event.action == 'edited'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
+      - run: npm ci
+      - name: Validate PR title
+        run: echo "${{ github.event.pull_request.title }}" | npx commitlint
+
   test:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'edited')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: ['master']
   pull_request:
+    types: [opened, edited, synchronize, reopened]
     branches: ['master']
 jobs:
   test:
@@ -23,6 +24,9 @@ jobs:
       - name: Validate PR commits with commitlint
         if: github.event_name == 'pull_request'
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+      - name: Validate PR title
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.title }}" | npx commitlint
       - run: npm run ci:verify
       - name: Upload code coverage
         uses: codecov/codecov-action@v5.3.1


### PR DESCRIPTION
After changes to the master branch protection we can encounter a case where the PR title is incorrect, but its not checked when commitlint runs in PR. 
Our commitlint setup validates individual commits.
But when GitHub merges a PR, it uses the PR title as the merge commit message.
If the PR title is wrong it will throw an error on merge commit into master.


Default pull_request trigger (when you don't specify types) includes:                         
opened, reopened, synchronize
So we need to specify types to add "edited".

Added a job for title validation that fires following this logic:                                                  
                                                                                                
Scenario 1: PR Created (opened)                                                               
                                                                                                
  - validate-pr-title: SKIP (action ≠ edited)                                                   
  - test: RUN (action = opened ≠ edited)                                                        
  - Jobs: Full test suite + title validation                                                    
                                                                                                
  Scenario 2: New Commits Pushed (synchronize)                                                  
                                                                                                
  - validate-pr-title: SKIP (action ≠ edited)                                                   
  - test: RUN (action = synchronize ≠ edited)
  - Jobs: Full test suite + title validation                                                    
                                                                                                
  Scenario 3: PR Reopened (reopened)                                                            
                                                                                                
  - validate-pr-title: SKIP (action ≠ edited)                                                   
  - test: RUN (action = reopened ≠ edited)
  - Jobs: Full test suite + title validation                                                    
                                                                                                
  Scenario 4: PR Title Edited Only                                                              
                                                                                                
  - validate-pr-title: RUN (action = edited + changes.title exists)                             
  - test: SKIP (action = edited)
  - Jobs: Title validation only                                                                 
                                                                                                
  Scenario 5: PR Title + Description Edited                                                     
                                                                                                
  - validate-pr-title: RUN (action = edited + changes.title exists)                             
  - test: SKIP (action = edited)
  - Jobs: Title validation only                                                                 
                                                                                                
  Scenario 6: PR Description Edited Only                                                        
                                                                                                
  - validate-pr-title: SKIP (no changes.title)                                                  
  - test: SKIP (action = edited)
  - Jobs: Nothing runs                                                                          
                                                                                                
  Scenario 7: Push to Master                                                                    
                                                                                                
  - validate-pr-title: SKIP (event ≠ pull_request)                                              
  - test: RUN (event = push)
  - Jobs: Full test suite (no title validation)


## Summary by Sourcery

CI:
- Extend the test workflow to trigger on additional pull request events and validate PR titles with commitlint alongside commit messages.