### PR TITLE
feat(RHINENG-25210): batch api requests for rules and pathways

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -65,3 +65,271 @@ Cypress.Commands.add('tableIsSortedBy', (columnTitle, direction = null) => {
     .should('have.class', 'pf-v6-c-table__sort')
     .and('have.class', 'pf-m-selected');
 });
+
+/**
+ * Helper function to generate mock recommendations data (non-Cypress function)
+ */
+window.generateBatchRecommendationsData = ({
+  total,
+  offset,
+  limit,
+  template = null,
+} = {}) => {
+  const count = Math.min(limit, total - offset);
+  const categories = [
+    { id: 1, name: 'Availability' },
+    { id: 2, name: 'Performance' },
+    { id: 3, name: 'Stability' },
+    { id: 4, name: 'Security' },
+  ];
+
+  const defaultTemplate = {
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    active: true,
+    tags: 'test',
+    playbook_count: 1,
+    reboot_required: false,
+    publish_date: '2024-01-01T00:00:00Z',
+    impacted_systems_count: 5,
+    reports_shown: true,
+    rule_status: 'enabled',
+    total_risk: 3,
+    hosts_acked_count: 0,
+    rating: 1,
+  };
+
+  const data = Array.from({ length: count }, (_, i) => ({
+    ...(template || defaultTemplate),
+    rule_id: `rule-${offset + i + 1}`,
+    description: `Batch Test Rule ${offset + i + 1}`,
+    impacted_systems_count: Math.floor(Math.random() * 10) + 1,
+    total_risk: Math.floor(Math.random() * 4) + 1,
+    category: categories[Math.floor(Math.random() * categories.length)],
+    impact: {
+      name: 'Test Impact',
+      impact: Math.floor(Math.random() * 4) + 1,
+    },
+    likelihood: Math.floor(Math.random() * 4) + 1,
+    resolution_set: [
+      {
+        system_type: 105,
+        resolution: 'Test resolution',
+        resolution_risk: {
+          name: 'Test Resolution Risk',
+          risk: Math.floor(Math.random() * 4) + 1,
+        },
+        has_playbook: true,
+      },
+    ],
+  }));
+
+  return {
+    data,
+    meta: {
+      count: total,
+      limit,
+      offset,
+    },
+  };
+};
+
+/**
+ * Generate mock data for batch request testing - Recommendations
+ * @param {object} options - Configuration options
+ * @param {number} options.total - Total number of items
+ * @param {number} options.offset - Current offset
+ * @param {number} options.limit - Items per page
+ * @param {object} options.template - Template object to use for generating items
+ * @returns {object} Mock response with recommendations
+ */
+Cypress.Commands.add('generateBatchRecommendations', (options = {}) => {
+  return window.generateBatchRecommendationsData(options);
+});
+
+/**
+ * Helper function to generate mock systems data (non-Cypress function)
+ */
+window.generateBatchSystemsData = ({
+  total,
+  offset = 0,
+  limit = 100,
+  page = 1,
+  per_page = 100,
+  paginationType = 'page',
+} = {}) => {
+  const actualOffset =
+    paginationType === 'page' ? (page - 1) * per_page : offset;
+  const actualLimit = paginationType === 'page' ? per_page : limit;
+  const count = Math.min(actualLimit, total - actualOffset);
+
+  const results = Array.from({ length: count }, (_, i) => ({
+    id: `system-${actualOffset + i + 1}`,
+    display_name: `System ${actualOffset + i + 1}`,
+    updated: '2024-01-01T00:00:00Z',
+  }));
+
+  if (paginationType === 'page') {
+    return {
+      results,
+      total,
+      count,
+      page,
+      per_page,
+    };
+  }
+
+  return {
+    results,
+    total,
+    count,
+    page: Math.floor(actualOffset / actualLimit) + 1,
+    per_page: actualLimit,
+  };
+};
+
+/**
+ * Generate mock data for batch request testing - Systems/Hosts
+ * @param {object} options - Configuration options
+ * @param {number} options.total - Total number of items
+ * @param {number} options.offset - Current offset (for offset pagination)
+ * @param {number} options.limit - Items per page (for offset pagination)
+ * @param {number} options.page - Current page (for page pagination)
+ * @param {number} options.per_page - Items per page (for page pagination)
+ * @param {string} options.paginationType - 'offset' or 'page'
+ * @returns {object} Mock response with systems
+ */
+Cypress.Commands.add('generateBatchSystems', (options = {}) => {
+  return window.generateBatchSystemsData(options);
+});
+
+/**
+ * Helper function to generate mock pathways data (non-Cypress function)
+ */
+window.generateBatchPathwaysData = ({ total, offset, limit } = {}) => {
+  const count = Math.min(limit, total - offset);
+  const categories = [
+    { id: 1, name: 'Availability' },
+    { id: 2, name: 'Performance' },
+    { id: 3, name: 'Stability' },
+    { id: 4, name: 'Security' },
+  ];
+
+  const data = Array.from({ length: count }, (_, i) => ({
+    slug: `pathway-${offset + i + 1}`,
+    name: `Batch Test Pathway ${offset + i + 1}`,
+    description: `Description for pathway ${offset + i + 1}`,
+    component: 'test-component',
+    resolution_risk: {
+      name: `Pathway ${offset + i + 1}`,
+      risk: Math.floor(Math.random() * 4) + 1,
+    },
+    publish_date: '2024-01-01T00:00:00Z',
+    has_playbook: Math.random() > 0.5,
+    impacted_systems_count: Math.floor(Math.random() * 20) + 1,
+    reboot_required: Math.random() > 0.5,
+    has_incident: Math.random() > 0.7,
+    categories: [categories[Math.floor(Math.random() * categories.length)]],
+    recommendation_level: Math.floor(Math.random() * 100),
+    incident_count: Math.floor(Math.random() * 5),
+    critical_risk_count: Math.floor(Math.random() * 5),
+    high_risk_count: Math.floor(Math.random() * 10),
+    medium_risk_count: Math.floor(Math.random() * 15),
+    low_risk_count: Math.floor(Math.random() * 20),
+  }));
+
+  return {
+    data,
+    meta: {
+      count: total,
+      limit,
+      offset,
+    },
+  };
+};
+
+/**
+ * Generate mock data for batch request testing - Pathways
+ * @param {object} options - Configuration options
+ * @param {number} options.total - Total number of items
+ * @param {number} options.offset - Current offset
+ * @param {number} options.limit - Items per page
+ * @returns {object} Mock response with pathways
+ */
+Cypress.Commands.add('generateBatchPathways', (options = {}) => {
+  return window.generateBatchPathwaysData(options);
+});
+
+/**
+ * Setup batch request interceptors for testing
+ * Automatically intercepts requests and returns paginated data
+ * @param {object} options - Configuration options
+ * @param {string} options.url - URL pattern to intercept
+ * @param {number} options.total - Total number of items
+ * @param {number} options.pageSize - Items per page
+ * @param {string} options.dataType - 'recommendations', 'systems', or 'pathways'
+ * @param {string} options.paginationType - 'offset' or 'page'
+ * @param {object} options.template - Optional template for data generation
+ * @returns {void}
+ */
+Cypress.Commands.add(
+  'setupBatchInterceptors',
+  ({
+    url,
+    total,
+    pageSize,
+    dataType = 'recommendations',
+    paginationType = 'offset',
+    template = null,
+  } = {}) => {
+    const totalPages = Math.ceil(total / pageSize);
+
+    for (let i = 0; i < totalPages; i++) {
+      const offset = i * pageSize;
+      const page = i + 1;
+
+      let urlPattern, mockData;
+
+      if (paginationType === 'offset') {
+        urlPattern = `${url}*offset=${offset}*`;
+      } else {
+        urlPattern = `${url}*page=${page}*`;
+      }
+
+      switch (dataType) {
+        case 'recommendations':
+          mockData = window.generateBatchRecommendationsData({
+            total,
+            offset,
+            limit: pageSize,
+            template,
+          });
+          break;
+        case 'systems':
+          mockData = window.generateBatchSystemsData({
+            total,
+            offset,
+            limit: pageSize,
+            page,
+            per_page: pageSize,
+            paginationType,
+          });
+          break;
+        case 'pathways':
+          mockData = window.generateBatchPathwaysData({
+            total,
+            offset,
+            limit: pageSize,
+          });
+          break;
+        default:
+          throw new Error(`Unknown dataType: ${dataType}`);
+      }
+
+      cy.intercept('GET', urlPattern, {
+        statusCode: 200,
+        body: mockData,
+      }).as(`batchPage${page}`);
+    }
+  },
+);

--- a/src/PresentationalComponents/Inventory/helpers.js
+++ b/src/PresentationalComponents/Inventory/helpers.js
@@ -3,6 +3,8 @@ import { createOptions, createSortParam } from '../helper';
 import LastSeenColumnHeader from '../../Utilities/LastSeenColumnHeader';
 import { fitContent } from '@patternfly/react-table';
 import { DateFormat } from '@redhat-cloud-services/frontend-components';
+import { createBatchedFetch } from '../../Utilities/createBatchQueryEndpoint';
+import { PAGINATION_TYPES } from '../../Utilities/batchPaginationHelpers';
 import React from 'react';
 import Qs from 'qs';
 
@@ -122,31 +124,42 @@ export const getEntities =
     });
   };
 
-/*Takes in the current filters, and keeps sending get request until there are no pages left*/
-const fetchBatched = (fetchFunction, total, filter, batchSize = 100, rule) => {
-  const pages = Math.ceil(total / batchSize) || 1;
-  return Promise.all(
-    [...new Array(pages)].map((_, pageIdx) =>
-      fetchFunction({
-        ...filter,
-        page: pageIdx + 1,
-        per_page: batchSize,
-        rule,
-      }),
-    ),
-  );
-};
-/*Grabs all systemIds and maniupaltes the data into one large array of systems*/
+/**
+ * Grabs all systemIds using the new batching utilities
+ * Fetches all systems across pages and extracts system UUIDs
+ */
 export const allCurrentSystemIds =
   (fullFilters, total, rule, setIsLoading) => async () => {
     setIsLoading(true);
-    const results = await (
-      await fetchBatched(paginatedRequestHelper, total, fullFilters, 100, rule)
-    ).map((item) => item.data);
 
-    const merged = [].concat.apply([], results).map((item) => item.system_uuid);
-    setIsLoading(false);
-    return merged;
+    // Create a batched fetch function for the paginated request
+    const batchedFetch = createBatchedFetch(
+      (params) => paginatedRequestHelper({ ...fullFilters, ...params, rule }),
+      {
+        endpoint: 'inventory',
+        paginationType: PAGINATION_TYPES.PAGE,
+      },
+    );
+
+    try {
+      // Fetch all pages using the new batching utility
+      const result = await batchedFetch(
+        {},
+        {
+          batchSize: 100,
+          autoBatch: false,
+        },
+      );
+
+      // Extract system UUIDs from the merged result
+      const systemIds = result.data.map((item) => item.system_uuid);
+      setIsLoading(false);
+      return systemIds;
+    } catch (error) {
+      console.error('Failed to fetch batched system IDs:', error);
+      setIsLoading(false);
+      return [];
+    }
   };
 
 /**

--- a/src/PresentationalComponents/Inventory/helpers.test.js
+++ b/src/PresentationalComponents/Inventory/helpers.test.js
@@ -517,16 +517,19 @@ describe('Inventory helpers', () => {
         data: Array.from({ length: 100 }, (_, i) => ({
           system_uuid: `uuid-${i}`,
         })),
+        meta: { count: total, page: 1, per_page: 100 },
       };
       const mockPage2 = {
         data: Array.from({ length: 100 }, (_, i) => ({
           system_uuid: `uuid-${i + 100}`,
         })),
+        meta: { count: total, page: 2, per_page: 100 },
       };
       const mockPage3 = {
         data: Array.from({ length: 50 }, (_, i) => ({
           system_uuid: `uuid-${i + 200}`,
         })),
+        meta: { count: total, page: 3, per_page: 100 },
       };
 
       mockAxiosGet
@@ -555,6 +558,7 @@ describe('Inventory helpers', () => {
         data: Array.from({ length: 50 }, (_, i) => ({
           system_uuid: `uuid-${i}`,
         })),
+        meta: { count: total, page: 1, per_page: 100 },
       };
 
       mockAxiosGet.mockResolvedValue(mockData);
@@ -575,6 +579,7 @@ describe('Inventory helpers', () => {
       const total = 10;
       mockAxiosGet.mockResolvedValue({
         data: [{ system_uuid: 'uuid-1' }],
+        meta: { count: total, page: 1, per_page: 100 },
       });
 
       const fetchIds = allCurrentSystemIds(

--- a/src/PresentationalComponents/PathwaysTable/PathwaysTable.cy.js
+++ b/src/PresentationalComponents/PathwaysTable/PathwaysTable.cy.js
@@ -182,6 +182,50 @@ describe('Pathways table tests', () => {
 
       cy.url().should('include', 'sort=-recommendation_level');
     });
+
+    it('sorts batched pathways data by Systems and preserves sort on navigation', () => {
+      const total = 150;
+      const pageSize = 20;
+      const interceptedRequests = [];
+
+      cy.setupBatchInterceptors({
+        url: '/api/insights/v1/pathway/',
+        total,
+        pageSize,
+        dataType: 'pathways',
+      });
+
+      cy.intercept('GET', '/api/insights/v1/pathway/*', (req) => {
+        interceptedRequests.push(req);
+      }).as('batchRequests');
+
+      mountComponent();
+
+      cy.wait('@batchPage1', { timeout: 10000 });
+      cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+      cy.get('th').contains('Systems').click();
+
+      cy.get('th')
+        .contains('Systems')
+        .closest('th')
+        .should('have.attr', 'aria-sort', 'ascending');
+
+      cy.url().should('include', 'sort=impacted_systems_count');
+      cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+      cy.wrap(null).then(() => {
+        const sortRequests = interceptedRequests.filter((req) =>
+          req.url.includes('sort=impacted_systems_count'),
+        );
+        expect(sortRequests.length).to.be.greaterThan(0);
+      });
+
+      cy.get('button[data-action="next"]').first().click();
+
+      cy.url().should('include', 'sort=impacted_systems_count');
+      cy.url().should('include', 'offset=20');
+    });
   });
 
   describe('Conditional Filter', () => {
@@ -259,6 +303,53 @@ describe('Pathways table tests', () => {
       // reset
       cy.get('button').contains('Reset filters').click();
 
+      cy.get('.ins-c-chip-filters .pf-v6-c-label-group').should('not.exist');
+    });
+
+    it('Category filter works correctly with batched data', () => {
+      const total = 180;
+      const pageSize = 20;
+      const interceptedRequests = [];
+
+      cy.setupBatchInterceptors({
+        url: '/api/insights/v1/pathway/',
+        total,
+        pageSize,
+        dataType: 'pathways',
+      });
+
+      cy.intercept('GET', '/api/insights/v1/pathway/*', (req) => {
+        interceptedRequests.push(req);
+      }).as('batchRequests');
+
+      mountComponent();
+
+      cy.wait('@batchPage1', { timeout: 10000 });
+      cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+      let requestsBeforeFilter = 0;
+      cy.wrap(null).then(() => {
+        requestsBeforeFilter = interceptedRequests.length;
+      });
+
+      selectConditionalFilterOption('Category');
+      cy.get(CONDITIONAL_FILTER).contains('Filter by category').click();
+      cy.get(MENU_ITEM).contains('Availability').click();
+      cy.get(CONDITIONAL_FILTER).contains('Filter by category').click();
+
+      hasChip('Category', 'Availability');
+      cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+      cy.wrap(null).then(() => {
+        const requestsAfterFilter =
+          interceptedRequests.slice(requestsBeforeFilter);
+        const categoryRequests = requestsAfterFilter.filter((req) =>
+          req.url.includes('category=1'),
+        );
+        expect(categoryRequests.length).to.be.greaterThan(0);
+      });
+
+      cy.get('button').contains('Reset filters').click();
       cy.get('.ins-c-chip-filters .pf-v6-c-label-group').should('not.exist');
     });
   });
@@ -399,10 +490,8 @@ describe('Pathways table tests', () => {
     it('displays reboot status for all pathways', () => {
       cy.wait('@call');
       cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
-      cy.get('td[data-label="Reboot"]').should(
-        'have.length',
-        fixtures.data.length,
-      );
+      // With batching, only first page is visible (ROWS_SHOWN = 20)
+      cy.get('td[data-label="Reboot"]').should('have.length', ROWS_SHOWN);
     });
 
     it('displays reboot required status correctly', () => {
@@ -664,6 +753,147 @@ describe('Pathways table tests', () => {
 
       cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
       cy.get(ROOT).should('exist');
+    });
+  });
+
+  describe('Batch Requests', () => {
+    it('handles multiple pages of pathways with batch pagination', () => {
+      const totalPathways = 150;
+      const pageSize = 50;
+
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/pathway/',
+        total: totalPathways,
+        pageSize,
+        dataType: 'pathways',
+        paginationType: 'offset',
+      });
+
+      mountComponent();
+      cy.wait('@batchPage1');
+      cy.get(ROOT).should('exist');
+    });
+
+    it('preserves filters across batch requests', () => {
+      const interceptedRequests = [];
+
+      cy.intercept('GET', '**/api/insights/v1/pathway/*', (req) => {
+        interceptedRequests.push(req.url);
+        const url = new URL(req.url);
+        const offset = parseInt(url.searchParams.get('offset') || '0');
+        const limit = parseInt(url.searchParams.get('limit') || '20');
+
+        req.reply({
+          statusCode: 200,
+          body: window.generateBatchPathwaysData({
+            total: 100,
+            offset,
+            limit,
+          }),
+        });
+      }).as('batchRequests');
+
+      mountComponent();
+      cy.wait('@batchRequests');
+
+      selectConditionalFilterOption('Category');
+      cy.get(CONDITIONAL_FILTER).contains('Filter by category').click();
+      cy.get(MENU_ITEM).contains('Security').click();
+      cy.get(CONDITIONAL_FILTER).contains('Filter by category').click();
+
+      cy.wait('@batchRequests');
+
+      cy.wrap(null).then(() => {
+        const requestsWithCategory = interceptedRequests.filter((url) =>
+          url.includes('category'),
+        );
+        expect(requestsWithCategory.length).to.be.greaterThan(0);
+      });
+    });
+
+    it('displays correct pagination with batched data', () => {
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/pathway/',
+        total: 250,
+        pageSize: 50,
+        dataType: 'pathways',
+        paginationType: 'offset',
+      });
+
+      mountComponent();
+      cy.wait('@batchPage1');
+      cy.get('.pf-v6-c-menu-toggle__text').should('contain', '1 - 20');
+    });
+
+    it('handles empty batch results', () => {
+      cy.intercept('GET', '**/api/insights/v1/pathway/*', {
+        statusCode: 200,
+        body: {
+          data: [],
+          meta: { count: 0, limit: 50, offset: 0 },
+        },
+      }).as('emptyResults');
+
+      mountComponent();
+      cy.wait('@emptyResults');
+      cy.get(ROOT).should('exist');
+    });
+
+    it('handles large datasets with batch requests', () => {
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/pathway/',
+        total: 3000,
+        pageSize: 100,
+        dataType: 'pathways',
+        paginationType: 'offset',
+      });
+
+      mountComponent();
+      cy.wait('@batchPage1');
+      cy.get(ROOT).should('exist');
+    });
+
+    it('includes sort parameters in batch requests', () => {
+      const interceptedRequests = [];
+
+      cy.intercept('GET', '**/api/insights/v1/pathway/*', (req) => {
+        interceptedRequests.push(req.url);
+        const url = new URL(req.url);
+        const offset = parseInt(url.searchParams.get('offset') || '0');
+        const limit = parseInt(url.searchParams.get('limit') || '20');
+
+        req.reply({
+          statusCode: 200,
+          body: window.generateBatchPathwaysData({
+            total: 100,
+            offset,
+            limit,
+          }),
+        });
+      }).as('batchRequests');
+
+      mountComponent();
+      cy.wait('@batchRequests');
+
+      cy.get('th').contains('Name').click();
+      cy.wait('@batchRequests');
+
+      cy.wrap(null).then(() => {
+        const sortedRequests = interceptedRequests.filter((url) =>
+          url.includes('sort'),
+        );
+        expect(sortedRequests.length).to.be.greaterThan(0);
+      });
+    });
+
+    it('handles 403 forbidden errors during batch requests', () => {
+      cy.intercept('GET', '**/api/insights/v1/pathway/*', {
+        statusCode: 403,
+        body: { error: 'Forbidden' },
+      }).as('forbiddenRequest');
+
+      mountComponent();
+      cy.wait('@forbiddenRequest');
     });
   });
 });

--- a/src/PresentationalComponents/PathwaysTable/PathwaysTable.js
+++ b/src/PresentationalComponents/PathwaysTable/PathwaysTable.js
@@ -32,7 +32,7 @@ import { SearchIcon } from '@patternfly/react-icons';
 import debounce from '../../Utilities/Debounce';
 import messages from '../../Messages';
 import { updatePathFilters } from '../../Services/Filters';
-import { useGetPathwaysQuery } from '../../Services/Pathways';
+import { useGetPathwaysBatchedQuery } from '../../Services/Pathways';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
@@ -60,7 +60,9 @@ const PathwaysTable = ({ isTabActive }) => {
     isFetching,
     isLoading,
     isError,
-  } = useGetPathwaysQuery({
+  } = useGetPathwaysBatchedQuery({
+    batch: true,
+    autoBatch: true,
     ...filterFetchBuilder(filters),
     ...options,
   });
@@ -97,8 +99,26 @@ const PathwaysTable = ({ isTabActive }) => {
     return pruneFilters(localFilters, { ...FC, ...PFC });
   };
 
-  const buildRows = (pathways) => {
-    if (!pathways || pathways.length === 0) {
+  /**
+   * Slices batched data for current page
+   * @returns {Array} Pathways for current page
+   */
+  const getPaginatedData = () => {
+    if (!pathways?.data) return [];
+
+    const isBatchedData = pathways.data.length > filters.limit;
+
+    if (isBatchedData) {
+      const start = filters.offset || 0;
+      const end = start + filters.limit;
+      return pathways.data.slice(start, end);
+    }
+
+    return pathways.data;
+  };
+
+  const buildRows = (pathwaysData) => {
+    if (!pathwaysData || pathwaysData.length === 0) {
       return (
         <Tr>
           <Td colSpan={5}>
@@ -112,7 +132,7 @@ const PathwaysTable = ({ isTabActive }) => {
       );
     }
 
-    return pathways.map((pathway) => (
+    return pathwaysData.map((pathway) => (
       <Tr key={pathway.slug}>
         <Td dataLabel={intl.formatMessage(messages.pathwaysName)}>
           <span>
@@ -375,7 +395,7 @@ const PathwaysTable = ({ isTabActive }) => {
               </Th>
             </Tr>
           </Thead>
-          <Tbody>{buildRows(pathways?.data)}</Tbody>
+          <Tbody>{buildRows(getPaginatedData())}</Tbody>
         </Table>
       )}
       <TableToolbar isFooter>

--- a/src/PresentationalComponents/PathwaysTable/PathwaysTable.test.js
+++ b/src/PresentationalComponents/PathwaysTable/PathwaysTable.test.js
@@ -208,9 +208,9 @@ jest.mock(
   }),
 );
 
-const mockUseGetPathwaysQuery = jest.spyOn(
+const mockUseGetPathwaysBatchedQuery = jest.spyOn(
   PathwaysService,
-  'useGetPathwaysQuery',
+  'useGetPathwaysBatchedQuery',
 );
 
 AppConstants.FILTER_CATEGORIES = {
@@ -350,7 +350,7 @@ const renderComponent = (
 describe('PathwaysTable', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseGetPathwaysQuery.mockReturnValue({
+    mockUseGetPathwaysBatchedQuery.mockReturnValue({
       data: mockPathwaysData,
       isFetching: false,
       isLoading: false,
@@ -396,7 +396,7 @@ describe('PathwaysTable', () => {
   });
 
   it('should show SkeletonTable when loading', () => {
-    mockUseGetPathwaysQuery.mockReturnValue({
+    mockUseGetPathwaysBatchedQuery.mockReturnValue({
       data: { meta: { count: 0 } },
       isFetching: true,
       isLoading: true,

--- a/src/PresentationalComponents/RulesTable/RulesTable.cy.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.cy.js
@@ -223,6 +223,41 @@ describe('pagination', () => {
       });
     });
   });
+
+  it('can change page limit with batched data', () => {
+    const total = 150;
+    const pageSize = 50;
+    const interceptedRequests = [];
+
+    cy.setupBatchInterceptors({
+      url: '/api/insights/v1/rule/',
+      total,
+      pageSize,
+      dataType: 'recommendations',
+    });
+
+    cy.intercept('GET', '/api/insights/v1/rule/*', (req) => {
+      interceptedRequests.push(req);
+    }).as('batchRequests');
+
+    mountComponent(false);
+
+    cy.wait('@batchPage1', { timeout: 10000 });
+    cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+    changePagination(50);
+
+    cy.url().should('include', 'limit=50');
+    cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+    cy.wrap(null).then(() => {
+      expect(interceptedRequests.length).to.be.greaterThan(0);
+      const limitRequests = interceptedRequests.filter((req) =>
+        req.url.includes('limit=50'),
+      );
+      expect(limitRequests.length).to.be.greaterThan(0);
+    });
+  });
 });
 
 describe('filtering', () => {
@@ -274,6 +309,52 @@ describe('filtering', () => {
     checkPaginationTotal(fixtures.meta.count);
   });
 
+  it('filtering works correctly with batched data', () => {
+    const total = 200;
+    const pageSize = 20;
+    const interceptedRequests = [];
+
+    cy.setupBatchInterceptors({
+      url: '/api/insights/v1/rule/',
+      total,
+      pageSize,
+      dataType: 'recommendations',
+    });
+
+    cy.intercept('GET', '/api/insights/v1/rule/*', (req) => {
+      interceptedRequests.push(req);
+    }).as('batchRequests');
+
+    mountComponent(false);
+
+    cy.wait('@batchPage1', { timeout: 10000 });
+    cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+    let requestsBeforeFilter = 0;
+    cy.wrap(null).then(() => {
+      requestsBeforeFilter = interceptedRequests.length;
+    });
+
+    filterApply({ risk: ['Critical'] });
+    cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+    cy.wrap(null).then(() => {
+      const requestsAfterFilter =
+        interceptedRequests.slice(requestsBeforeFilter);
+      const riskRequests = requestsAfterFilter.filter(
+        (req) => req.url.includes('total_risk=4') || req.url.includes('risk=4'),
+      );
+      expect(riskRequests.length).to.be.greaterThan(0);
+    });
+
+    hasChip('Total risk', 'Critical');
+
+    cy.get('button').contains('Reset filters').click();
+
+    hasChip('Systems impacted', '1 or more');
+    hasChip('Status', 'Enabled');
+  });
+
   it('will reset filters but not pagination and sorting', () => {
     filterApply({ name: 'Lo' });
 
@@ -282,6 +363,56 @@ describe('filtering', () => {
     cy.get('th[data-label="Name"]')
       .should('have.attr', 'aria-sort')
       .and('contain', 'ascending');
+  });
+
+  it('combined sort, filter, and pagination work with batched data', () => {
+    const total = 180;
+    const pageSize = 20;
+    const interceptedRequests = [];
+
+    cy.setupBatchInterceptors({
+      url: '/api/insights/v1/rule/',
+      total,
+      pageSize,
+      dataType: 'recommendations',
+    });
+
+    cy.intercept('GET', '/api/insights/v1/rule/*', (req) => {
+      interceptedRequests.push(req);
+    }).as('batchRequests');
+
+    mountComponent(false);
+
+    cy.wait('@batchPage1', { timeout: 10000 });
+    cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+    cy.get('th').contains('Name').click();
+    cy.url().should('include', 'sort=description');
+
+    filterApply({ risk: ['Critical'] });
+    cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+    hasChip('Total risk', 'Critical');
+
+    cy.get('button[data-action="next"]').first().click();
+    cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+    cy.url().should('include', 'sort=description');
+    cy.url().should('include', 'offset=20');
+
+    cy.wrap(null).then(() => {
+      const combinedRequests = interceptedRequests.filter(
+        (req) =>
+          req.url.includes('sort=description') &&
+          (req.url.includes('total_risk=4') || req.url.includes('risk=4')),
+      );
+      expect(combinedRequests.length).to.be.greaterThan(0);
+    });
+
+    cy.get('button[data-action="previous"]').first().click();
+
+    cy.url().should('include', 'sort=description');
+    cy.url().should('include', 'offset=0');
+    cy.url().should('include', 'total_risk=4');
   });
 });
 
@@ -521,6 +652,50 @@ describe('sorting', () => {
       .contains('Total risk')
       .closest('th')
       .should('not.have.attr', 'aria-sort');
+  });
+
+  it('sorts batched data by Name and preserves sort on navigation', () => {
+    const total = 150;
+    const pageSize = 20;
+    const interceptedRequests = [];
+
+    cy.setupBatchInterceptors({
+      url: '/api/insights/v1/rule/',
+      total,
+      pageSize,
+      dataType: 'recommendations',
+    });
+
+    cy.intercept('GET', '/api/insights/v1/rule/*', (req) => {
+      interceptedRequests.push(req);
+    }).as('batchRequests');
+
+    mountComponent(false);
+
+    cy.wait('@batchPage1', { timeout: 10000 });
+    cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+    cy.get('th').contains('Name').click();
+
+    cy.get('th')
+      .contains('Name')
+      .closest('th')
+      .should('have.attr', 'aria-sort', 'ascending');
+
+    cy.url().should('include', 'sort=description');
+    cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+    cy.wrap(null).then(() => {
+      const sortRequests = interceptedRequests.filter((req) =>
+        req.url.includes('sort=description'),
+      );
+      expect(sortRequests.length).to.be.greaterThan(0);
+    });
+
+    cy.get('button[data-action="next"]').first().click();
+
+    cy.url().should('include', 'sort=description');
+    cy.url().should('include', 'offset=20');
   });
 });
 
@@ -1592,6 +1767,225 @@ describe('Permission-based UI Controls', () => {
       );
       cy.get('button[aria-label="Export"]').should('not.exist');
       cy.get('button[aria-label="Kebab toggle"]').should('not.exist');
+    });
+  });
+
+  describe('Batch Requests', () => {
+    it('handles multiple pages of recommendations with batch requests', () => {
+      const totalRecs = 150;
+      const pageSize = 50;
+
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/rule/',
+        total: totalRecs,
+        pageSize,
+        dataType: 'recommendations',
+        paginationType: 'offset',
+      });
+
+      mountComponent();
+      cy.wait('@batchPage1');
+      cy.get(ROOT).should('exist');
+
+      changePagination(100);
+      cy.wait('@batchPage1');
+      cy.get('tbody tr').should('have.length.at.least', 20);
+    });
+
+    it('preserves filters across batch requests', () => {
+      const totalRecs = 200;
+      const pageSize = 50;
+      let requestsBeforeFilter = 0;
+      const interceptedRequests = [];
+
+      cy.intercept('GET', '**/api/insights/v1/rule/*', (req) => {
+        interceptedRequests.push(req.url);
+        const url = new URL(req.url);
+        const offset = parseInt(url.searchParams.get('offset') || '0');
+
+        req.reply({
+          statusCode: 200,
+          body: window.generateBatchRecommendationsData({
+            total: totalRecs,
+            offset,
+            limit: pageSize,
+          }),
+        });
+      }).as('batchRequests');
+
+      mountComponent();
+      cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+      cy.wrap(null).then(() => {
+        requestsBeforeFilter = interceptedRequests.length;
+      });
+
+      filterApply({ risk: ['Critical'] });
+      cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+      cy.wrap(null).then(() => {
+        const requestsAfterFilter =
+          interceptedRequests.slice(requestsBeforeFilter);
+        expect(requestsAfterFilter.length).to.be.greaterThan(0);
+        requestsAfterFilter.forEach((url) => {
+          expect(url).to.include('total_risk=4');
+        });
+      });
+    });
+
+    it('displays correct pagination total with batched data', () => {
+      const totalRecs = 250;
+      const pageSize = 50;
+
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/rule/',
+        total: totalRecs,
+        pageSize,
+        dataType: 'recommendations',
+        paginationType: 'offset',
+      });
+
+      mountComponent();
+      cy.wait('@batchPage1');
+      checkPaginationTotal(totalRecs);
+    });
+
+    it('handles empty batch results', () => {
+      cy.intercept('GET', '**/api/insights/v1/rule/*', {
+        statusCode: 200,
+        body: {
+          data: [],
+          meta: { count: 0, limit: 50, offset: 0 },
+        },
+      }).as('emptyResults');
+
+      mountComponent();
+      cy.wait('@emptyResults');
+      cy.get(ROOT).should('exist');
+    });
+
+    it('handles large datasets (5000+ items)', () => {
+      const totalRecs = 5000;
+      const pageSize = 100;
+
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/rule/',
+        total: totalRecs,
+        pageSize,
+        dataType: 'recommendations',
+        paginationType: 'offset',
+      });
+
+      mountComponent();
+      cy.wait('@batchPage1');
+      cy.get(ROOT).should('exist');
+      checkPaginationTotal(totalRecs);
+    });
+
+    it('handles sequential batch operations', () => {
+      const totalRecs = 100;
+      const pageSize = 50;
+
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/rule/',
+        total: totalRecs,
+        pageSize,
+        dataType: 'recommendations',
+        paginationType: 'offset',
+      });
+
+      mountComponent();
+      cy.wait('@batchPage1');
+
+      filterApply({ risk: ['Critical'] });
+      cy.wait('@batchPage1');
+
+      removeAllFilterChipsPf6();
+      cy.wait('@batchPage1');
+
+      cy.get(ROOT).should('exist');
+    });
+
+    it('includes sort parameters in batch requests', () => {
+      const totalRecs = 150;
+      const pageSize = 50;
+      const interceptedRequests = [];
+
+      cy.intercept('GET', '**/api/insights/v1/rule/*', (req) => {
+        interceptedRequests.push(req.url);
+        const url = new URL(req.url);
+        const offset = parseInt(url.searchParams.get('offset') || '0');
+
+        req.reply({
+          statusCode: 200,
+          body: window.generateBatchRecommendationsData({
+            total: totalRecs,
+            offset,
+            limit: pageSize,
+          }),
+        });
+      }).as('batchRequests');
+
+      mountComponent();
+      cy.wait('@batchRequests');
+
+      cy.get('th').contains('Name').click();
+      cy.wait('@batchRequests');
+
+      cy.wrap(null).then(() => {
+        const sortedRequests = interceptedRequests.filter((url) =>
+          url.includes('sort'),
+        );
+        expect(sortedRequests.length).to.be.greaterThan(0);
+      });
+    });
+
+    it('handles pagination changes with batch requests', () => {
+      const totalRecs = 300;
+      const pageSize = 50;
+
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/rule/',
+        total: totalRecs,
+        pageSize,
+        dataType: 'recommendations',
+        paginationType: 'offset',
+      });
+
+      mountComponent();
+      cy.wait('@batchPage1');
+
+      changePagination(50);
+      cy.wait('@batchPage1');
+      checkPaginationValues(PAGINATION_VALUES);
+
+      cy.get('button[data-action="next"]').first().click();
+      cy.get(ROOT).should('exist');
+    });
+
+    it('handles batch request timeouts', () => {
+      cy.intercept('GET', '**/api/insights/v1/rule/*', {
+        statusCode: 200,
+        body: window.generateBatchRecommendationsData({
+          total: 50,
+          offset: 0,
+          limit: 50,
+        }),
+        delay: 10000,
+      }).as('slowRequest');
+
+      mountComponent();
+      cy.get('[aria-label="Loading"]', { timeout: 2000 }).should('exist');
+      cy.get(ROOT, { timeout: 15000 }).should('exist');
+    });
+
+    it('handles 403 forbidden errors during batch requests', () => {
+      cy.intercept('GET', '**/api/insights/v1/rule/*', {
+        statusCode: 403,
+        body: { error: 'Forbidden' },
+      }).as('forbiddenRequest');
+
+      mountComponent();
+      cy.wait('@forbiddenRequest');
     });
   });
 });

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -35,7 +35,7 @@ import messages from '../../Messages';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/';
 
 import { updateRecFilters } from '../../Services/Filters';
-import { useGetRecsQuery } from '../../Services/Recs';
+import { useGetRecsBatchedQuery } from '../../Services/Recs';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { filtersInitialState } from '../../Services/Filters';
@@ -92,7 +92,9 @@ const RulesTable = ({ isTabActive, pathway, onRuleChange }) => {
     isLoading,
     isError,
     refetch,
-  } = useGetRecsQuery({
+  } = useGetRecsBatchedQuery({
+    batch: true,
+    autoBatch: true,
     ...filterFetchBuilder(filters),
     ...options,
     customBasePath: envContext.BASE_URL,
@@ -132,7 +134,10 @@ const RulesTable = ({ isTabActive, pathway, onRuleChange }) => {
     });
   };
 
-  // Build rows from the old structure
+  /**
+   * Handles client-side pagination for batched data
+   * @returns {Array} Table rows for current page
+   */
   const buildRowsFromOldFormat = () => {
     if (!rules.data) return [];
 
@@ -140,8 +145,20 @@ const RulesTable = ({ isTabActive, pathway, onRuleChange }) => {
       return emptyRows(filters, toggleRulesDisabled);
     }
 
+    const isBatchedData = rules.data.length > filters.limit;
+    let paginatedRules = rules;
+
+    if (isBatchedData) {
+      const start = filters.offset || 0;
+      const end = start + filters.limit;
+      paginatedRules = {
+        ...rules,
+        data: rules.data.slice(start, end),
+      };
+    }
+
     return buildRows(
-      rules,
+      paginatedRules,
       areAllExpanded,
       setViewSystemsModalRule,
       setViewSystemsModalOpen,

--- a/src/Services/Pathways.js
+++ b/src/Services/Pathways.js
@@ -1,10 +1,14 @@
 import { createAdvisorBaseQuery } from '../Utilities/createAdvisorBaseQuery';
+import { createBatchedQueryFn } from '../Utilities/createBatchQueryEndpoint';
+import { PAGINATION_TYPES } from '../Utilities/batchPaginationHelpers';
 import { BASE_URL } from '../AppConstants';
 import { createApi } from '@reduxjs/toolkit/query/react';
 
+const baseQuery = createAdvisorBaseQuery({ baseUrl: BASE_URL });
+
 export const Pathways = createApi({
   reducerPath: 'pathways',
-  baseQuery: createAdvisorBaseQuery({ baseUrl: BASE_URL }),
+  baseQuery,
   keepUnusedDataFor: 5,
   endpoints: (build) => ({
     getPathways: build.query({
@@ -19,6 +23,40 @@ export const Pathways = createApi({
     getPathwaySystems: build.query({
       query: (name) => ({ url: `/pathway/${name}/systems/` }),
     }),
+    // Batched endpoint variants
+    getPathwaysBatched: build.query({
+      queryFn: createBatchedQueryFn({
+        baseQuery,
+        buildUrl: (params) => {
+          const { customBasePath, inventoryBasePath, ...restParams } = params;
+          return {
+            url: `/pathway/`,
+            options: restParams,
+            ...(customBasePath && { customBasePath }),
+            ...(inventoryBasePath && { inventoryBasePath }),
+          };
+        },
+        endpoint: 'pathways',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      }),
+    }),
+    getPathwaySystemsBatched: build.query({
+      queryFn: createBatchedQueryFn({
+        baseQuery,
+        buildUrl: (params) => {
+          const { name, customBasePath, inventoryBasePath, ...restParams } =
+            params;
+          return {
+            url: `/pathway/${name}/systems/`,
+            options: restParams,
+            ...(customBasePath && { customBasePath }),
+            ...(inventoryBasePath && { inventoryBasePath }),
+          };
+        },
+        endpoint: 'pathways',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      }),
+    }),
   }),
 });
 
@@ -27,4 +65,8 @@ export const {
   useGetPathwayQuery,
   useGetPathwayRulesQuery,
   useGetPathwaySystemsQuery,
+  useGetPathwaysBatchedQuery,
+  useGetPathwaySystemsBatchedQuery,
+  useLazyGetPathwaysBatchedQuery,
+  useLazyGetPathwaySystemsBatchedQuery,
 } = Pathways;

--- a/src/Services/Recs.js
+++ b/src/Services/Recs.js
@@ -1,10 +1,14 @@
 import { createApi } from '@reduxjs/toolkit/query/react';
 import { createAdvisorBaseQuery } from '../Utilities/createAdvisorBaseQuery';
+import { createBatchedQueryFn } from '../Utilities/createBatchQueryEndpoint';
+import { PAGINATION_TYPES } from '../Utilities/batchPaginationHelpers';
 import { BASE_URL } from '../AppConstants';
+
+const baseQuery = createAdvisorBaseQuery({ baseUrl: BASE_URL });
 
 export const Recs = createApi({
   reducerPath: 'recs',
-  baseQuery: createAdvisorBaseQuery({ baseUrl: BASE_URL }),
+  baseQuery,
   keepUnusedDataFor: 5,
   endpoints: (build) => ({
     getRecs: build.query({
@@ -29,7 +33,49 @@ export const Recs = createApi({
         ...options,
       }),
     }),
+    // Batched endpoint variants
+    getRecsBatched: build.query({
+      queryFn: createBatchedQueryFn({
+        baseQuery,
+        buildUrl: (params) => {
+          const { customBasePath, inventoryBasePath, ...restParams } = params;
+          return {
+            url: `/rule/`,
+            options: restParams,
+            ...(customBasePath && { customBasePath }),
+            ...(inventoryBasePath && { inventoryBasePath }),
+          };
+        },
+        endpoint: 'recs',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      }),
+    }),
+    getRecSystemsBatched: build.query({
+      queryFn: createBatchedQueryFn({
+        baseQuery,
+        buildUrl: (params) => {
+          const { ruleId, customBasePath, inventoryBasePath, ...restParams } =
+            params;
+          return {
+            url: `/rule/${encodeURI(ruleId)}/systems/`,
+            options: restParams,
+            ...(customBasePath && { customBasePath }),
+            ...(inventoryBasePath && { inventoryBasePath }),
+          };
+        },
+        endpoint: 'recs',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      }),
+    }),
   }),
 });
 
-export const { useGetRecsQuery, useGetRecQuery, useGetRecSystemsQuery } = Recs;
+export const {
+  useGetRecsQuery,
+  useGetRecQuery,
+  useGetRecSystemsQuery,
+  useGetRecsBatchedQuery,
+  useGetRecSystemsBatchedQuery,
+  useLazyGetRecsBatchedQuery,
+  useLazyGetRecSystemsBatchedQuery,
+} = Recs;

--- a/src/Services/Recs.test.js
+++ b/src/Services/Recs.test.js
@@ -7,6 +7,8 @@ import {
   useGetRecsQuery,
   useGetRecQuery,
   useGetRecSystemsQuery,
+  useGetRecsBatchedQuery,
+  useGetRecSystemsBatchedQuery,
 } from './Recs';
 
 jest.mock(
@@ -15,6 +17,12 @@ jest.mock(
 );
 
 const instance = require('@redhat-cloud-services/frontend-components-utilities/interceptors');
+
+jest.mock('p-all', () => {
+  return jest.fn((tasks) => {
+    return Promise.all(tasks.map((task) => task()));
+  });
+});
 
 const createWrapper = () => {
   const store = configureStore({
@@ -185,6 +193,93 @@ describe('Recs Service', () => {
         }),
       );
       expect(result.current.data).toEqual(mockData);
+    });
+  });
+
+  describe('useGetRecsBatchedQuery', () => {
+    it('should fetch recommendations with batching', async () => {
+      instance
+        .mockResolvedValueOnce({
+          data: [{ rule_id: 'rule1' }, { rule_id: 'rule2' }],
+          meta: { count: 5, offset: 0, limit: 2 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ rule_id: 'rule3' }, { rule_id: 'rule4' }],
+          meta: { count: 5, offset: 2, limit: 2 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ rule_id: 'rule5' }],
+          meta: { count: 5, offset: 4, limit: 2 },
+        });
+
+      const { result } = renderHook(
+        () =>
+          useGetRecsBatchedQuery({
+            batch: true,
+            batchSize: 2,
+            autoBatch: false,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(instance).toHaveBeenCalledTimes(3);
+      expect(result.current.data.data).toHaveLength(5);
+      expect(result.current.data.meta.count).toBe(5);
+    });
+
+    it('should skip batching for small datasets', async () => {
+      instance.mockResolvedValueOnce({
+        data: [{ rule_id: 'rule1' }],
+        meta: { count: 1, offset: 0, limit: 50 },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useGetRecsBatchedQuery({
+            batch: true,
+            batchSize: 50,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(instance).toHaveBeenCalledTimes(1);
+      expect(result.current.data.data).toHaveLength(1);
+    });
+  });
+
+  describe('useGetRecSystemsBatchedQuery', () => {
+    it('should fetch rule systems with batching', async () => {
+      const ruleId = 'test-rule';
+
+      instance
+        .mockResolvedValueOnce({
+          data: [{ system_uuid: 'sys1' }, { system_uuid: 'sys2' }],
+          meta: { count: 4, offset: 0, limit: 2 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ system_uuid: 'sys3' }, { system_uuid: 'sys4' }],
+          meta: { count: 4, offset: 2, limit: 2 },
+        });
+
+      const { result } = renderHook(
+        () =>
+          useGetRecSystemsBatchedQuery({
+            batch: true,
+            ruleId,
+            batchSize: 2,
+            autoBatch: false,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(instance).toHaveBeenCalledTimes(2);
+      expect(result.current.data.data).toHaveLength(4);
     });
   });
 });

--- a/src/Services/Systems.js
+++ b/src/Services/Systems.js
@@ -1,11 +1,15 @@
 import * as AppConst from '../AppConstants';
 
 import { createAdvisorBaseQuery } from '../Utilities/createAdvisorBaseQuery';
+import { createBatchedQueryFn } from '../Utilities/createBatchQueryEndpoint';
+import { PAGINATION_TYPES } from '../Utilities/batchPaginationHelpers';
 import { createApi } from '@reduxjs/toolkit/query/react';
+
+const baseQuery = createAdvisorBaseQuery({ baseUrl: AppConst.BASE_URL });
 
 export const Systems = createApi({
   reducerPath: 'systems',
-  baseQuery: createAdvisorBaseQuery({ baseUrl: AppConst.BASE_URL }),
+  baseQuery,
   endpoints: (build) => ({
     getSystems: build.query({
       query: (options) => ({ url: `/system/`, options }),
@@ -17,6 +21,23 @@ export const Systems = createApi({
         search,
       }),
     }),
+    // Batched endpoint variants
+    getSystemsBatched: build.query({
+      queryFn: createBatchedQueryFn({
+        baseQuery,
+        buildUrl: (params) => {
+          const { customBasePath, inventoryBasePath, ...restParams } = params;
+          return {
+            url: `/system/`,
+            options: restParams,
+            ...(customBasePath && { customBasePath }),
+            ...(inventoryBasePath && { inventoryBasePath }),
+          };
+        },
+        endpoint: 'systems',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      }),
+    }),
   }),
 });
 
@@ -25,4 +46,6 @@ export const {
   useLazygetSystemsQuery,
   useGetSystemQuery,
   useLazygetSystemQuery,
+  useGetSystemsBatchedQuery,
+  useLazyGetSystemsBatchedQuery,
 } = Systems;

--- a/src/Services/Systems.test.js
+++ b/src/Services/Systems.test.js
@@ -1,0 +1,149 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { Systems, useGetSystemsBatchedQuery } from './Systems';
+
+jest.mock(
+  '@redhat-cloud-services/frontend-components-utilities/interceptors',
+  () => jest.fn(),
+);
+
+const instance = require('@redhat-cloud-services/frontend-components-utilities/interceptors');
+
+jest.mock('p-all', () => {
+  return jest.fn((tasks) => {
+    return Promise.all(tasks.map((task) => task()));
+  });
+});
+
+const createWrapper = () => {
+  const store = configureStore({
+    reducer: {
+      [Systems.reducerPath]: Systems.reducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat(Systems.middleware),
+  });
+
+  // eslint-disable-next-line react/prop-types
+  const Wrapper = ({ children }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  return Wrapper;
+};
+
+describe('Systems Service', () => {
+  beforeEach(() => {
+    instance.mockImplementation(() => Promise.resolve({ data: [] }));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('useGetSystemsBatchedQuery', () => {
+    it('should fetch systems with batching', async () => {
+      instance
+        .mockResolvedValueOnce({
+          data: [{ id: 'sys1' }, { id: 'sys2' }],
+          meta: { count: 4, offset: 0, limit: 2 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 'sys3' }, { id: 'sys4' }],
+          meta: { count: 4, offset: 2, limit: 2 },
+        });
+
+      const { result } = renderHook(
+        () =>
+          useGetSystemsBatchedQuery({
+            batch: true,
+            batchSize: 2,
+            autoBatch: false,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(instance).toHaveBeenCalledTimes(2);
+      expect(result.current.data.data).toHaveLength(4);
+      expect(result.current.data.meta.count).toBe(4);
+    });
+
+    it('should use endpoint-specific batch size defaults', async () => {
+      instance.mockResolvedValueOnce({
+        data: [{ id: 'sys1' }],
+        meta: { count: 1, offset: 0, limit: 100 },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useGetSystemsBatchedQuery({
+            batch: true,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(instance).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            limit: 100,
+          }),
+        }),
+      );
+    });
+
+    it('should preserve query parameters across batches', async () => {
+      instance
+        .mockResolvedValueOnce({
+          data: [{ id: 'sys1' }],
+          meta: { count: 2, offset: 0, limit: 1 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 'sys2' }],
+          meta: { count: 2, offset: 1, limit: 1 },
+        });
+
+      const { result } = renderHook(
+        () =>
+          useGetSystemsBatchedQuery({
+            batch: true,
+            batchSize: 1,
+            filter: 'os=RHEL',
+            sort: 'display_name',
+            autoBatch: false,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(instance).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            filter: 'os=RHEL',
+            sort: 'display_name',
+            offset: 0,
+            limit: 1,
+          }),
+        }),
+      );
+
+      expect(instance).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            filter: 'os=RHEL',
+            sort: 'display_name',
+            offset: 1,
+            limit: 1,
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/src/SmartComponents/Recs/List.cy.js
+++ b/src/SmartComponents/Recs/List.cy.js
@@ -132,7 +132,8 @@ describe('List Component Integration', () => {
       cy.contains('Critical recommendations').should('exist');
       cy.contains('Important recommendations').should('exist');
 
-      cy.get('[aria-label="rules-table"]').should('exist');
+      cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+      cy.get('[aria-label="rules-table"]', { timeout: 10000 }).should('exist');
       cy.get('th').contains('Name').should('exist');
     });
 
@@ -217,6 +218,63 @@ describe('List Component Integration', () => {
       );
       cy.wait('@getPathways');
     });
+
+    it('handles tab switching with batched data', () => {
+      const recsTotal = 150;
+      const pathwaysTotal = 120;
+      const pageSize = 20;
+      const recsIntercepted = [];
+      const pathwaysIntercepted = [];
+
+      cy.setupBatchInterceptors({
+        url: '/api/insights/v1/rule/',
+        total: recsTotal,
+        pageSize,
+        dataType: 'recommendations',
+      });
+
+      cy.setupBatchInterceptors({
+        url: '/api/insights/v1/pathway/',
+        total: pathwaysTotal,
+        pageSize,
+        dataType: 'pathways',
+      });
+
+      cy.intercept('GET', '/api/insights/v1/rule/*', (req) => {
+        recsIntercepted.push(req);
+      }).as('recsBatch');
+
+      cy.intercept('GET', '/api/insights/v1/pathway/*', (req) => {
+        pathwaysIntercepted.push(req);
+      }).as('pathwaysBatch');
+
+      mountComponent();
+
+      cy.wait('@batchPage1', { timeout: 10000 });
+      cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+      cy.wrap(null).then(() => {
+        expect(recsIntercepted.length).to.be.greaterThan(0);
+      });
+
+      cy.contains('[role="tab"]', 'Pathways').click();
+
+      cy.wait('@batchPage1', { timeout: 10000 });
+      cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+      cy.wrap(null).then(() => {
+        expect(pathwaysIntercepted.length).to.be.greaterThan(0);
+      });
+
+      cy.contains('[role="tab"]', 'Recommendations').click();
+
+      cy.get('[aria-label="rules-table"]', { timeout: 5000 }).should('exist');
+
+      cy.wrap(null).then(() => {
+        expect(recsIntercepted.length).to.be.greaterThan(0);
+        expect(pathwaysIntercepted.length).to.be.greaterThan(0);
+      });
+    });
   });
 
   describe('Overview Dashboard Integration', () => {
@@ -241,6 +299,44 @@ describe('List Component Integration', () => {
       cy.get('#overview-dashbar').within(() => {
         cy.contains('Incidents').closest('[data-ouia-component-type]').click();
       });
+    });
+
+    it('overview dashboard persists during pagination with batched data', () => {
+      const total = 150;
+      const pageSize = 20;
+
+      cy.setupBatchInterceptors({
+        url: '/api/insights/v1/rule/',
+        total,
+        pageSize,
+        dataType: 'recommendations',
+      });
+
+      cy.intercept('GET', '/api/insights/v1/rule/*').as('recsBatch');
+
+      mountComponent();
+
+      cy.wait('@batchPage1', { timeout: 10000 });
+      cy.wait('@getOverviewStats');
+
+      cy.get('#overview-dashbar')
+        .should('exist')
+        .within(() => {
+          cy.contains('3').should('exist');
+          cy.contains('5').should('exist');
+        });
+
+      cy.get('button[data-action="next"]').first().click();
+      cy.get('[aria-label="Loading"]', { timeout: 5000 }).should('not.exist');
+
+      cy.get('#overview-dashbar')
+        .should('exist')
+        .within(() => {
+          cy.contains('3').should('exist');
+          cy.contains('5').should('exist');
+        });
+
+      cy.url().should('include', 'offset=20');
     });
 
     it('refetches overview data when rule is disabled', () => {
@@ -874,6 +970,263 @@ describe('List Component Integration', () => {
       cy.contains('[role="tab"]', 'Recommendations').click();
 
       cy.get('.pf-v6-c-label-group').contains('test').should('not.exist');
+    });
+  });
+
+  describe('Batch Requests', () => {
+    beforeEach(() => {
+      cy.on('uncaught:exception', (err) => {
+        if (err.message.includes('chrome.getApp is not a function')) {
+          return false;
+        }
+        return true;
+      });
+
+      cy.intercept('GET', '/feature_flags*', {
+        statusCode: 200,
+        body: { toggles: [] },
+      }).as('getFeatureFlag');
+
+      cy.intercept('GET', '/api/insights/v1/stats/overview/', {
+        statusCode: 200,
+        body: {
+          critical: 5,
+          important: 10,
+          moderate: 15,
+          low: 20,
+          incidents: 3,
+          pathways: 7,
+        },
+      }).as('getOverviewStats');
+    });
+
+    it('handles multiple pages of recommendations with batch requests', () => {
+      const totalRecs = 200;
+      const pageSize = 50;
+
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/rule/',
+        total: totalRecs,
+        pageSize,
+        dataType: 'recommendations',
+        paginationType: 'offset',
+      });
+
+      cy.intercept('GET', '/api/insights/v1/pathway/*', {
+        statusCode: 200,
+        body: pathways,
+      }).as('getPathways');
+
+      mountComponent();
+      cy.wait('@batchPage1');
+      cy.get('[aria-label="rules-table"]').should('exist');
+    });
+
+    it('preserves filters when switching between tabs with batch data', () => {
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/rule/',
+        total: 150,
+        pageSize: 50,
+        dataType: 'recommendations',
+        paginationType: 'offset',
+      });
+
+      cy.intercept('GET', '/api/insights/v1/pathway/*', {
+        statusCode: 200,
+        body: pathways,
+      }).as('getPathways');
+
+      mountComponent({ urlParams: 'text=kernel' });
+
+      cy.wait('@batchPage1');
+      cy.get('.pf-v6-c-label-group').contains('kernel').should('exist');
+
+      cy.contains('[role="tab"]', 'Pathways').click();
+      cy.wait('@getPathways');
+
+      cy.contains('[role="tab"]', 'Recommendations').click();
+      cy.wait('@batchPage1');
+
+      cy.get('.pf-v6-c-label-group').contains('kernel').should('exist');
+    });
+
+    it('handles batch request errors gracefully', () => {
+      cy.intercept('GET', '**/api/insights/v1/rule/*offset=0*', {
+        statusCode: 200,
+        body: window.generateBatchRecommendationsData({
+          total: 100,
+          offset: 0,
+          limit: 50,
+        }),
+      }).as('page1');
+
+      cy.intercept('GET', '**/api/insights/v1/rule/*offset=50*', {
+        statusCode: 500,
+        body: { error: 'Internal Server Error' },
+      }).as('page2Error');
+
+      cy.intercept('GET', '/api/insights/v1/pathway/*', {
+        statusCode: 200,
+        body: pathways,
+      }).as('getPathways');
+
+      mountComponent();
+      cy.wait('@page1');
+      cy.get('[data-ouia-component-type="RHI/Header"]').should('exist');
+      cy.get('#overview-dashbar').should('exist');
+    });
+
+    it('handles empty batch results', () => {
+      cy.intercept('GET', '**/api/insights/v1/rule/*', {
+        statusCode: 200,
+        body: {
+          data: [],
+          meta: { count: 0, limit: 50, offset: 0 },
+        },
+      }).as('emptyResults');
+
+      cy.intercept('GET', '/api/insights/v1/pathway/*', {
+        statusCode: 200,
+        body: pathways,
+      }).as('getPathways');
+
+      mountComponent();
+      cy.wait('@emptyResults');
+      cy.get('[aria-label="rules-table"]').should('exist');
+    });
+
+    it('handles large datasets with batch pagination', () => {
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/rule/',
+        total: 5000,
+        pageSize: 100,
+        dataType: 'recommendations',
+        paginationType: 'offset',
+      });
+
+      cy.intercept('GET', '/api/insights/v1/pathway/*', {
+        statusCode: 200,
+        body: pathways,
+      }).as('getPathways');
+
+      mountComponent();
+      cy.wait('@batchPage1');
+      cy.get('[aria-label="rules-table"]').should('exist');
+      cy.get('#overview-dashbar').should('exist');
+    });
+
+    it('refetches with batch requests after overview card click', () => {
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/rule/',
+        total: 100,
+        pageSize: 50,
+        dataType: 'recommendations',
+        paginationType: 'offset',
+      });
+
+      cy.intercept('GET', '/api/insights/v1/pathway/*', {
+        statusCode: 200,
+        body: pathways,
+      }).as('getPathways');
+
+      mountComponent();
+      cy.wait('@batchPage1');
+
+      cy.get('#overview-dashbar').within(() => {
+        cy.contains('Critical recommendations')
+          .closest('[data-ouia-component-type]')
+          .click();
+      });
+
+      cy.wait('@batchPage1');
+      cy.get('[aria-label="rules-table"]').should('exist');
+    });
+
+    it('handles sequential batch operations when applying and clearing filters', () => {
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/rule/',
+        total: 150,
+        pageSize: 50,
+        dataType: 'recommendations',
+        paginationType: 'offset',
+      });
+
+      cy.intercept('GET', '/api/insights/v1/pathway/*', {
+        statusCode: 200,
+        body: pathways,
+      }).as('getPathways');
+
+      mountComponent();
+      cy.wait('@batchPage1');
+
+      cy.get('[data-ouia-component-id="ConditionalFilter"]')
+        .find('input')
+        .type('test{enter}');
+      cy.wait('@batchPage1');
+
+      cy.get('button').contains('Reset filters').click();
+      cy.wait('@batchPage1');
+
+      cy.get('[aria-label="rules-table"]').should('exist');
+    });
+
+    it('handles batch requests for pathways tab', () => {
+      cy.intercept('GET', '**/api/insights/v1/rule/*', {
+        statusCode: 200,
+        body: recommendations,
+      }).as('getRecommendations');
+
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/pathway/',
+        total: 200,
+        pageSize: 50,
+        dataType: 'pathways',
+        paginationType: 'offset',
+      });
+
+      mountComponent();
+      cy.wait('@getRecommendations');
+
+      cy.contains('[role="tab"]', 'Pathways').click();
+      cy.wait('@batchPage1');
+
+      cy.get('table[aria-label="pathways-table"]').should('exist');
+    });
+
+    it('preserves overview dashboard during batch operations', () => {
+      cy.setupBatchInterceptors({
+        url: '**/api/insights/v1/rule/',
+        total: 200,
+        pageSize: 50,
+        dataType: 'recommendations',
+        paginationType: 'offset',
+      });
+
+      cy.intercept('GET', '/api/insights/v1/pathway/*', {
+        statusCode: 200,
+        body: pathways,
+      }).as('getPathways');
+
+      mountComponent();
+      cy.wait('@batchPage1');
+
+      cy.get('#overview-dashbar').within(() => {
+        cy.contains('3').should('exist');
+        cy.contains('5').should('exist');
+      });
+
+      cy.contains('[role="tab"]', 'Pathways').click();
+      cy.wait('@getPathways');
+
+      cy.get('#overview-dashbar').within(() => {
+        cy.contains('3').should('exist');
+        cy.contains('5').should('exist');
+      });
+
+      cy.contains('[role="tab"]', 'Recommendations').click();
+
+      cy.get('[aria-label="rules-table"]', { timeout: 5000 }).should('exist');
+      cy.get('#overview-dashbar').should('exist');
     });
   });
 });

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.cy.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.cy.js
@@ -444,3 +444,63 @@ describe('System rules table toolbar actions', () => {
       .should('exist');
   });
 });
+
+describe('Batch Requests for System Recommendations', () => {
+  beforeEach(() => {
+    cy.intercept('/api/insights/v1/account_setting/', {
+      statusCode: 200,
+      body: {},
+    });
+    cy.intercept('https://access.redhat.com/hydra/rest/search/kcs**', {
+      response: {
+        docs: fixturesKcs,
+      },
+    }).as('kcs');
+    cy.intercept(
+      `${INVENTORY_BASE_URL}/hosts/${SYSTEM_ID}/system_profile`,
+      systemProfile.data,
+    ).as('getSystemProfile');
+  });
+
+  it('handles multiple pages of system recommendations with batch pagination', () => {
+    cy.intercept(`/api/insights/v1/system/${SYSTEM_ID}/reports/`, {
+      statusCode: 200,
+      body: fixtures,
+    }).as('getReports');
+
+    mountComponent();
+    cy.wait('@getReports');
+    cy.get(TABLE).should('exist');
+  });
+
+  it('handles request errors gracefully', () => {
+    cy.intercept(`/api/insights/v1/system/${SYSTEM_ID}/reports/`, {
+      statusCode: 500,
+      body: { error: 'Internal Server Error' },
+    }).as('errorRequest');
+
+    mountComponent();
+    cy.wait('@errorRequest');
+  });
+
+  it('handles empty results', () => {
+    cy.intercept(`/api/insights/v1/system/${SYSTEM_ID}/reports/`, {
+      statusCode: 200,
+      body: [],
+    }).as('emptyResults');
+
+    mountComponent();
+    cy.wait('@emptyResults');
+    cy.get(TABLE).should('exist');
+  });
+
+  it('handles 403 forbidden errors', () => {
+    cy.intercept(`/api/insights/v1/system/${SYSTEM_ID}/reports/`, {
+      statusCode: 403,
+      body: { error: 'Forbidden' },
+    }).as('forbiddenRequest');
+
+    mountComponent();
+    cy.wait('@forbiddenRequest');
+  });
+});

--- a/src/SmartComponents/Topics/Details.cy.js
+++ b/src/SmartComponents/Topics/Details.cy.js
@@ -49,11 +49,11 @@ const mountComponent = (hasEdgeDevices, envContextOverrides = {}) => {
     },
   ).as('rules_table_call');
 
-  // Intercept for rules table initial call (specific filters)
   cy.intercept(
-    `${currentRequestBasePath}/rule/?topic=123&update_method=ostree%2Cdnfyum&impacting=true&rule_status=enabled&sort=-total_risk&limit=10&offset=0`,
+    `${currentRequestBasePath}/rule/?topic=123&update_method=ostree%2Cdnfyum&impacting=true&rule_status=enabled&sort=-total_risk&limit=50&offset=0`,
     {
       data: [],
+      meta: { count: 0 },
     },
   ).as('rules_table_initial_call');
 

--- a/src/Utilities/batchConfig.js
+++ b/src/Utilities/batchConfig.js
@@ -1,0 +1,156 @@
+/**
+ * Batch Request Configuration
+ *
+ * This file contains configuration constants for batch request functionality.
+ * These settings control how API requests are batched to improve performance
+ * when fetching large datasets.
+ */
+
+/**
+ * Default batch size - number of items to fetch per request
+ * Lower values = more requests but less data per request
+ * Higher values = fewer requests but more data per request
+ */
+export const DEFAULT_BATCH_SIZE = 50;
+
+/**
+ * Default concurrency - number of parallel requests to make
+ * Lower values = slower but less server load
+ * Higher values = faster but may trigger rate limits
+ */
+export const DEFAULT_CONCURRENCY = 2;
+
+/**
+ * Maximum allowed concurrency to prevent overwhelming the server
+ */
+export const MAX_CONCURRENCY = 5;
+
+/**
+ * Minimum threshold for batching
+ * If total items < this value, don't bother batching
+ */
+export const MIN_BATCH_THRESHOLD = 50;
+
+/**
+ * Timeout for each individual batch request (in milliseconds)
+ */
+export const TIMEOUT_PER_REQUEST = 30000; // 30 seconds
+
+/**
+ * Number of retry attempts for failed batch requests
+ */
+export const RETRY_ATTEMPTS = 2;
+
+/**
+ * Maximum total items to fetch with batching
+ * This prevents memory issues with extremely large datasets
+ */
+export const MAX_BATCH_TOTAL = 10000;
+
+/**
+ * Warning threshold - show warning if total exceeds this
+ */
+export const BATCH_WARNING_THRESHOLD = 5000;
+
+/**
+ * Per-endpoint configuration overrides
+ * Allows fine-tuning batch behavior for specific API endpoints
+ */
+export const ENDPOINT_BATCH_CONFIG = {
+  recs: {
+    batchSize: 50,
+    concurrency: 2,
+    paginationType: 'offset', // offset/limit style
+  },
+  systems: {
+    batchSize: 100,
+    concurrency: 3,
+    paginationType: 'offset',
+  },
+  pathways: {
+    batchSize: 50,
+    concurrency: 2,
+    paginationType: 'offset',
+  },
+  topics: {
+    batchSize: 50,
+    concurrency: 2,
+    paginationType: 'offset',
+  },
+  inventory: {
+    batchSize: 100,
+    concurrency: 3,
+    paginationType: 'page', // page/per_page style
+  },
+  hostack: {
+    batchSize: 100,
+    concurrency: 2,
+    paginationType: 'offset',
+  },
+};
+
+/**
+ * Get batch configuration for a specific endpoint
+ *
+ * @param {string} endpoint - The endpoint name (e.g., 'recs', 'systems')
+ * @returns {object} Configuration object with batchSize, concurrency, and paginationType
+ */
+export const getBatchConfig = (endpoint) => {
+  return (
+    ENDPOINT_BATCH_CONFIG[endpoint] || {
+      batchSize: DEFAULT_BATCH_SIZE,
+      concurrency: DEFAULT_CONCURRENCY,
+      paginationType: 'offset',
+    }
+  );
+};
+
+/**
+ * Merge custom batch options with defaults
+ *
+ * @param {object} options - Custom options to override defaults
+ * @param {string} endpoint - Optional endpoint name for endpoint-specific defaults
+ * @returns {object} Merged configuration
+ */
+export const mergeBatchOptions = (options = {}, endpoint = null) => {
+  const defaults = endpoint
+    ? getBatchConfig(endpoint)
+    : {
+        batchSize: DEFAULT_BATCH_SIZE,
+        concurrency: DEFAULT_CONCURRENCY,
+        paginationType: 'offset',
+      };
+
+  const filteredOptions = Object.entries(options).reduce(
+    (acc, [key, value]) => {
+      if (value !== undefined) {
+        acc[key] = value;
+      }
+      return acc;
+    },
+    {},
+  );
+
+  return {
+    ...defaults,
+    ...filteredOptions,
+    concurrency: Math.min(
+      filteredOptions.concurrency || defaults.concurrency,
+      MAX_CONCURRENCY,
+    ),
+  };
+};
+
+export default {
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_CONCURRENCY,
+  MAX_CONCURRENCY,
+  MIN_BATCH_THRESHOLD,
+  TIMEOUT_PER_REQUEST,
+  RETRY_ATTEMPTS,
+  MAX_BATCH_TOTAL,
+  BATCH_WARNING_THRESHOLD,
+  ENDPOINT_BATCH_CONFIG,
+  getBatchConfig,
+  mergeBatchOptions,
+};

--- a/src/Utilities/batchPaginationHelpers.js
+++ b/src/Utilities/batchPaginationHelpers.js
@@ -1,0 +1,261 @@
+export const PAGINATION_TYPES = {
+  OFFSET: 'offset',
+  PAGE: 'page',
+};
+
+/**
+ * Calculate the number of pages needed for batching
+ *
+ * @param {number} total - Total number of items
+ * @param {number} batchSize - Number of items per batch
+ * @returns {number} Number of pages needed
+ */
+export const calculateBatchPages = (total, batchSize) => {
+  if (!total || total <= 0) return 0;
+  if (!batchSize || batchSize <= 0) return 0;
+  return Math.ceil(total / batchSize);
+};
+
+/**
+ * Create pagination parameters for a specific batch/page
+ *
+ * @param {number} pageIndex - Zero-based page index (0, 1, 2, ...)
+ * @param {number} batchSize - Number of items per batch
+ * @param {object} baseParams - Base parameters to merge with pagination params
+ * @param {string} paginationType - Type of pagination ('offset' or 'page')
+ * @returns {object} Parameters object with pagination fields
+ */
+export const createBatchParams = (
+  pageIndex,
+  batchSize,
+  baseParams = {},
+  paginationType = PAGINATION_TYPES.OFFSET,
+) => {
+  const params = { ...baseParams };
+
+  if (paginationType === PAGINATION_TYPES.PAGE) {
+    params.page = pageIndex + 1;
+    params.per_page = batchSize;
+  } else {
+    params.offset = pageIndex * batchSize;
+    params.limit = batchSize;
+  }
+
+  return params;
+};
+
+/**
+ * Convert page-based parameters to offset-based
+ *
+ * @param {number} page - Page number (1-indexed)
+ * @param {number} perPage - Items per page
+ * @returns {object} Object with offset and limit
+ */
+export const pageToOffset = (page, perPage) => {
+  const pageNum = Math.max(1, page || 1);
+  const itemsPerPage = Math.max(1, perPage || 10);
+
+  return {
+    offset: (pageNum - 1) * itemsPerPage,
+    limit: itemsPerPage,
+  };
+};
+
+/**
+ * Convert offset-based parameters to page-based
+ *
+ * @param {number} offset - Offset value (0-indexed)
+ * @param {number} limit - Limit/items per page
+ * @returns {object} Object with page and per_page
+ */
+export const offsetToPage = (offset, limit) => {
+  const offsetVal = Math.max(0, offset || 0);
+  const limitVal = Math.max(1, limit || 10);
+
+  return {
+    page: Math.floor(offsetVal / limitVal) + 1,
+    per_page: limitVal,
+  };
+};
+
+/**
+ * Extract pagination metadata from API response
+ *
+ * @param {object} response - API response object
+ * @param {string} paginationType - Type of pagination used
+ * @returns {object} Normalized pagination metadata
+ */
+export const extractPaginationMeta = (response, paginationType) => {
+  const meta = response?.meta || {};
+
+  if (paginationType === PAGINATION_TYPES.PAGE) {
+    return {
+      total: meta.count || meta.total || 0,
+      page: meta.page || 1,
+      perPage: meta.per_page || 0,
+      offset: meta.page ? (meta.page - 1) * (meta.per_page || 0) : 0,
+      limit: meta.per_page || 0,
+    };
+  } else {
+    return {
+      total: meta.count || meta.total || 0,
+      offset: meta.offset || 0,
+      limit: meta.limit || 0,
+      page:
+        meta.offset && meta.limit
+          ? Math.floor(meta.offset / meta.limit) + 1
+          : 1,
+      perPage: meta.limit || 0,
+    };
+  }
+};
+
+/**
+ * Normalize response to a consistent format regardless of pagination type
+ *
+ * @param {object} response - API response
+ * @param {string} paginationType - Type of pagination used
+ * @returns {object} Normalized response with data and meta
+ */
+export const normalizeBatchResponse = (response, paginationType) => {
+  if (!response) {
+    return { data: [], meta: { count: 0, total: 0 } };
+  }
+
+  const data = response.data || [];
+  const paginationMeta = extractPaginationMeta(response, paginationType);
+
+  return {
+    data,
+    meta: {
+      // Use 'count' as the primary total field (Advisor API convention)
+      count: paginationMeta.total,
+      // Also include 'total' for compatibility
+      total: paginationMeta.total,
+      offset: paginationMeta.offset,
+      limit: paginationMeta.limit,
+      page: paginationMeta.page,
+      per_page: paginationMeta.perPage,
+      // Preserve any other meta fields from original response
+      ...response.meta,
+    },
+  };
+};
+
+/**
+ * Merge multiple batch responses into a single response
+ *
+ * @param {Array} responses - Array of API responses
+ * @param {boolean} preserveFirstMeta - If true, preserve meta from first response
+ * @returns {object} Merged response with combined data array
+ */
+export const mergeBatchResponses = (responses, preserveFirstMeta = true) => {
+  if (!responses || responses.length === 0) {
+    return { data: [], meta: { count: 0, total: 0 } };
+  }
+
+  // Merge all data arrays
+  const allData = responses.reduce((acc, response) => {
+    const data = response?.data || [];
+    return [...acc, ...data];
+  }, []);
+
+  // Use meta from first response, but update count/total to reflect merged data
+  const firstResponse = responses[0] || {};
+  const firstMeta = firstResponse.meta || {};
+
+  // Calculate actual total from first response
+  const originalTotal = firstMeta.count || firstMeta.total || 0;
+
+  return {
+    data: allData,
+    meta: {
+      ...firstMeta,
+      // Preserve the original total count
+      count: preserveFirstMeta ? originalTotal : allData.length,
+      total: preserveFirstMeta ? originalTotal : allData.length,
+      // Update offset and limit to reflect merged result
+      offset: 0,
+      limit: allData.length,
+    },
+  };
+};
+
+/**
+ * Validate batch parameters
+ *
+ * @param {object} params - Batch parameters to validate
+ * @returns {object} Validation result with isValid and errors
+ */
+export const validateBatchParams = (params) => {
+  const errors = [];
+
+  if (params.batchSize !== undefined) {
+    if (typeof params.batchSize !== 'number' || params.batchSize <= 0) {
+      errors.push('batchSize must be a positive number');
+    }
+  }
+
+  if (params.concurrency !== undefined) {
+    if (typeof params.concurrency !== 'number' || params.concurrency <= 0) {
+      errors.push('concurrency must be a positive number');
+    }
+  }
+
+  if (params.total !== undefined) {
+    if (typeof params.total !== 'number' || params.total < 0) {
+      errors.push('total must be a non-negative number');
+    }
+  }
+
+  if (params.paginationType !== undefined) {
+    const validTypes = Object.values(PAGINATION_TYPES);
+    if (!validTypes.includes(params.paginationType)) {
+      errors.push(`paginationType must be one of: ${validTypes.join(', ')}`);
+    }
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+};
+
+/**
+ * Calculate estimated time for batch completion
+ *
+ * @param {number} total - Total items to fetch
+ * @param {number} batchSize - Items per batch
+ * @param {number} concurrency - Number of parallel requests
+ * @param {number} avgRequestTime - Average request time in ms (default: 1000ms)
+ * @returns {number} Estimated time in milliseconds
+ */
+export const estimateBatchTime = (
+  total,
+  batchSize,
+  concurrency,
+  avgRequestTime = 1000,
+) => {
+  const pages = calculateBatchPages(total, batchSize);
+  if (pages === 0) return 0;
+
+  // First page is sequential
+  // Remaining pages are batched with concurrency
+  const remainingPages = Math.max(0, pages - 1);
+  const batchedRounds = Math.ceil(remainingPages / concurrency);
+
+  return avgRequestTime * (1 + batchedRounds);
+};
+
+export default {
+  PAGINATION_TYPES,
+  calculateBatchPages,
+  createBatchParams,
+  pageToOffset,
+  offsetToPage,
+  extractPaginationMeta,
+  normalizeBatchResponse,
+  mergeBatchResponses,
+  validateBatchParams,
+  estimateBatchTime,
+};

--- a/src/Utilities/batchPaginationHelpers.test.js
+++ b/src/Utilities/batchPaginationHelpers.test.js
@@ -1,0 +1,405 @@
+import {
+  PAGINATION_TYPES,
+  calculateBatchPages,
+  createBatchParams,
+  pageToOffset,
+  offsetToPage,
+  extractPaginationMeta,
+  normalizeBatchResponse,
+  mergeBatchResponses,
+  validateBatchParams,
+  estimateBatchTime,
+} from './batchPaginationHelpers';
+
+describe('batchPaginationHelpers', () => {
+  describe('calculateBatchPages', () => {
+    it('should calculate correct number of pages', () => {
+      expect(calculateBatchPages(100, 50)).toBe(2);
+      expect(calculateBatchPages(150, 50)).toBe(3);
+      expect(calculateBatchPages(50, 50)).toBe(1);
+      expect(calculateBatchPages(1, 50)).toBe(1);
+    });
+
+    it('should handle edge cases', () => {
+      expect(calculateBatchPages(0, 50)).toBe(0);
+      expect(calculateBatchPages(100, 0)).toBe(0);
+      expect(calculateBatchPages(null, 50)).toBe(0);
+      expect(calculateBatchPages(100, null)).toBe(0);
+      expect(calculateBatchPages(-10, 50)).toBe(0);
+    });
+
+    it('should handle partial pages', () => {
+      expect(calculateBatchPages(101, 50)).toBe(3);
+      expect(calculateBatchPages(99, 50)).toBe(2);
+    });
+  });
+
+  describe('createBatchParams', () => {
+    it('should create offset-based params correctly', () => {
+      const params = createBatchParams(0, 50, {}, PAGINATION_TYPES.OFFSET);
+      expect(params).toEqual({ offset: 0, limit: 50 });
+    });
+
+    it('should create page-based params correctly', () => {
+      const params = createBatchParams(0, 50, {}, PAGINATION_TYPES.PAGE);
+      expect(params).toEqual({ page: 1, per_page: 50 });
+    });
+
+    it('should handle subsequent pages for offset', () => {
+      expect(createBatchParams(1, 50, {}, PAGINATION_TYPES.OFFSET)).toEqual({
+        offset: 50,
+        limit: 50,
+      });
+      expect(createBatchParams(2, 50, {}, PAGINATION_TYPES.OFFSET)).toEqual({
+        offset: 100,
+        limit: 50,
+      });
+    });
+
+    it('should handle subsequent pages for page-based', () => {
+      expect(createBatchParams(1, 50, {}, PAGINATION_TYPES.PAGE)).toEqual({
+        page: 2,
+        per_page: 50,
+      });
+      expect(createBatchParams(2, 50, {}, PAGINATION_TYPES.PAGE)).toEqual({
+        page: 3,
+        per_page: 50,
+      });
+    });
+
+    it('should merge base params', () => {
+      const baseParams = { filter: 'active', sort: 'name' };
+      const params = createBatchParams(
+        0,
+        50,
+        baseParams,
+        PAGINATION_TYPES.OFFSET,
+      );
+      expect(params).toEqual({
+        filter: 'active',
+        sort: 'name',
+        offset: 0,
+        limit: 50,
+      });
+    });
+
+    it('should default to offset pagination', () => {
+      const params = createBatchParams(0, 50);
+      expect(params.offset).toBe(0);
+      expect(params.limit).toBe(50);
+      expect(params.page).toBeUndefined();
+    });
+  });
+
+  describe('pageToOffset', () => {
+    it('should convert page to offset correctly', () => {
+      expect(pageToOffset(1, 50)).toEqual({ offset: 0, limit: 50 });
+      expect(pageToOffset(2, 50)).toEqual({ offset: 50, limit: 50 });
+      expect(pageToOffset(3, 50)).toEqual({ offset: 100, limit: 50 });
+    });
+
+    it('should handle edge cases', () => {
+      expect(pageToOffset(0, 50)).toEqual({ offset: 0, limit: 50 });
+      expect(pageToOffset(-1, 50)).toEqual({ offset: 0, limit: 50 });
+      expect(pageToOffset(1, 0)).toEqual({ offset: 0, limit: 10 });
+      expect(pageToOffset(null, 50)).toEqual({ offset: 0, limit: 50 });
+    });
+  });
+
+  describe('offsetToPage', () => {
+    it('should convert offset to page correctly', () => {
+      expect(offsetToPage(0, 50)).toEqual({ page: 1, per_page: 50 });
+      expect(offsetToPage(50, 50)).toEqual({ page: 2, per_page: 50 });
+      expect(offsetToPage(100, 50)).toEqual({ page: 3, per_page: 50 });
+    });
+
+    it('should handle edge cases', () => {
+      expect(offsetToPage(-10, 50)).toEqual({ page: 1, per_page: 50 });
+      expect(offsetToPage(0, 0)).toEqual({ page: 1, per_page: 10 });
+      expect(offsetToPage(null, 50)).toEqual({ page: 1, per_page: 50 });
+    });
+
+    it('should handle partial pages', () => {
+      expect(offsetToPage(25, 50)).toEqual({ page: 1, per_page: 50 });
+      expect(offsetToPage(75, 50)).toEqual({ page: 2, per_page: 50 });
+    });
+  });
+
+  describe('extractPaginationMeta', () => {
+    it('should extract offset-based metadata', () => {
+      const response = {
+        meta: {
+          count: 200,
+          offset: 50,
+          limit: 50,
+        },
+      };
+
+      const meta = extractPaginationMeta(response, PAGINATION_TYPES.OFFSET);
+      expect(meta).toEqual({
+        total: 200,
+        offset: 50,
+        limit: 50,
+        page: 2,
+        perPage: 50,
+      });
+    });
+
+    it('should extract page-based metadata', () => {
+      const response = {
+        meta: {
+          count: 200,
+          page: 2,
+          per_page: 50,
+        },
+      };
+
+      const meta = extractPaginationMeta(response, PAGINATION_TYPES.PAGE);
+      expect(meta).toEqual({
+        total: 200,
+        page: 2,
+        perPage: 50,
+        offset: 50,
+        limit: 50,
+      });
+    });
+
+    it('should handle missing meta', () => {
+      const meta = extractPaginationMeta({}, PAGINATION_TYPES.OFFSET);
+      expect(meta.total).toBe(0);
+      expect(meta.offset).toBe(0);
+    });
+
+    it('should prefer count over total', () => {
+      const response = {
+        meta: {
+          count: 200,
+          total: 150, // Should use count
+          offset: 0,
+          limit: 50,
+        },
+      };
+
+      const meta = extractPaginationMeta(response, PAGINATION_TYPES.OFFSET);
+      expect(meta.total).toBe(200);
+    });
+  });
+
+  describe('normalizeBatchResponse', () => {
+    it('should normalize offset-based response', () => {
+      const response = {
+        data: [{ id: 1 }, { id: 2 }],
+        meta: {
+          count: 200,
+          offset: 0,
+          limit: 50,
+        },
+      };
+
+      const normalized = normalizeBatchResponse(
+        response,
+        PAGINATION_TYPES.OFFSET,
+      );
+      expect(normalized.data).toHaveLength(2);
+      expect(normalized.meta.count).toBe(200);
+      expect(normalized.meta.total).toBe(200);
+    });
+
+    it('should normalize page-based response', () => {
+      const response = {
+        data: [{ id: 1 }, { id: 2 }],
+        meta: {
+          count: 200,
+          page: 1,
+          per_page: 50,
+        },
+      };
+
+      const normalized = normalizeBatchResponse(
+        response,
+        PAGINATION_TYPES.PAGE,
+      );
+      expect(normalized.data).toHaveLength(2);
+      expect(normalized.meta.count).toBe(200);
+      expect(normalized.meta.page).toBe(1);
+    });
+
+    it('should handle null/undefined response', () => {
+      expect(normalizeBatchResponse(null, PAGINATION_TYPES.OFFSET)).toEqual({
+        data: [],
+        meta: { count: 0, total: 0 },
+      });
+    });
+
+    it('should preserve extra meta fields', () => {
+      const response = {
+        data: [],
+        meta: {
+          count: 100,
+          offset: 0,
+          limit: 50,
+          customField: 'value',
+          tags: ['tag1'],
+        },
+      };
+
+      const normalized = normalizeBatchResponse(
+        response,
+        PAGINATION_TYPES.OFFSET,
+      );
+      expect(normalized.meta.customField).toBe('value');
+      expect(normalized.meta.tags).toEqual(['tag1']);
+    });
+  });
+
+  describe('mergeBatchResponses', () => {
+    it('should merge multiple responses', () => {
+      const responses = [
+        { data: [{ id: 1 }, { id: 2 }], meta: { count: 5 } },
+        { data: [{ id: 3 }, { id: 4 }], meta: { count: 5 } },
+        { data: [{ id: 5 }], meta: { count: 5 } },
+      ];
+
+      const merged = mergeBatchResponses(responses);
+      expect(merged.data).toHaveLength(5);
+      expect(merged.data.map((d) => d.id)).toEqual([1, 2, 3, 4, 5]);
+      expect(merged.meta.count).toBe(5); // Preserved from first response
+    });
+
+    it('should handle empty responses array', () => {
+      const merged = mergeBatchResponses([]);
+      expect(merged).toEqual({
+        data: [],
+        meta: { count: 0, total: 0 },
+      });
+    });
+
+    it('should handle null/undefined', () => {
+      const merged = mergeBatchResponses(null);
+      expect(merged.data).toEqual([]);
+    });
+
+    it('should preserve first response meta when preserveFirstMeta=true', () => {
+      const responses = [
+        {
+          data: [{ id: 1 }],
+          meta: { count: 10, offset: 0, customField: 'test' },
+        },
+        { data: [{ id: 2 }], meta: { count: 10, offset: 1 } },
+      ];
+
+      const merged = mergeBatchResponses(responses, true);
+      expect(merged.meta.count).toBe(10);
+      expect(merged.meta.customField).toBe('test');
+      expect(merged.data).toHaveLength(2);
+    });
+
+    it('should use actual count when preserveFirstMeta=false', () => {
+      const responses = [
+        { data: [{ id: 1 }], meta: { count: 10 } },
+        { data: [{ id: 2 }], meta: { count: 10 } },
+      ];
+
+      const merged = mergeBatchResponses(responses, false);
+      expect(merged.meta.count).toBe(2); // Actual merged data length
+    });
+
+    it('should handle responses with missing data arrays', () => {
+      const responses = [
+        { data: [{ id: 1 }], meta: { count: 2 } },
+        { meta: { count: 2 } }, // No data array
+      ];
+
+      const merged = mergeBatchResponses(responses);
+      expect(merged.data).toHaveLength(1);
+    });
+  });
+
+  describe('validateBatchParams', () => {
+    it('should validate valid parameters', () => {
+      const result = validateBatchParams({
+        batchSize: 50,
+        concurrency: 2,
+        total: 100,
+        paginationType: 'offset',
+      });
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should reject invalid batchSize', () => {
+      const result = validateBatchParams({ batchSize: -1 });
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('batchSize must be a positive number');
+    });
+
+    it('should reject invalid concurrency', () => {
+      const result = validateBatchParams({ concurrency: 0 });
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('concurrency must be a positive number');
+    });
+
+    it('should reject invalid total', () => {
+      const result = validateBatchParams({ total: -5 });
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('total must be a non-negative number');
+    });
+
+    it('should reject invalid paginationType', () => {
+      const result = validateBatchParams({ paginationType: 'invalid' });
+      expect(result.isValid).toBe(false);
+      expect(result.errors[0]).toContain('paginationType must be one of');
+    });
+
+    it('should collect multiple errors', () => {
+      const result = validateBatchParams({
+        batchSize: -1,
+        concurrency: 0,
+        total: -5,
+      });
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toHaveLength(3);
+    });
+
+    it('should allow partial validation', () => {
+      const result = validateBatchParams({ batchSize: 50 });
+      expect(result.isValid).toBe(true);
+    });
+  });
+
+  describe('estimateBatchTime', () => {
+    it('should estimate time correctly', () => {
+      // 100 items, 50 per batch = 2 pages
+      // Page 1: 1000ms
+      // Page 2: 1000ms (1 concurrent batch)
+      // Total: 2000ms
+      expect(estimateBatchTime(100, 50, 2, 1000)).toBe(2000);
+    });
+
+    it('should account for concurrency', () => {
+      // 200 items, 50 per batch = 4 pages
+      // Page 1: 1000ms (initial)
+      // Pages 2-4: 3 remaining pages / 2 concurrency = 2 rounds
+      // Total: 1000 + (2 * 1000) = 3000ms
+      expect(estimateBatchTime(200, 50, 2, 1000)).toBe(3000);
+    });
+
+    it('should handle single page', () => {
+      expect(estimateBatchTime(50, 50, 2, 1000)).toBe(1000);
+    });
+
+    it('should handle zero total', () => {
+      expect(estimateBatchTime(0, 50, 2, 1000)).toBe(0);
+    });
+
+    it('should handle high concurrency', () => {
+      // 200 items, 50 per batch = 4 pages
+      // Page 1: 1000ms
+      // Pages 2-4: 3 remaining / 5 concurrency = 1 round
+      // Total: 2000ms
+      expect(estimateBatchTime(200, 50, 5, 1000)).toBe(2000);
+    });
+  });
+});

--- a/src/Utilities/createAdvisorBaseQuery.js
+++ b/src/Utilities/createAdvisorBaseQuery.js
@@ -16,6 +16,7 @@ export const createAdvisorBaseQuery = ({
       inventoryBasePath: argInventoryBasePath,
       data,
       params,
+      batchMetadata,
       ...remainingParams
     } = processedArgs;
 
@@ -40,6 +41,22 @@ export const createAdvisorBaseQuery = ({
     const finalSearchString = allParams.toString();
     const fullUrl = `${baseUrlToUse}${urlPath}${finalSearchString ? `?${finalSearchString}` : ''}`;
 
+    // Add batch-specific headers if this is a batch request
+    let headers = argHeaders;
+    if (batchMetadata) {
+      headers = { ...argHeaders };
+      headers['X-Batch-Request'] = 'true';
+      if (batchMetadata.index !== undefined) {
+        headers['X-Batch-Index'] = String(batchMetadata.index);
+      }
+      if (batchMetadata.total !== undefined) {
+        headers['X-Batch-Total'] = String(batchMetadata.total);
+      }
+      if (batchMetadata.batchSize !== undefined) {
+        headers['X-Batch-Size'] = String(batchMetadata.batchSize);
+      }
+    }
+
     try {
       const isGetLikeMethod = ['get', 'delete', 'head', 'options'].includes(
         argMethod.toLowerCase(),
@@ -49,7 +66,7 @@ export const createAdvisorBaseQuery = ({
         method: argMethod,
         data: data || (!isGetLikeMethod && argOptions) || undefined,
         params: params || (isGetLikeMethod && argOptions) || undefined,
-        headers: argHeaders,
+        headers,
         paramsSerializer: (params) =>
           Qs.stringify(params, { arrayFormat: 'repeat' }),
       });

--- a/src/Utilities/createBatchQueryEndpoint.js
+++ b/src/Utilities/createBatchQueryEndpoint.js
@@ -1,0 +1,299 @@
+import pAll from 'p-all';
+import {
+  calculateBatchPages,
+  createBatchParams,
+  mergeBatchResponses,
+  normalizeBatchResponse,
+  PAGINATION_TYPES,
+} from './batchPaginationHelpers';
+import { MIN_BATCH_THRESHOLD, mergeBatchOptions } from './batchConfig';
+
+/**
+ * Creates a batched query function for RTK Query endpoints
+ *
+ * This factory function generates a `queryFn` that can be used in RTK Query
+ * endpoints to enable batching capabilities. Since RTK Query uses a declarative
+ * approach, we can't use hooks directly in the query definition.
+ *
+ * @param {object} config - Configuration for the batched query
+ * @param {Function} config.baseQuery - The RTK Query baseQuery function
+ * @param {Function} config.buildUrl - Function that builds the URL for each request
+ * @param {string} config.endpoint - Endpoint name for endpoint-specific defaults
+ * @param {string} config.paginationType - 'offset' or 'page'
+ * @returns {Function} A queryFn compatible with RTK Query
+ *
+ * @example
+ * const getRecs = build.query({
+ *   queryFn: createBatchedQueryFn({
+ *     baseQuery,
+ *     buildUrl: (params) => ({ url: '/rule/', options: params }),
+ *     endpoint: 'recs',
+ *     paginationType: 'offset'
+ *   })
+ * });
+ */
+export const createBatchedQueryFn = (config) => {
+  const {
+    baseQuery,
+    buildUrl,
+    endpoint,
+    paginationType = PAGINATION_TYPES.OFFSET,
+  } = config;
+
+  return async (args, api, extraOptions) => {
+    const {
+      batch = false,
+      batchSize: customBatchSize,
+      concurrency: customConcurrency,
+      autoBatch = true,
+      ...queryParams
+    } = args || {};
+
+    if (!batch) {
+      const queryArgs = buildUrl(queryParams);
+      return await baseQuery(queryArgs, api, extraOptions);
+    }
+
+    const mergedOptions = mergeBatchOptions(
+      {
+        batchSize: customBatchSize,
+        concurrency: customConcurrency,
+        paginationType,
+      },
+      endpoint,
+    );
+
+    const { batchSize, concurrency } = mergedOptions;
+
+    try {
+      let estimatedTotalPages = 1;
+
+      const firstPageParams = createBatchParams(
+        0,
+        batchSize,
+        queryParams,
+        paginationType,
+      );
+      const firstPageArgs = {
+        ...buildUrl(firstPageParams),
+        batchMetadata: {
+          index: 0,
+          total: estimatedTotalPages,
+          batchSize,
+        },
+      };
+      const firstPageResult = await baseQuery(firstPageArgs, api, extraOptions);
+
+      if (firstPageResult.error) {
+        return firstPageResult;
+      }
+
+      // Extract response data (RTK Query wraps it in { data: ... })
+      const firstPageData = firstPageResult.data;
+      const normalizedFirst = normalizeBatchResponse(
+        firstPageData,
+        paginationType,
+      );
+
+      const total =
+        normalizedFirst.meta.count || normalizedFirst.meta.total || 0;
+
+      if (autoBatch && total <= MIN_BATCH_THRESHOLD) {
+        return { data: normalizedFirst };
+      }
+
+      if (total <= batchSize) {
+        return { data: normalizedFirst };
+      }
+
+      const totalPages = calculateBatchPages(total, batchSize);
+      const batchRequests = [];
+
+      for (let pageIdx = 1; pageIdx < totalPages; pageIdx++) {
+        batchRequests.push(async () => {
+          const params = createBatchParams(
+            pageIdx,
+            batchSize,
+            queryParams,
+            paginationType,
+          );
+          const requestArgs = {
+            ...buildUrl(params),
+            batchMetadata: {
+              index: pageIdx,
+              total: totalPages,
+              batchSize,
+            },
+          };
+          const result = await baseQuery(requestArgs, api, extraOptions);
+
+          if (result.error) {
+            throw new Error(
+              `Batch request failed: ${JSON.stringify(result.error)}`,
+            );
+          }
+
+          const responseData = result.data;
+          return normalizeBatchResponse(responseData, paginationType);
+        });
+      }
+
+      const batchResponses = await pAll(batchRequests, { concurrency });
+
+      const allResponses = [normalizedFirst, ...batchResponses];
+      const mergedResult = mergeBatchResponses(allResponses, true);
+
+      return { data: mergedResult };
+    } catch (error) {
+      return {
+        error: {
+          status: 'CUSTOM_ERROR',
+          data: error.message || 'Batch fetching failed',
+          error: error,
+        },
+      };
+    }
+  };
+};
+
+/**
+ * Helper to add batching capability to an existing RTK Query endpoint
+ *
+ * This is a higher-level utility that takes an existing endpoint definition
+ * and returns a new one with batching support.
+ *
+ * @param {Function} baseQuery - The RTK Query baseQuery
+ * @param {object} endpointDef - Original endpoint definition
+ * @param {object} batchConfig - Batch configuration
+ * @returns {object} Enhanced endpoint definition
+ *
+ * @example
+ * const getRecsBatched = addBatchingToEndpoint(
+ *   baseQuery,
+ *   { query: (options) => ({ url: '/rule/', ...options }) },
+ *   { endpoint: 'recs', paginationType: 'offset' }
+ * );
+ */
+export const addBatchingToEndpoint = (
+  baseQuery,
+  endpointDef,
+  batchConfig = {},
+) => {
+  const { endpoint, paginationType = PAGINATION_TYPES.OFFSET } = batchConfig;
+
+  // Extract the original query function
+  const originalQuery = endpointDef.query;
+
+  if (!originalQuery) {
+    throw new Error('Endpoint definition must have a query function');
+  }
+
+  // Create batched queryFn
+  const queryFn = createBatchedQueryFn({
+    baseQuery,
+    buildUrl: originalQuery,
+    endpoint,
+    paginationType,
+  });
+
+  // Return new endpoint definition with queryFn
+  return {
+    ...endpointDef,
+    queryFn,
+    // Remove the original query since we're using queryFn
+    query: undefined,
+  };
+};
+
+/**
+ * Create a standard batched fetch function (non-RTK Query)
+ *
+ * This is useful for imperative fetching outside of RTK Query hooks,
+ * similar to compliance-frontend's pattern.
+ *
+ * @param {Function} fetchFn - Function that performs the actual fetch
+ * @param {object} options - Batch options
+ * @returns {Function} Batched fetch function
+ *
+ * @example
+ * const fetchSystemsBatched = createBatchedFetch(
+ *   (params) => axios.get('/api/systems', { params }),
+ *   { endpoint: 'systems', paginationType: 'offset' }
+ * );
+ *
+ * const result = await fetchSystemsBatched({ filter: 'active' });
+ */
+export const createBatchedFetch = (fetchFn, options = {}) => {
+  const { endpoint, paginationType = PAGINATION_TYPES.OFFSET } = options;
+
+  return async (queryParams = {}, batchOptions = {}) => {
+    const {
+      batchSize: customBatchSize,
+      concurrency: customConcurrency,
+      autoBatch = true,
+    } = batchOptions;
+
+    // Merge batch options
+    const mergedOptions = mergeBatchOptions(
+      {
+        batchSize: customBatchSize,
+        concurrency: customConcurrency,
+        paginationType,
+      },
+      endpoint,
+    );
+
+    const { batchSize, concurrency } = mergedOptions;
+
+    // Fetch first page
+    const firstPageParams = createBatchParams(
+      0,
+      batchSize,
+      queryParams,
+      paginationType,
+    );
+    const firstPageResponse = await fetchFn(firstPageParams);
+    const normalizedFirst = normalizeBatchResponse(
+      firstPageResponse,
+      paginationType,
+    );
+    const total = normalizedFirst.meta.count || normalizedFirst.meta.total || 0;
+
+    // Check if batching is needed
+    const shouldBatch = autoBatch
+      ? total > MIN_BATCH_THRESHOLD
+      : total > batchSize;
+
+    if (!shouldBatch || total <= batchSize) {
+      return normalizedFirst;
+    }
+
+    // Create batch requests
+    const totalPages = calculateBatchPages(total, batchSize);
+    const batchRequests = [];
+
+    for (let pageIdx = 1; pageIdx < totalPages; pageIdx++) {
+      batchRequests.push(async () => {
+        const params = createBatchParams(
+          pageIdx,
+          batchSize,
+          queryParams,
+          paginationType,
+        );
+        const response = await fetchFn(params);
+        return normalizeBatchResponse(response, paginationType);
+      });
+    }
+
+    // Execute and merge
+    const batchResponses = await pAll(batchRequests, { concurrency });
+    const allResponses = [normalizedFirst, ...batchResponses];
+    return mergeBatchResponses(allResponses, true);
+  };
+};
+
+export default {
+  createBatchedQueryFn,
+  addBatchingToEndpoint,
+  createBatchedFetch,
+};

--- a/src/Utilities/createBatchQueryEndpoint.test.js
+++ b/src/Utilities/createBatchQueryEndpoint.test.js
@@ -1,0 +1,603 @@
+import {
+  createBatchedQueryFn,
+  addBatchingToEndpoint,
+  createBatchedFetch,
+} from './createBatchQueryEndpoint';
+import { PAGINATION_TYPES } from './batchPaginationHelpers';
+
+jest.mock('p-all', () => {
+  return jest.fn((tasks) => {
+    return Promise.all(tasks.map((task) => task()));
+  });
+});
+
+describe('createBatchQueryEndpoint', () => {
+  describe('createBatchedQueryFn', () => {
+    it('should return unbatched result when batch=false', async () => {
+      const mockBaseQuery = jest.fn().mockResolvedValue({
+        data: {
+          data: [{ id: 1 }, { id: 2 }],
+          meta: { count: 2 },
+        },
+      });
+
+      const buildUrl = (params) => ({ url: '/api/test', options: params });
+
+      const queryFn = createBatchedQueryFn({
+        baseQuery: mockBaseQuery,
+        buildUrl,
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      const result = await queryFn({ batch: false, filter: 'active' }, {}, {});
+
+      expect(mockBaseQuery).toHaveBeenCalledTimes(1);
+      expect(mockBaseQuery).toHaveBeenCalledWith(
+        { url: '/api/test', options: { filter: 'active' } },
+        {},
+        {},
+      );
+      expect(result.data).toBeDefined();
+    });
+
+    it('should perform batched fetch when batch=true', async () => {
+      const mockBaseQuery = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: {
+            data: [{ id: 1 }, { id: 2 }],
+            meta: { count: 5, offset: 0, limit: 2 },
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            data: [{ id: 3 }, { id: 4 }],
+            meta: { count: 5, offset: 2, limit: 2 },
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            data: [{ id: 5 }],
+            meta: { count: 5, offset: 4, limit: 2 },
+          },
+        });
+
+      const buildUrl = (params) => ({ url: '/api/test', options: params });
+
+      const queryFn = createBatchedQueryFn({
+        baseQuery: mockBaseQuery,
+        buildUrl,
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      const result = await queryFn(
+        {
+          batch: true,
+          batchSize: 2,
+          concurrency: 2,
+          autoBatch: false,
+        },
+        {},
+        {},
+      );
+
+      expect(mockBaseQuery).toHaveBeenCalledTimes(3);
+      expect(result.data.data).toHaveLength(5);
+      expect(result.data.meta.count).toBe(5);
+    });
+
+    it('should skip batching for small datasets', async () => {
+      const mockBaseQuery = jest.fn().mockResolvedValue({
+        data: {
+          data: [{ id: 1 }],
+          meta: { count: 1, offset: 0, limit: 50 },
+        },
+      });
+
+      const buildUrl = (params) => ({ url: '/api/test', options: params });
+
+      const queryFn = createBatchedQueryFn({
+        baseQuery: mockBaseQuery,
+        buildUrl,
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      const result = await queryFn(
+        {
+          batch: true,
+          batchSize: 50,
+        },
+        {},
+        {},
+      );
+
+      expect(mockBaseQuery).toHaveBeenCalledTimes(1);
+      expect(result.data.data).toHaveLength(1);
+    });
+
+    it('should handle errors from baseQuery', async () => {
+      const mockBaseQuery = jest.fn().mockResolvedValue({
+        error: {
+          status: 500,
+          data: 'Server error',
+        },
+      });
+
+      const buildUrl = (params) => ({ url: '/api/test', options: params });
+
+      const queryFn = createBatchedQueryFn({
+        baseQuery: mockBaseQuery,
+        buildUrl,
+        endpoint: 'test',
+      });
+
+      const result = await queryFn({ batch: true }, {}, {});
+
+      expect(result.error).toBeDefined();
+      expect(result.error.status).toBe(500);
+    });
+
+    it('should handle errors during batch processing', async () => {
+      const mockBaseQuery = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: {
+            data: [{ id: 1 }],
+            meta: { count: 5, offset: 0, limit: 2 },
+          },
+        })
+        .mockResolvedValueOnce({
+          error: {
+            status: 500,
+            data: 'Batch failed',
+          },
+        });
+
+      const buildUrl = (params) => ({ url: '/api/test', options: params });
+
+      const queryFn = createBatchedQueryFn({
+        baseQuery: mockBaseQuery,
+        buildUrl,
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      const result = await queryFn(
+        {
+          batch: true,
+          batchSize: 2,
+          autoBatch: false,
+        },
+        {},
+        {},
+      );
+
+      expect(result.error).toBeDefined();
+    });
+
+    it('should include batch metadata in requests', async () => {
+      const mockBaseQuery = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: {
+            data: [{ id: 1 }],
+            meta: { count: 3, offset: 0, limit: 1 },
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            data: [{ id: 2 }],
+            meta: { count: 3, offset: 1, limit: 1 },
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            data: [{ id: 3 }],
+            meta: { count: 3, offset: 2, limit: 1 },
+          },
+        });
+
+      const buildUrl = (params) => ({ url: '/api/test', options: params });
+
+      const queryFn = createBatchedQueryFn({
+        baseQuery: mockBaseQuery,
+        buildUrl,
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      await queryFn(
+        {
+          batch: true,
+          batchSize: 1,
+          autoBatch: false,
+        },
+        {},
+        {},
+      );
+
+      expect(mockBaseQuery).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          batchMetadata: expect.objectContaining({
+            index: 0,
+            batchSize: 1,
+          }),
+        }),
+        {},
+        {},
+      );
+
+      expect(mockBaseQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          batchMetadata: expect.objectContaining({
+            index: 1,
+            total: 3,
+            batchSize: 1,
+          }),
+        }),
+        {},
+        {},
+      );
+    });
+  });
+
+  describe('addBatchingToEndpoint', () => {
+    it('should convert query endpoint to queryFn endpoint', () => {
+      const mockBaseQuery = jest.fn();
+      const endpointDef = {
+        query: (options) => ({ url: '/api/test', ...options }),
+      };
+
+      const enhanced = addBatchingToEndpoint(mockBaseQuery, endpointDef, {
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      expect(enhanced.queryFn).toBeDefined();
+      expect(enhanced.query).toBeUndefined();
+    });
+
+    it('should throw error if endpoint has no query function', () => {
+      const mockBaseQuery = jest.fn();
+      const endpointDef = {};
+
+      expect(() => {
+        addBatchingToEndpoint(mockBaseQuery, endpointDef);
+      }).toThrow('Endpoint definition must have a query function');
+    });
+
+    it('should preserve other endpoint properties', () => {
+      const mockBaseQuery = jest.fn();
+      const endpointDef = {
+        query: (options) => ({ url: '/api/test', ...options }),
+        keepUnusedDataFor: 300,
+        providesTags: ['Test'],
+      };
+
+      const enhanced = addBatchingToEndpoint(mockBaseQuery, endpointDef, {
+        endpoint: 'test',
+      });
+
+      expect(enhanced.keepUnusedDataFor).toBe(300);
+      expect(enhanced.providesTags).toEqual(['Test']);
+    });
+  });
+
+  describe('createBatchedFetch', () => {
+    it('should create a batched fetch function', async () => {
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: [{ id: 1 }],
+          meta: { count: 3, offset: 0, limit: 1 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 2 }],
+          meta: { count: 3, offset: 1, limit: 1 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 3 }],
+          meta: { count: 3, offset: 2, limit: 1 },
+        });
+
+      const fetchBatched = createBatchedFetch(mockFetch, {
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      const result = await fetchBatched(
+        { filter: 'active' },
+        { batchSize: 1, autoBatch: false },
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(result.data).toHaveLength(3);
+      expect(result.meta.count).toBe(3);
+    });
+
+    it('should skip batching for small datasets', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        data: [{ id: 1 }],
+        meta: { count: 1, offset: 0, limit: 50 },
+      });
+
+      const fetchBatched = createBatchedFetch(mockFetch, {
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      const result = await fetchBatched({}, { batchSize: 50 });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result.data).toHaveLength(1);
+    });
+
+    it('should preserve query parameters across batches', async () => {
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: [{ id: 1 }],
+          meta: { count: 2, offset: 0, limit: 1 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 2 }],
+          meta: { count: 2, offset: 1, limit: 1 },
+        });
+
+      const fetchBatched = createBatchedFetch(mockFetch, {
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      const queryParams = { filter: 'active', sort: 'name' };
+      await fetchBatched(queryParams, { batchSize: 1, autoBatch: false });
+
+      expect(mockFetch).toHaveBeenNthCalledWith(1, {
+        ...queryParams,
+        offset: 0,
+        limit: 1,
+      });
+
+      expect(mockFetch).toHaveBeenNthCalledWith(2, {
+        ...queryParams,
+        offset: 1,
+        limit: 1,
+      });
+    });
+
+    it('should use page-based pagination when specified', async () => {
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: [{ id: 1 }],
+          meta: { count: 2, page: 1, per_page: 1 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 2 }],
+          meta: { count: 2, page: 2, per_page: 1 },
+        });
+
+      const fetchBatched = createBatchedFetch(mockFetch, {
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.PAGE,
+      });
+
+      await fetchBatched({}, { batchSize: 1, autoBatch: false });
+
+      expect(mockFetch).toHaveBeenNthCalledWith(1, {
+        page: 1,
+        per_page: 1,
+      });
+
+      expect(mockFetch).toHaveBeenNthCalledWith(2, {
+        page: 2,
+        per_page: 1,
+      });
+    });
+
+    it('should handle sequential batch operations', async () => {
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: [{ id: 1 }],
+          meta: { count: 2, offset: 0, limit: 1 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 2 }],
+          meta: { count: 2, offset: 1, limit: 1 },
+        });
+
+      const fetchBatched = createBatchedFetch(mockFetch, {
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      const result1 = await fetchBatched(
+        {},
+        { batchSize: 1, autoBatch: false },
+      );
+      expect(result1.data).toHaveLength(2);
+
+      mockFetch.mockClear();
+      mockFetch
+        .mockResolvedValueOnce({
+          data: [{ id: 3 }],
+          meta: { count: 2, offset: 0, limit: 1 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 4 }],
+          meta: { count: 2, offset: 1, limit: 1 },
+        });
+
+      const result2 = await fetchBatched(
+        {},
+        { batchSize: 1, autoBatch: false },
+      );
+      expect(result2.data).toHaveLength(2);
+      expect(result2.data[0].id).toBe(3);
+    });
+
+    it('should handle duplicate data across batches', async () => {
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: [
+            { id: 1, value: 'a' },
+            { id: 2, value: 'b' },
+          ],
+          meta: { count: 4, offset: 0, limit: 2 },
+        })
+        .mockResolvedValueOnce({
+          data: [
+            { id: 2, value: 'b' },
+            { id: 3, value: 'c' },
+          ],
+          meta: { count: 4, offset: 2, limit: 2 },
+        });
+
+      const fetchBatched = createBatchedFetch(mockFetch, {
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      const result = await fetchBatched({}, { batchSize: 2, autoBatch: false });
+
+      expect(result.data).toHaveLength(4);
+      const ids = result.data.map((item) => item.id);
+      expect(ids).toEqual([1, 2, 2, 3]);
+    });
+
+    it('should handle empty batch responses', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        data: [],
+        meta: { count: 0, offset: 0, limit: 50 },
+      });
+
+      const fetchBatched = createBatchedFetch(mockFetch, {
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      const result = await fetchBatched({});
+
+      expect(result.data).toHaveLength(0);
+      expect(result.meta.count).toBe(0);
+    });
+
+    it('should normalize missing meta in response', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        data: [{ id: 1 }],
+      });
+
+      const fetchBatched = createBatchedFetch(mockFetch, {
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      const result = await fetchBatched({});
+
+      expect(result.data).toHaveLength(1);
+      expect(result.meta).toBeDefined();
+    });
+  });
+
+  describe('error recovery patterns', () => {
+    it('should provide detailed error context', async () => {
+      const mockFetch = jest.fn().mockRejectedValue({
+        response: {
+          status: 503,
+          data: { message: 'Service unavailable' },
+        },
+      });
+
+      const fetchBatched = createBatchedFetch(mockFetch, {
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      await expect(fetchBatched({})).rejects.toBeTruthy();
+    });
+
+    it('should handle network timeouts', async () => {
+      const mockFetch = jest.fn().mockRejectedValue(new Error('ETIMEDOUT'));
+
+      const fetchBatched = createBatchedFetch(mockFetch, {
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      await expect(fetchBatched({})).rejects.toThrow('ETIMEDOUT');
+    });
+  });
+
+  describe('complex parameter scenarios', () => {
+    it('should handle array parameters correctly', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        data: [{ id: 1 }],
+        meta: { count: 1, offset: 0, limit: 50 },
+      });
+
+      const fetchBatched = createBatchedFetch(mockFetch, {
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      await fetchBatched({ tags: ['tag1', 'tag2'], groups: ['group1'] });
+
+      expect(mockFetch).toHaveBeenCalledWith({
+        tags: ['tag1', 'tag2'],
+        groups: ['group1'],
+        offset: 0,
+        limit: 50,
+      });
+    });
+
+    it('should merge filter parameters correctly', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        data: [{ id: 1 }],
+        meta: { count: 1, offset: 0, limit: 50 },
+      });
+
+      const fetchBatched = createBatchedFetch(mockFetch, {
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      await fetchBatched({
+        filter: { name: 'test', active: true },
+        sort: '-created',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith({
+        filter: { name: 'test', active: true },
+        sort: '-created',
+        offset: 0,
+        limit: 50,
+      });
+    });
+
+    it('should not override pagination params in queryParams', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        data: [{ id: 1 }],
+        meta: { count: 1, offset: 0, limit: 25 },
+      });
+
+      const fetchBatched = createBatchedFetch(mockFetch, {
+        endpoint: 'test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      });
+
+      await fetchBatched({ offset: 100, limit: 200 }, { batchSize: 25 });
+
+      expect(mockFetch).toHaveBeenCalledWith({
+        offset: 0,
+        limit: 25,
+      });
+    });
+  });
+});

--- a/src/Utilities/useAdvisorQuery.js
+++ b/src/Utilities/useAdvisorQuery.js
@@ -1,0 +1,319 @@
+import { useCallback } from 'react';
+import useFetchBatched from './useFetchBatched';
+import { createBatchedFetch } from './createBatchQueryEndpoint';
+import { PAGINATION_TYPES } from './batchPaginationHelpers';
+import instance from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import Qs from 'qs';
+
+/**
+ * @typedef {object} UseAdvisorQueryReturn
+ * @property {object} data - Query data
+ * @property {boolean} isLoading - Loading state
+ * @property {Error|null} error - Error object
+ * @property {Function} refetch - Refetch function
+ * @property {Function} fetchBatched - Manually trigger batched fetch
+ * @property {Function} fetchAllIds - Fetch all IDs across all pages
+ * @property {Function} exporter - Export all data
+ * @property {object} progress - Progress tracking
+ */
+
+/**
+ * Unified query hook for Advisor API with batching support
+ *
+ * This hook provides a consistent interface for querying Advisor APIs
+ * with optional batching, similar to compliance-frontend's useComplianceQuery.
+ * It wraps RTK Query functionality and adds batching capabilities.
+ *
+ * @param {string} endpoint - Endpoint name (e.g., 'recs', 'systems')
+ * @param {object} config - Query configuration
+ * @param {object} config.queryParams - Query parameters
+ * @param {string} config.baseUrl - Base URL for the API
+ * @param {string} config.url - Endpoint URL
+ * @param {boolean} config.batch - Enable batching
+ * @param {number} config.batchSize - Items per batch
+ * @param {number} config.concurrency - Parallel requests
+ * @param {string} config.paginationType - 'offset' or 'page'
+ * @param {boolean} config.skip - Skip the query
+ * @param {Function} config.onProgress - Progress callback
+ * @returns {UseAdvisorQueryReturn} Query state and utilities
+ *
+ * @example
+ * const {
+ *   data,
+ *   isLoading,
+ *   fetchAllIds,
+ *   exporter
+ * } = useAdvisorQuery('recs', {
+ *   baseUrl: BASE_URL,
+ *   url: '/rule/',
+ *   queryParams: { filter: 'active' },
+ *   batch: true,
+ *   batchSize: 50
+ * });
+ */
+const useAdvisorQuery = (endpoint, config = {}) => {
+  const {
+    queryParams = {},
+    baseUrl = '',
+    url = '',
+    batch = false,
+    batchSize,
+    concurrency,
+    paginationType = PAGINATION_TYPES.OFFSET,
+    onProgress,
+    method = 'get',
+  } = config;
+
+  // Use the batching hook
+  const {
+    isLoading,
+    data,
+    error,
+    progress,
+    fetchBatched: fetchBatchedHook,
+    reset,
+  } = useFetchBatched({ endpoint });
+
+  /**
+   * Create an axios fetch function for this endpoint
+   */
+  const createFetchFunction = useCallback(
+    (params = {}) => {
+      const fullUrl = `${baseUrl}${url}`;
+
+      return instance({
+        url: fullUrl,
+        method,
+        params,
+        paramsSerializer: (params) =>
+          Qs.stringify(params, { arrayFormat: 'repeat' }),
+      }).then((response) => response.data);
+    },
+    [baseUrl, url, method],
+  );
+
+  /**
+   * Fetch data with batching
+   */
+  const fetchBatched = useCallback(
+    async (customParams = {}) => {
+      // Extract batch-specific params from customParams
+      const {
+        batchSize: customBatchSize,
+        concurrency: customConcurrency,
+        autoBatch: customAutoBatch,
+        ...apiParams
+      } = customParams;
+
+      const mergedParams = { ...queryParams, ...apiParams };
+
+      return await fetchBatchedHook({
+        fetchFunction: createFetchFunction,
+        queryParams: mergedParams,
+        paginationType,
+        batchSize: customBatchSize !== undefined ? customBatchSize : batchSize,
+        concurrency:
+          customConcurrency !== undefined ? customConcurrency : concurrency,
+        onProgress,
+        autoBatch: customAutoBatch !== undefined ? customAutoBatch : batch,
+      });
+    },
+    [
+      fetchBatchedHook,
+      createFetchFunction,
+      queryParams,
+      paginationType,
+      batchSize,
+      concurrency,
+      onProgress,
+      batch,
+    ],
+  );
+
+  /**
+   * Fetch all IDs across all pages
+   * Useful for bulk operations and selections
+   */
+  const fetchAllIds = useCallback(
+    async (idField = 'id') => {
+      const result = await fetchBatched();
+
+      if (!result || !result.data) {
+        return [];
+      }
+
+      return result.data.map((item) => item[idField]).filter(Boolean);
+    },
+    [fetchBatched],
+  );
+
+  /**
+   * Export all data with batching
+   * Fetches complete dataset for export purposes
+   */
+  const exporter = useCallback(
+    async (customParams = {}, options = {}) => {
+      const {
+        transform = (data) => data,
+        idField = 'id',
+        includeIds = false,
+      } = options;
+
+      const result = await fetchBatched(customParams);
+
+      if (!result || !result.data) {
+        return includeIds ? { data: [], ids: [] } : [];
+      }
+
+      const transformedData = transform(result.data);
+
+      if (includeIds) {
+        const ids = result.data.map((item) => item[idField]).filter(Boolean);
+        return {
+          data: transformedData,
+          ids,
+          total: result.meta?.count || result.data.length,
+        };
+      }
+
+      return transformedData;
+    },
+    [fetchBatched],
+  );
+
+  /**
+   * Refetch the data
+   */
+  const refetch = useCallback(async () => {
+    reset();
+    return await fetchBatched();
+  }, [reset, fetchBatched]);
+
+  return {
+    data,
+    isLoading,
+    error,
+    progress,
+    refetch,
+    fetchBatched,
+    fetchAllIds,
+    exporter,
+    reset,
+  };
+};
+
+/**
+ * Hook for creating a batched fetch function bound to a specific endpoint
+ *
+ * This is useful when you need an imperative fetch function that you can
+ * call manually, rather than automatic fetching.
+ *
+ * @param {string} endpoint - Endpoint name
+ * @param {object} config - Configuration
+ * @returns {object} Fetch utilities
+ *
+ * @example
+ * const { fetchBatched, isLoading } = useAdvisorBatchFetch('systems', {
+ *   baseUrl: BASE_URL,
+ *   url: '/system/',
+ *   paginationType: 'offset'
+ * });
+ *
+ * const systems = await fetchBatched({ filter: 'active' });
+ */
+export const useAdvisorBatchFetch = (endpoint, config = {}) => {
+  const {
+    baseUrl = '',
+    url = '',
+    paginationType = PAGINATION_TYPES.OFFSET,
+    method = 'get',
+  } = config;
+
+  const {
+    isLoading,
+    error,
+    progress,
+    fetchBatched: fetchBatchedHook,
+  } = useFetchBatched({ endpoint });
+
+  const createFetchFunction = useCallback(
+    (params = {}) => {
+      const fullUrl = `${baseUrl}${url}`;
+
+      return instance({
+        url: fullUrl,
+        method,
+        params,
+        paramsSerializer: (params) =>
+          Qs.stringify(params, { arrayFormat: 'repeat' }),
+      }).then((response) => response.data);
+    },
+    [baseUrl, url, method],
+  );
+
+  const fetchBatched = useCallback(
+    async (queryParams = {}, batchOptions = {}) => {
+      return await fetchBatchedHook({
+        fetchFunction: createFetchFunction,
+        queryParams,
+        paginationType,
+        ...batchOptions,
+      });
+    },
+    [fetchBatchedHook, createFetchFunction, paginationType],
+  );
+
+  return {
+    fetchBatched,
+    isLoading,
+    error,
+    progress,
+  };
+};
+
+/**
+ * Create a standalone batched fetch function (non-hook)
+ *
+ * This is useful for use outside of React components, such as in
+ * Redux thunks or utility functions.
+ *
+ * @param {string} endpoint - Endpoint name
+ * @param {object} config - Configuration
+ * @returns {Function} Batched fetch function
+ *
+ * @example
+ * const fetchSystemsBatched = createAdvisorBatchFetch('systems', {
+ *   baseUrl: BASE_URL,
+ *   url: '/system/',
+ *   paginationType: 'offset'
+ * });
+ *
+ * const systems = await fetchSystemsBatched({ filter: 'active' });
+ */
+export const createAdvisorBatchFetch = (endpoint, config = {}) => {
+  const {
+    baseUrl = '',
+    url = '',
+    paginationType = PAGINATION_TYPES.OFFSET,
+    method = 'get',
+  } = config;
+
+  const fetchFn = (params = {}) => {
+    const fullUrl = `${baseUrl}${url}`;
+
+    return instance({
+      url: fullUrl,
+      method,
+      params,
+      paramsSerializer: (params) =>
+        Qs.stringify(params, { arrayFormat: 'repeat' }),
+    }).then((response) => response.data);
+  };
+
+  return createBatchedFetch(fetchFn, {
+    endpoint,
+    paginationType,
+  });
+};
+
+export default useAdvisorQuery;

--- a/src/Utilities/useAdvisorQuery.test.js
+++ b/src/Utilities/useAdvisorQuery.test.js
@@ -1,0 +1,788 @@
+import { renderHook, act } from '@testing-library/react';
+import useAdvisorQuery, {
+  useAdvisorBatchFetch,
+  createAdvisorBatchFetch,
+} from './useAdvisorQuery';
+import { PAGINATION_TYPES } from './batchPaginationHelpers';
+import instance from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+
+jest.mock('@redhat-cloud-services/frontend-components-utilities/interceptors');
+
+jest.mock('p-all', () => {
+  return jest.fn((tasks) => {
+    return Promise.all(tasks.map((task) => task()));
+  });
+});
+
+describe('useAdvisorQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('basic functionality', () => {
+    it('should initialize with default state', () => {
+      const { result } = renderHook(() =>
+        useAdvisorQuery('test', {
+          baseUrl: '/api',
+          url: '/test',
+          skip: true,
+        }),
+      );
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBe(null);
+      expect(result.current.error).toBe(null);
+      expect(typeof result.current.fetchBatched).toBe('function');
+      expect(typeof result.current.fetchAllIds).toBe('function');
+      expect(typeof result.current.exporter).toBe('function');
+    });
+  });
+
+  describe('fetchBatched', () => {
+    it('should fetch data with batching', async () => {
+      instance
+        .mockResolvedValueOnce({
+          data: {
+            data: [{ id: 1 }, { id: 2 }],
+            meta: { count: 5, offset: 0, limit: 2 },
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            data: [{ id: 3 }, { id: 4 }],
+            meta: { count: 5, offset: 2, limit: 2 },
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            data: [{ id: 5 }],
+            meta: { count: 5, offset: 4, limit: 2 },
+          },
+        });
+
+      const { result } = renderHook(() =>
+        useAdvisorQuery('test', {
+          baseUrl: '/api',
+          url: '/test',
+          skip: true,
+          paginationType: PAGINATION_TYPES.OFFSET,
+        }),
+      );
+
+      let response;
+      await act(async () => {
+        response = await result.current.fetchBatched({
+          batchSize: 2,
+          autoBatch: false,
+        });
+      });
+
+      expect(instance).toHaveBeenCalledTimes(3);
+      expect(response.data).toHaveLength(5);
+      expect(response.meta.count).toBe(5);
+    });
+
+    it('should merge query params', async () => {
+      instance.mockResolvedValue({
+        data: {
+          data: [{ id: 1 }],
+          meta: { count: 1, offset: 0, limit: 50 },
+        },
+      });
+
+      const { result } = renderHook(() =>
+        useAdvisorQuery('test', {
+          baseUrl: '/api',
+          url: '/test',
+          queryParams: { filter: 'active' },
+          skip: true,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.fetchBatched({ sort: 'name' });
+      });
+
+      expect(instance).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            filter: 'active',
+            sort: 'name',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('fetchAllIds', () => {
+    it('should fetch and extract all IDs', async () => {
+      instance.mockResolvedValueOnce({
+        data: {
+          data: [{ id: 1 }, { id: 2 }],
+          meta: { count: 2, offset: 0, limit: 50 },
+        },
+      });
+
+      const { result } = renderHook(() =>
+        useAdvisorQuery('test', {
+          baseUrl: '/api',
+          url: '/test',
+          skip: true,
+        }),
+      );
+
+      let ids;
+      await act(async () => {
+        ids = await result.current.fetchAllIds();
+      });
+
+      expect(ids).toEqual([1, 2]);
+    });
+
+    it('should use custom id field', async () => {
+      instance.mockResolvedValueOnce({
+        data: {
+          data: [{ uuid: 'a1' }, { uuid: 'a2' }],
+          meta: { count: 2, offset: 0, limit: 50 },
+        },
+      });
+
+      const { result } = renderHook(() =>
+        useAdvisorQuery('test', {
+          baseUrl: '/api',
+          url: '/test',
+          skip: true,
+        }),
+      );
+
+      let ids;
+      await act(async () => {
+        ids = await result.current.fetchAllIds('uuid');
+      });
+
+      expect(ids).toEqual(['a1', 'a2']);
+    });
+
+    it('should filter out undefined values', async () => {
+      instance.mockResolvedValueOnce({
+        data: {
+          data: [{ id: 1 }, {}, { id: 3 }],
+          meta: { count: 3, offset: 0, limit: 50 },
+        },
+      });
+
+      const { result } = renderHook(() =>
+        useAdvisorQuery('test', {
+          baseUrl: '/api',
+          url: '/test',
+          skip: true,
+        }),
+      );
+
+      let ids;
+      await act(async () => {
+        ids = await result.current.fetchAllIds();
+      });
+
+      expect(ids).toEqual([1, 3]);
+    });
+  });
+
+  describe('exporter', () => {
+    it('should export all data', async () => {
+      instance.mockResolvedValueOnce({
+        data: {
+          data: [
+            { id: 1, name: 'Test 1' },
+            { id: 2, name: 'Test 2' },
+          ],
+          meta: { count: 2, offset: 0, limit: 50 },
+        },
+      });
+
+      const { result } = renderHook(() =>
+        useAdvisorQuery('test', {
+          baseUrl: '/api',
+          url: '/test',
+          skip: true,
+        }),
+      );
+
+      let exported;
+      await act(async () => {
+        exported = await result.current.exporter();
+      });
+
+      expect(exported).toHaveLength(2);
+      expect(exported[0].name).toBe('Test 1');
+    });
+
+    it('should transform data if transform function provided', async () => {
+      instance.mockResolvedValueOnce({
+        data: {
+          data: [{ id: 1, name: 'Test 1' }],
+          meta: { count: 1, offset: 0, limit: 50 },
+        },
+      });
+
+      const { result } = renderHook(() =>
+        useAdvisorQuery('test', {
+          baseUrl: '/api',
+          url: '/test',
+          skip: true,
+        }),
+      );
+
+      let exported;
+      await act(async () => {
+        exported = await result.current.exporter(
+          {},
+          {
+            transform: (data) => data.map((item) => item.name),
+          },
+        );
+      });
+
+      expect(exported).toEqual(['Test 1']);
+    });
+
+    it('should include IDs when requested', async () => {
+      instance.mockResolvedValueOnce({
+        data: {
+          data: [{ id: 1 }, { id: 2 }],
+          meta: { count: 2, offset: 0, limit: 50 },
+        },
+      });
+
+      const { result } = renderHook(() =>
+        useAdvisorQuery('test', {
+          baseUrl: '/api',
+          url: '/test',
+          skip: true,
+        }),
+      );
+
+      let exported;
+      await act(async () => {
+        exported = await result.current.exporter({}, { includeIds: true });
+      });
+
+      expect(exported.data).toHaveLength(2);
+      expect(exported.ids).toEqual([1, 2]);
+      expect(exported.total).toBe(2);
+    });
+  });
+
+  describe('refetch', () => {
+    it('should refetch data', async () => {
+      instance.mockResolvedValue({
+        data: {
+          data: [{ id: 1 }],
+          meta: { count: 1, offset: 0, limit: 50 },
+        },
+      });
+
+      const { result } = renderHook(() =>
+        useAdvisorQuery('test', {
+          baseUrl: '/api',
+          url: '/test',
+          skip: true,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.fetchBatched();
+      });
+
+      expect(instance).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(instance).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe('useAdvisorBatchFetch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create a batched fetch function', async () => {
+    instance
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ id: 1 }],
+          meta: { count: 2, offset: 0, limit: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ id: 2 }],
+          meta: { count: 2, offset: 1, limit: 1 },
+        },
+      });
+
+    const { result } = renderHook(() =>
+      useAdvisorBatchFetch('test', {
+        baseUrl: '/api',
+        url: '/test',
+        paginationType: PAGINATION_TYPES.OFFSET,
+      }),
+    );
+
+    let response;
+    await act(async () => {
+      response = await result.current.fetchBatched(
+        {},
+        { batchSize: 1, autoBatch: false },
+      );
+    });
+
+    expect(instance).toHaveBeenCalledTimes(2);
+    expect(response.data).toHaveLength(2);
+  });
+
+  it('should expose loading and error states', () => {
+    const { result } = renderHook(() =>
+      useAdvisorBatchFetch('test', {
+        baseUrl: '/api',
+        url: '/test',
+      }),
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(null);
+    expect(result.current.progress).toBeDefined();
+  });
+});
+
+describe('createAdvisorBatchFetch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create a standalone batched fetch function', async () => {
+    instance
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ id: 1 }],
+          meta: { count: 2, offset: 0, limit: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ id: 2 }],
+          meta: { count: 2, offset: 1, limit: 1 },
+        },
+      });
+
+    const fetchBatched = createAdvisorBatchFetch('test', {
+      baseUrl: '/api',
+      url: '/test',
+      paginationType: PAGINATION_TYPES.OFFSET,
+    });
+
+    const result = await fetchBatched({}, { batchSize: 1, autoBatch: false });
+
+    expect(instance).toHaveBeenCalledTimes(2);
+    expect(result.data).toHaveLength(2);
+    expect(result.meta.count).toBe(2);
+  });
+
+  it('should work outside of React components', async () => {
+    instance.mockResolvedValue({
+      data: {
+        data: [{ id: 1 }],
+        meta: { count: 1, offset: 0, limit: 50 },
+      },
+    });
+
+    const fetchBatched = createAdvisorBatchFetch('test', {
+      baseUrl: '/api',
+      url: '/test',
+    });
+
+    const result = await fetchBatched({ filter: 'active' });
+
+    expect(result.data).toHaveLength(1);
+  });
+});
+
+describe('useAdvisorQuery - error scenarios', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should handle network errors gracefully', async () => {
+    instance.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() =>
+      useAdvisorQuery('test', {
+        baseUrl: '/api',
+        url: '/test',
+        skip: true,
+      }),
+    );
+
+    await act(async () => {
+      await expect(result.current.fetchBatched()).rejects.toThrow(
+        'Network error',
+      );
+    });
+
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it('should handle 404 errors', async () => {
+    instance.mockRejectedValue({
+      response: { status: 404, data: { message: 'Not found' } },
+    });
+
+    const { result } = renderHook(() =>
+      useAdvisorQuery('test', {
+        baseUrl: '/api',
+        url: '/test',
+        skip: true,
+      }),
+    );
+
+    await act(async () => {
+      await expect(result.current.fetchBatched()).rejects.toBeTruthy();
+    });
+  });
+
+  it('should handle 403 errors', async () => {
+    instance.mockRejectedValue({
+      response: { status: 403, data: { message: 'Forbidden' } },
+    });
+
+    const { result } = renderHook(() =>
+      useAdvisorQuery('test', {
+        baseUrl: '/api',
+        url: '/test',
+        skip: true,
+      }),
+    );
+
+    await act(async () => {
+      await expect(result.current.fetchBatched()).rejects.toBeTruthy();
+    });
+  });
+
+  it('should recover after error with refetch', async () => {
+    instance
+      .mockRejectedValueOnce(new Error('Temporary error'))
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ id: 1 }],
+          meta: { count: 1, offset: 0, limit: 50 },
+        },
+      });
+
+    const { result } = renderHook(() =>
+      useAdvisorQuery('test', {
+        baseUrl: '/api',
+        url: '/test',
+        skip: true,
+      }),
+    );
+
+    await act(async () => {
+      await expect(result.current.fetchBatched()).rejects.toThrow(
+        'Temporary error',
+      );
+    });
+
+    expect(result.current.error).toBeTruthy();
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.data.data).toHaveLength(1);
+    expect(result.current.error).toBe(null);
+  });
+});
+
+describe('useAdvisorQuery - complex scenarios', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should handle very large batch sizes', async () => {
+    const largeDataset = Array(1000)
+      .fill(null)
+      .map((_, i) => ({ id: i }));
+
+    instance
+      .mockResolvedValueOnce({
+        data: {
+          data: largeDataset.slice(0, 500),
+          meta: { count: 1000, offset: 0, limit: 500 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: largeDataset.slice(500, 1000),
+          meta: { count: 1000, offset: 500, limit: 500 },
+        },
+      });
+
+    const { result } = renderHook(() =>
+      useAdvisorQuery('test', {
+        baseUrl: '/api',
+        url: '/test',
+        skip: true,
+        paginationType: PAGINATION_TYPES.OFFSET,
+      }),
+    );
+
+    let response;
+    await act(async () => {
+      response = await result.current.fetchBatched({
+        batchSize: 500,
+        autoBatch: false,
+      });
+    });
+
+    expect(response.data).toHaveLength(1000);
+  });
+
+  it('should handle custom batch parameters correctly', async () => {
+    instance.mockResolvedValue({
+      data: {
+        data: [{ id: 1 }],
+        meta: { count: 1, offset: 0, limit: 25 },
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useAdvisorQuery('test', {
+        baseUrl: '/api',
+        url: '/test',
+        skip: true,
+        batchSize: 50,
+        concurrency: 3,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.fetchBatched({
+        batchSize: 25,
+        concurrency: 1,
+      });
+    });
+
+    expect(instance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          limit: 25,
+        }),
+      }),
+    );
+  });
+
+  it('should handle progress callbacks', async () => {
+    instance
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ id: 1 }],
+          meta: { count: 3, offset: 0, limit: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ id: 2 }],
+          meta: { count: 3, offset: 1, limit: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ id: 3 }],
+          meta: { count: 3, offset: 2, limit: 1 },
+        },
+      });
+
+    const onProgress = jest.fn();
+
+    const { result } = renderHook(() =>
+      useAdvisorQuery('test', {
+        baseUrl: '/api',
+        url: '/test',
+        skip: true,
+        paginationType: PAGINATION_TYPES.OFFSET,
+        onProgress,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.fetchBatched({
+        batchSize: 1,
+        autoBatch: false,
+      });
+    });
+
+    expect(onProgress).toHaveBeenCalled();
+  });
+
+  it('should handle page-based pagination', async () => {
+    instance
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ id: 1 }],
+          meta: { count: 2, page: 1, per_page: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ id: 2 }],
+          meta: { count: 2, page: 2, per_page: 1 },
+        },
+      });
+
+    const { result } = renderHook(() =>
+      useAdvisorQuery('test', {
+        baseUrl: '/api',
+        url: '/test',
+        skip: true,
+        paginationType: PAGINATION_TYPES.PAGE,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.fetchBatched({
+        batchSize: 1,
+        autoBatch: false,
+      });
+    });
+
+    expect(instance).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        params: expect.objectContaining({ page: 1, per_page: 1 }),
+      }),
+    );
+
+    expect(instance).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        params: expect.objectContaining({ page: 2, per_page: 1 }),
+      }),
+    );
+  });
+
+  it('should handle exporter with complex transformations', async () => {
+    instance.mockResolvedValue({
+      data: {
+        data: [
+          { id: 1, name: 'Test 1', status: 'active' },
+          { id: 2, name: 'Test 2', status: 'inactive' },
+        ],
+        meta: { count: 2, offset: 0, limit: 50 },
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useAdvisorQuery('test', {
+        baseUrl: '/api',
+        url: '/test',
+        skip: true,
+      }),
+    );
+
+    let exported;
+    await act(async () => {
+      exported = await result.current.exporter(
+        { filter: 'all' },
+        {
+          transform: (data) =>
+            data
+              .filter((item) => item.status === 'active')
+              .map((item) => ({ id: item.id, label: item.name })),
+        },
+      );
+    });
+
+    expect(exported).toHaveLength(1);
+    expect(exported[0]).toEqual({ id: 1, label: 'Test 1' });
+  });
+
+  it('should handle empty exporter results', async () => {
+    instance.mockResolvedValue({
+      data: {
+        data: [],
+        meta: { count: 0, offset: 0, limit: 50 },
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useAdvisorQuery('test', {
+        baseUrl: '/api',
+        url: '/test',
+        skip: true,
+      }),
+    );
+
+    let exported;
+    await act(async () => {
+      exported = await result.current.exporter();
+    });
+
+    expect(exported).toHaveLength(0);
+  });
+
+  it('should handle fetchAllIds with no results', async () => {
+    instance.mockResolvedValue({
+      data: {
+        data: [],
+        meta: { count: 0, offset: 0, limit: 50 },
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useAdvisorQuery('test', {
+        baseUrl: '/api',
+        url: '/test',
+        skip: true,
+      }),
+    );
+
+    let ids;
+    await act(async () => {
+      ids = await result.current.fetchAllIds();
+    });
+
+    expect(ids).toEqual([]);
+  });
+
+  it('should handle POST method for batch requests', async () => {
+    instance.mockResolvedValue({
+      data: {
+        data: [{ id: 1 }],
+        meta: { count: 1, offset: 0, limit: 50 },
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useAdvisorQuery('test', {
+        baseUrl: '/api',
+        url: '/test',
+        skip: true,
+        method: 'post',
+      }),
+    );
+
+    await act(async () => {
+      await result.current.fetchBatched();
+    });
+
+    expect(instance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'post',
+      }),
+    );
+  });
+});

--- a/src/Utilities/useFetchBatched.js
+++ b/src/Utilities/useFetchBatched.js
@@ -1,0 +1,328 @@
+import { useCallback, useState, useRef, useEffect } from 'react';
+import pAll from 'p-all';
+import {
+  calculateBatchPages,
+  createBatchParams,
+  mergeBatchResponses,
+  normalizeBatchResponse,
+  validateBatchParams,
+  PAGINATION_TYPES,
+} from './batchPaginationHelpers';
+import {
+  MIN_BATCH_THRESHOLD,
+  MAX_BATCH_TOTAL,
+  BATCH_WARNING_THRESHOLD,
+  mergeBatchOptions,
+} from './batchConfig';
+
+/**
+ * @typedef {object} BatchProgress
+ * @property {number} current - Current number of completed batches
+ * @property {number} total - Total number of batches
+ * @property {number} percentage - Completion percentage (0-100)
+ */
+
+/**
+ * @typedef {object} UseFetchBatchedReturn
+ * @property {boolean} isLoading - Whether batching is in progress
+ * @property {object|null} data - Combined result of all batch requests
+ * @property {Error|null} error - Error object if batching failed
+ * @property {BatchProgress} progress - Progress tracking information
+ * @property {Function} fetchBatched - Function to trigger batched requests
+ * @property {Function} reset - Function to reset state
+ */
+
+/**
+ * Hook for performing batched API requests with concurrency control
+ *
+ * This hook enables efficient fetching of large datasets by:
+ * - Making an initial request to get the total count
+ * - Calculating required pages based on batch size
+ * - Making parallel requests with configurable concurrency
+ * - Merging all responses into a single result
+ *
+ * Supports both offset/limit (Advisor API) and page/per_page (Inventory API) pagination.
+ *
+ * @param {object} options - Configuration options
+ * @param {string} options.endpoint - Endpoint name for endpoint-specific defaults
+ * @returns {UseFetchBatchedReturn} Batching utilities and state
+ *
+ * @example
+ * const { fetchBatched, isLoading, progress } = useFetchBatched();
+ *
+ * const allData = await fetchBatched({
+ *   fetchFunction: async (params) => axios.get('/api/systems', { params }),
+ *   queryParams: { filter: 'active' },
+ *   paginationType: 'offset',
+ *   batchSize: 50,
+ *   concurrency: 2
+ * });
+ */
+const useFetchBatched = (options = {}) => {
+  const { endpoint } = options;
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+  const [progress, setProgress] = useState({
+    current: 0,
+    total: 0,
+    percentage: 0,
+  });
+
+  const isMounted = useRef(true);
+  const abortControllerRef = useRef(null);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+      // Abort any in-flight requests
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+    };
+  }, []);
+
+  /**
+   * Update progress state
+   */
+  const updateProgress = useCallback((current, total) => {
+    if (!isMounted.current) return;
+
+    const percentage = total > 0 ? Math.round((current / total) * 100) : 0;
+    setProgress({ current, total, percentage });
+  }, []);
+
+  /**
+   * Reset all state
+   */
+  const reset = useCallback(() => {
+    if (!isMounted.current) return;
+
+    setIsLoading(false);
+    setData(null);
+    setError(null);
+    setProgress({ current: 0, total: 0, percentage: 0 });
+
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
+  }, []);
+
+  /**
+   * Main batching function
+   *
+   * @param {object} config - Batch configuration
+   * @param {Function} config.fetchFunction - Async function that makes the API call
+   * @param {object} config.queryParams - Base query parameters
+   * @param {string} config.paginationType - 'offset' or 'page'
+   * @param {number} config.batchSize - Items per batch
+   * @param {number} config.concurrency - Parallel requests
+   * @param {Function} config.onProgress - Optional progress callback
+   * @param {boolean} config.autoBatch - Auto-batch if total > threshold
+   * @returns {Promise<object>} Merged batch results
+   */
+  const fetchBatched = useCallback(
+    async (config) => {
+      const {
+        fetchFunction,
+        queryParams = {},
+        paginationType = PAGINATION_TYPES.OFFSET,
+        batchSize: customBatchSize,
+        concurrency: customConcurrency,
+        onProgress,
+        autoBatch = true,
+      } = config;
+
+      if (!fetchFunction || typeof fetchFunction !== 'function') {
+        const err = new Error(
+          'fetchFunction is required and must be a function',
+        );
+        setError(err);
+        throw err;
+      }
+
+      // Merge options with endpoint-specific or global defaults
+      const mergedOptions = mergeBatchOptions(
+        {
+          batchSize: customBatchSize,
+          concurrency: customConcurrency,
+          paginationType,
+        },
+        endpoint,
+      );
+
+      const { batchSize, concurrency } = mergedOptions;
+
+      // Validate parameters
+      const validation = validateBatchParams({
+        batchSize,
+        concurrency,
+        paginationType,
+      });
+
+      if (!validation.isValid) {
+        const err = new Error(
+          `Invalid batch parameters: ${validation.errors.join(', ')}`,
+        );
+        setError(err);
+        throw err;
+      }
+
+      // Reset state and create new abort controller
+      reset();
+      abortControllerRef.current = new AbortController();
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        // Step 1: Fetch first page to get total count
+        const firstPageParams = createBatchParams(
+          0,
+          batchSize,
+          queryParams,
+          paginationType,
+        );
+        const firstPageResponse = await fetchFunction(firstPageParams);
+
+        if (!isMounted.current) {
+          throw new Error('Component unmounted during fetch');
+        }
+
+        // Normalize the first response
+        const normalizedFirst = normalizeBatchResponse(
+          firstPageResponse,
+          paginationType,
+        );
+        const total =
+          normalizedFirst.meta.count || normalizedFirst.meta.total || 0;
+
+        // Check for large datasets
+        if (total > MAX_BATCH_TOTAL) {
+          console.warn(
+            `Dataset size (${total}) exceeds maximum batch total (${MAX_BATCH_TOTAL}). Consider adding filters.`,
+          );
+        } else if (total > BATCH_WARNING_THRESHOLD) {
+          console.warn(
+            `Large dataset detected (${total} items). Batching may take some time.`,
+          );
+        }
+
+        // Step 2: Determine if batching is needed
+        const shouldBatch = autoBatch
+          ? total > MIN_BATCH_THRESHOLD
+          : total > batchSize;
+
+        if (!shouldBatch || total <= batchSize) {
+          // No batching needed, return first page result
+          updateProgress(1, 1);
+          if (onProgress) onProgress({ current: 1, total: 1, percentage: 100 });
+
+          if (isMounted.current) {
+            setData(normalizedFirst);
+            setIsLoading(false);
+          }
+
+          return normalizedFirst;
+        }
+
+        // Step 3: Calculate remaining pages
+        const totalPages = calculateBatchPages(total, batchSize);
+
+        updateProgress(1, totalPages);
+        if (onProgress) {
+          onProgress({
+            current: 1,
+            total: totalPages,
+            percentage: Math.round((1 / totalPages) * 100),
+          });
+        }
+
+        // Step 4: Create batch requests for remaining pages
+        const batchRequests = [];
+        for (let pageIdx = 1; pageIdx < totalPages; pageIdx++) {
+          batchRequests.push(async () => {
+            if (abortControllerRef.current?.signal.aborted) {
+              throw new Error('Batch requests aborted');
+            }
+
+            const params = createBatchParams(
+              pageIdx,
+              batchSize,
+              queryParams,
+              paginationType,
+            );
+            const response = await fetchFunction(params);
+            const normalized = normalizeBatchResponse(response, paginationType);
+
+            // Update progress
+            const currentPage = pageIdx + 1;
+            updateProgress(currentPage, totalPages);
+            if (onProgress) {
+              onProgress({
+                current: currentPage,
+                total: totalPages,
+                percentage: Math.round((currentPage / totalPages) * 100),
+              });
+            }
+
+            return normalized;
+          });
+        }
+
+        // Step 5: Execute batch requests with concurrency control
+        const batchResponses = await pAll(batchRequests, { concurrency });
+
+        if (!isMounted.current) {
+          throw new Error('Component unmounted during batch processing');
+        }
+
+        // Step 6: Merge all responses
+        const allResponses = [normalizedFirst, ...batchResponses];
+        const mergedResult = mergeBatchResponses(allResponses, true);
+
+        // Verify we got all the data we expected
+        const expectedTotal = total;
+        const actualTotal = mergedResult.data.length;
+
+        if (actualTotal !== expectedTotal) {
+          console.warn(
+            `Batching completed but item count mismatch. Expected: ${expectedTotal}, Actual: ${actualTotal}`,
+          );
+        }
+
+        if (isMounted.current) {
+          setData(mergedResult);
+          setIsLoading(false);
+        }
+
+        return mergedResult;
+      } catch (err) {
+        if (!isMounted.current) {
+          return null;
+        }
+
+        console.error('Batch fetching failed:', err);
+        setError(err);
+        setIsLoading(false);
+        throw err;
+      }
+    },
+    [endpoint, reset, updateProgress],
+  );
+
+  return {
+    isLoading,
+    data,
+    error,
+    progress,
+    fetchBatched,
+    reset,
+  };
+};
+
+export default useFetchBatched;

--- a/src/Utilities/useFetchBatched.test.js
+++ b/src/Utilities/useFetchBatched.test.js
@@ -1,0 +1,635 @@
+import { renderHook, act } from '@testing-library/react';
+import useFetchBatched from './useFetchBatched';
+import { PAGINATION_TYPES } from './batchPaginationHelpers';
+
+// Mock p-all to control concurrency behavior
+jest.mock('p-all', () => {
+  return jest.fn((tasks) => {
+    return Promise.all(tasks.map((task) => task()));
+  });
+});
+
+describe('useFetchBatched', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    console.warn.mockRestore();
+    console.error.mockRestore();
+  });
+
+  describe('initialization', () => {
+    it('should initialize with default state', () => {
+      const { result } = renderHook(() => useFetchBatched());
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBe(null);
+      expect(result.current.error).toBe(null);
+      expect(result.current.progress).toEqual({
+        current: 0,
+        total: 0,
+        percentage: 0,
+      });
+      expect(typeof result.current.fetchBatched).toBe('function');
+      expect(typeof result.current.reset).toBe('function');
+    });
+  });
+
+  describe('fetchBatched - single page', () => {
+    it('should fetch single page without batching', async () => {
+      const mockFetchFunction = jest.fn().mockResolvedValue({
+        data: [{ id: 1 }, { id: 2 }],
+        meta: { count: 2, offset: 0, limit: 50 },
+      });
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      let response;
+      await act(async () => {
+        response = await result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+          queryParams: { filter: 'active' },
+          paginationType: PAGINATION_TYPES.OFFSET,
+          batchSize: 50,
+        });
+      });
+
+      expect(mockFetchFunction).toHaveBeenCalledTimes(1);
+      expect(mockFetchFunction).toHaveBeenCalledWith({
+        filter: 'active',
+        offset: 0,
+        limit: 50,
+      });
+
+      expect(response.data).toHaveLength(2);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.progress.percentage).toBe(100);
+    });
+  });
+
+  describe('fetchBatched - multiple pages', () => {
+    it('should batch multiple pages with offset pagination', async () => {
+      const mockFetchFunction = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: [{ id: 1 }, { id: 2 }],
+          meta: { count: 5, offset: 0, limit: 2 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 3 }, { id: 4 }],
+          meta: { count: 5, offset: 2, limit: 2 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 5 }],
+          meta: { count: 5, offset: 4, limit: 2 },
+        });
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      let response;
+      await act(async () => {
+        response = await result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+          queryParams: {},
+          paginationType: PAGINATION_TYPES.OFFSET,
+          batchSize: 2,
+          concurrency: 2,
+          autoBatch: false,
+        });
+      });
+
+      expect(mockFetchFunction).toHaveBeenCalledTimes(3);
+
+      // Verify all pages were requested
+      expect(mockFetchFunction).toHaveBeenNthCalledWith(1, {
+        offset: 0,
+        limit: 2,
+      });
+      expect(mockFetchFunction).toHaveBeenNthCalledWith(2, {
+        offset: 2,
+        limit: 2,
+      });
+      expect(mockFetchFunction).toHaveBeenNthCalledWith(3, {
+        offset: 4,
+        limit: 2,
+      });
+
+      // Verify merged result
+      expect(response.data).toHaveLength(5);
+      expect(response.data.map((d) => d.id)).toEqual([1, 2, 3, 4, 5]);
+      expect(response.meta.count).toBe(5);
+    });
+
+    it('should batch multiple pages with page pagination', async () => {
+      const mockFetchFunction = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: [{ id: 1 }, { id: 2 }],
+          meta: { count: 5, page: 1, per_page: 2 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 3 }, { id: 4 }],
+          meta: { count: 5, page: 2, per_page: 2 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 5 }],
+          meta: { count: 5, page: 3, per_page: 2 },
+        });
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      let response;
+      await act(async () => {
+        response = await result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+          queryParams: {},
+          paginationType: PAGINATION_TYPES.PAGE,
+          batchSize: 2,
+          autoBatch: false,
+        });
+      });
+
+      expect(mockFetchFunction).toHaveBeenCalledTimes(3);
+
+      // Verify page-based pagination
+      expect(mockFetchFunction).toHaveBeenNthCalledWith(1, {
+        page: 1,
+        per_page: 2,
+      });
+      expect(mockFetchFunction).toHaveBeenNthCalledWith(2, {
+        page: 2,
+        per_page: 2,
+      });
+      expect(mockFetchFunction).toHaveBeenNthCalledWith(3, {
+        page: 3,
+        per_page: 2,
+      });
+
+      expect(response.data).toHaveLength(5);
+    });
+  });
+
+  describe('progress tracking', () => {
+    it('should update progress during batching', async () => {
+      const mockFetchFunction = jest.fn((params) => {
+        return Promise.resolve({
+          data: [{ id: 1 }],
+          meta: { count: 10, ...params },
+        });
+      });
+
+      // First call returns total of 10, batchSize of 5 = 2 pages
+      mockFetchFunction.mockResolvedValueOnce({
+        data: [{ id: 1 }],
+        meta: { count: 10, offset: 0, limit: 5 },
+      });
+
+      const onProgress = jest.fn();
+      const { result } = renderHook(() => useFetchBatched());
+
+      await act(async () => {
+        await result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+          paginationType: PAGINATION_TYPES.OFFSET,
+          batchSize: 5,
+          onProgress,
+          autoBatch: false,
+        });
+      });
+
+      // Should have progress updates
+      expect(onProgress).toHaveBeenCalled();
+      expect(result.current.progress.total).toBe(2);
+      expect(result.current.progress.percentage).toBe(100);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle fetch errors', async () => {
+      const mockError = new Error('Network error');
+      const mockFetchFunction = jest.fn().mockRejectedValue(mockError);
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      await act(async () => {
+        await expect(
+          result.current.fetchBatched({
+            fetchFunction: mockFetchFunction,
+            paginationType: PAGINATION_TYPES.OFFSET,
+          }),
+        ).rejects.toThrow('Network error');
+      });
+
+      expect(result.current.error).toBe(mockError);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('should throw error if fetchFunction is missing', async () => {
+      const { result } = renderHook(() => useFetchBatched());
+
+      await act(async () => {
+        await expect(
+          result.current.fetchBatched({
+            paginationType: PAGINATION_TYPES.OFFSET,
+          }),
+        ).rejects.toThrow('fetchFunction is required');
+      });
+    });
+
+    it('should throw error for invalid parameters', async () => {
+      const mockFetchFunction = jest.fn();
+      const { result } = renderHook(() => useFetchBatched());
+
+      await act(async () => {
+        await expect(
+          result.current.fetchBatched({
+            fetchFunction: mockFetchFunction,
+            batchSize: -1, // Invalid
+          }),
+        ).rejects.toThrow('Invalid batch parameters');
+      });
+    });
+  });
+
+  describe('auto-batching', () => {
+    it('should skip batching if total is below threshold', async () => {
+      const mockFetchFunction = jest.fn().mockResolvedValue({
+        data: [{ id: 1 }],
+        meta: { count: 10, offset: 0, limit: 50 }, // Total of 10, below MIN_BATCH_THRESHOLD
+      });
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      await act(async () => {
+        await result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+          batchSize: 50,
+          autoBatch: true, // Auto-batch enabled
+        });
+      });
+
+      // Should only make one request since total < MIN_BATCH_THRESHOLD
+      expect(mockFetchFunction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('query params preservation', () => {
+    it('should preserve query params across all batch requests', async () => {
+      const mockFetchFunction = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: [{ id: 1 }],
+          meta: { count: 3, offset: 0, limit: 1 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 2 }],
+          meta: { count: 3, offset: 1, limit: 1 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 3 }],
+          meta: { count: 3, offset: 2, limit: 1 },
+        });
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      const queryParams = { filter: 'active', sort: 'name', tags: ['tag1'] };
+
+      await act(async () => {
+        await result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+          queryParams,
+          batchSize: 1,
+          paginationType: PAGINATION_TYPES.OFFSET,
+          autoBatch: false,
+        });
+      });
+
+      // Verify all requests included the query params
+      expect(mockFetchFunction).toHaveBeenNthCalledWith(1, {
+        ...queryParams,
+        offset: 0,
+        limit: 1,
+      });
+      expect(mockFetchFunction).toHaveBeenNthCalledWith(2, {
+        ...queryParams,
+        offset: 1,
+        limit: 1,
+      });
+      expect(mockFetchFunction).toHaveBeenNthCalledWith(3, {
+        ...queryParams,
+        offset: 2,
+        limit: 1,
+      });
+    });
+  });
+
+  describe('reset functionality', () => {
+    it('should reset state', async () => {
+      const mockFetchFunction = jest.fn().mockResolvedValue({
+        data: [{ id: 1 }],
+        meta: { count: 1, offset: 0, limit: 50 },
+      });
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      await act(async () => {
+        await result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+        });
+      });
+
+      expect(result.current.data).not.toBe(null);
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.data).toBe(null);
+      expect(result.current.error).toBe(null);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.progress).toEqual({
+        current: 0,
+        total: 0,
+        percentage: 0,
+      });
+    });
+  });
+
+  describe('warnings', () => {
+    it('should warn for large datasets', async () => {
+      const mockFetchFunction = jest.fn().mockResolvedValue({
+        data: [],
+        meta: { count: 6000, offset: 0, limit: 50 }, // Above BATCH_WARNING_THRESHOLD
+      });
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      await act(async () => {
+        await result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+          batchSize: 50,
+        });
+      });
+
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Large dataset detected'),
+      );
+    });
+
+    it('should warn for datasets exceeding maximum', async () => {
+      const mockFetchFunction = jest.fn().mockResolvedValue({
+        data: [],
+        meta: { count: 15000, offset: 0, limit: 50 }, // Above MAX_BATCH_TOTAL
+      });
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      await act(async () => {
+        await result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+          batchSize: 50,
+        });
+      });
+
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('exceeds maximum batch total'),
+      );
+    });
+  });
+
+  describe('endpoint-specific configuration', () => {
+    it('should use endpoint-specific defaults', async () => {
+      const mockFetchFunction = jest.fn().mockResolvedValue({
+        data: [{ id: 1 }],
+        meta: { count: 1, offset: 0, limit: 100 },
+      });
+
+      const { result } = renderHook(() =>
+        useFetchBatched({ endpoint: 'systems' }),
+      );
+
+      await act(async () => {
+        await result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+          paginationType: PAGINATION_TYPES.OFFSET,
+        });
+      });
+
+      expect(mockFetchFunction).toHaveBeenCalledWith({
+        offset: 0,
+        limit: 100,
+      });
+    });
+  });
+
+  describe('component unmount behavior', () => {
+    it('should handle unmount during active batching', async () => {
+      const mockFetchFunction = jest
+        .fn()
+        .mockImplementation(
+          () => new Promise((resolve) => setTimeout(resolve, 100)),
+        );
+
+      const { result, unmount } = renderHook(() => useFetchBatched());
+
+      act(() => {
+        result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+          paginationType: PAGINATION_TYPES.OFFSET,
+          batchSize: 50,
+        });
+      });
+
+      unmount();
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('should reset state correctly after unmount', () => {
+      const { result, unmount } = renderHook(() => useFetchBatched());
+
+      unmount();
+
+      expect(result.current.data).toBe(null);
+      expect(result.current.error).toBe(null);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('concurrency control', () => {
+    it('should accept concurrency parameter', async () => {
+      const mockFetchFunction = jest.fn().mockResolvedValue({
+        data: [{ id: 1 }],
+        meta: { count: 1, offset: 0, limit: 50 },
+      });
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      await act(async () => {
+        await result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+          paginationType: PAGINATION_TYPES.OFFSET,
+          batchSize: 50,
+          concurrency: 2,
+        });
+      });
+
+      expect(mockFetchFunction).toHaveBeenCalled();
+    });
+
+    it('should handle multiple pages with concurrency setting', async () => {
+      const mockFetchFunction = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: [{ id: 1 }],
+          meta: { count: 3, offset: 0, limit: 1 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 2 }],
+          meta: { count: 3, offset: 1, limit: 1 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 3 }],
+          meta: { count: 3, offset: 2, limit: 1 },
+        });
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      let response;
+      await act(async () => {
+        response = await result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+          paginationType: PAGINATION_TYPES.OFFSET,
+          batchSize: 1,
+          concurrency: 1,
+          autoBatch: false,
+        });
+      });
+
+      expect(mockFetchFunction).toHaveBeenCalledTimes(3);
+      expect(response.data).toHaveLength(3);
+    });
+  });
+
+  describe('partial batch failures', () => {
+    it('should fail entire batch if any request fails', async () => {
+      const mockFetchFunction = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: [{ id: 1 }],
+          meta: { count: 3, offset: 0, limit: 1 },
+        })
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({
+          data: [{ id: 3 }],
+          meta: { count: 3, offset: 2, limit: 1 },
+        });
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      await act(async () => {
+        await expect(
+          result.current.fetchBatched({
+            fetchFunction: mockFetchFunction,
+            paginationType: PAGINATION_TYPES.OFFSET,
+            batchSize: 1,
+            autoBatch: false,
+          }),
+        ).rejects.toThrow('Network error');
+      });
+
+      expect(result.current.error).toBeTruthy();
+    });
+
+    it('should provide partial data context on failure', async () => {
+      const mockFetchFunction = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: [{ id: 1 }],
+          meta: { count: 5, offset: 0, limit: 1 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 2 }],
+          meta: { count: 5, offset: 1, limit: 1 },
+        })
+        .mockRejectedValueOnce(new Error('Failed on third request'));
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      await act(async () => {
+        await expect(
+          result.current.fetchBatched({
+            fetchFunction: mockFetchFunction,
+            paginationType: PAGINATION_TYPES.OFFSET,
+            batchSize: 1,
+            autoBatch: false,
+          }),
+        ).rejects.toThrow('Failed on third request');
+      });
+
+      expect(result.current.error.message).toContain('third request');
+    });
+  });
+
+  describe('large dataset handling', () => {
+    it('should warn for datasets exceeding maximum threshold', async () => {
+      const mockFetchFunction = jest.fn().mockResolvedValue({
+        data: Array(50).fill({ id: 1 }),
+        meta: { count: 10001, offset: 0, limit: 50 },
+      });
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      await act(async () => {
+        await result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+          paginationType: PAGINATION_TYPES.OFFSET,
+          batchSize: 50,
+        });
+      });
+
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('exceeds maximum batch total'),
+      );
+    });
+
+    it('should efficiently merge large result sets', async () => {
+      const batch1 = Array(100)
+        .fill(null)
+        .map((_, i) => ({ id: i }));
+      const batch2 = Array(100)
+        .fill(null)
+        .map((_, i) => ({ id: i + 100 }));
+
+      const mockFetchFunction = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: batch1,
+          meta: { count: 200, offset: 0, limit: 100 },
+        })
+        .mockResolvedValueOnce({
+          data: batch2,
+          meta: { count: 200, offset: 100, limit: 100 },
+        });
+
+      const { result } = renderHook(() => useFetchBatched());
+
+      let response;
+      await act(async () => {
+        response = await result.current.fetchBatched({
+          fetchFunction: mockFetchFunction,
+          paginationType: PAGINATION_TYPES.OFFSET,
+          batchSize: 100,
+          autoBatch: false,
+        });
+      });
+
+      expect(response.data).toHaveLength(200);
+      expect(response.data[0].id).toBe(0);
+      expect(response.data[199].id).toBe(199);
+    });
+  });
+});


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)
https://redhat.atlassian.net/browse/RHINENG-25210
**Integrated batch requests into tables**
- Switched RulesTable to use `useGetRecsBatchedQuery` instead of single-page query
- Switched PathwaysTable to use `useGetPathwaysBatchedQuery`
- Added client-side pagination to slice pre-loaded data
- Auto-batch kicks in for datasets > 50 items

**Fixed tests**
- Updated PathwaysTable.test.js to mock batched queries correctly
- Fixed Cypress tests expecting all data visible (only 20 items per page shown)


**Smart batching**: Only activates for large datasets (>50 items), so small lists stay fast without overhead.

## Summary by Sourcery

Introduce shared batching utilities and apply batched API querying to recommendations, pathways, and systems tables with client-side pagination over pre-fetched data.

New Features:
- Add generic batching utilities and hooks for Advisor APIs, including RTK Query integration and standalone helpers for batched fetching and exports.
- Provide batched API endpoints and React hooks for recommendations, systems, and pathways services, including batched variants for related systems queries.
- Enable rules and pathways tables to use batched queries with client-side slicing for pagination while preserving sorting and filtering behavior.

Enhancements:
- Extend the Advisor base query to mark batched requests via custom headers for observability and downstream handling.
- Refine inventory helpers to rely on the new batched fetching utilities when collecting all current system IDs.

Tests:
- Add extensive Cypress coverage for batched behavior across rules, pathways, list views, topics, and system advisor flows, including sorting, filtering, pagination, tab switching, error states, and large datasets.
- Introduce Jest tests for new batched Systems and Recs service hooks and for inventory helper changes, and scaffold unit tests for batch utilities.