### PR TITLE
fix(deps): bump axios to 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
-        "axios": "^1.8.4",
+        "axios": "^1.15.0",
         "babel-eslint": "10.1.0",
         "babel-jest": "^30.3.0",
         "babel-loader": "^10.1.1",
@@ -10380,19 +10380,24 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/babel-eslint": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "axios": "^1.8.4",
+    "axios": "^1.15.0",
     "babel-eslint": "10.1.0",
     "babel-jest": "^30.3.0",
     "babel-loader": "^10.1.1",
@@ -190,6 +190,6 @@
     "@react-pdf/image": "2.2.3",
     "@react-pdf/pdfkit": "3.0.4",
     "@react-pdf/layout": "3.6.4",
-    "axios": "^1.8.4"
+    "axios": "^1.15.0"
   }
 }


### PR DESCRIPTION
Bumps `axios` from `^1.8.4` to `^1.15.0` in `devDependencies` and `overrides`, and regenerates `package-lock.json`.

## CVEs fixed
- CVE-2026-40175 — Axios RCE via Prototype Pollution
- CVE-2026-25639 — Axios DoS via `__proto__`
- CVE-2026-26996 — Axios improper input validation
- CVE-2026-27904 — Axios improper input validation

## Backport
The same fix has been applied to `foreman-3.16` in #1856.
Branches have diverged too far for a clean cherry-pick — both PRs carry independent commits.

## Summary by Sourcery

Update axios dependency to a secure, newer minor version across the project.

Bug Fixes:
- Address multiple axios security vulnerabilities by upgrading to version 1.15.0.

Build:
- Bump axios version from ^1.8.4 to ^1.15.0 in devDependencies and overrides and regenerate package-lock.json.