### PR TITLE
fix(deps): bump lodash to 4.18.0 in advisor-frontend [foreman-3.16]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "identity-obj-proxy": "3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "lodash": "4.17.21",
+        "lodash": "4.18.0",
         "npm-run-all": "4.1.5",
         "prop-types": "^15.8.1",
         "qs": "^6.12.1",
@@ -19634,9 +19634,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
+      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
+      "deprecated": "Bad release. Please use lodash@4.17.21 instead.",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "identity-obj-proxy": "3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "lodash": "4.17.21",
+    "lodash": "4.18.0",
     "npm-run-all": "4.1.5",
     "prop-types": "^15.8.1",
     "qs": "^6.12.1",


### PR DESCRIPTION
## Summary

Bumps \`lodash\` in \`advisor-frontend\` to resolve 2 security CVEs.
Changes are confined to the dependency manifest and lockfile; no application logic was modified.

## CVEs addressed

| CVE ID | Package | Old version | New version | Jira |
|---|---|---|---|---|
| [CVE-2026-4800](https://access.redhat.com/security/cve/CVE-2026-4800) | lodash | 4.17.21 | 4.18.0 | [SAT-43984](https://redhat.atlassian.net/browse/SAT-43984) |
| [CVE-2025-13465](https://access.redhat.com/security/cve/CVE-2025-13465) | lodash | 4.17.21 | 4.18.0 | [SAT-41938](https://redhat.atlassian.net/browse/SAT-41938) |

## Changes

| File | Change |
|---|---|
| \`package.json\` | Bumped \`lodash\` constraint from \`4.17.21\` to \`4.18.0\` |
| \`package-lock.json\` | Bumped \`lodash\` from \`4.17.21\` to \`4.18.0\` |

## Testing

- [ ] CI pipeline passes on this branch.
- [ ] No breaking changes to public API or types introduced by the version bump.

## References

- [CVE-2026-4800](https://access.redhat.com/security/cve/CVE-2026-4800) — lodash arbitrary code execution via untrusted input (prototype pollution)
- [SAT-43984](https://redhat.atlassian.net/browse/SAT-43984) — Jira ticket
- [CVE-2025-13465](https://access.redhat.com/security/cve/CVE-2025-13465) — lodash prototype pollution in \`_.unset\` and \`_.omit\` functions
- [SAT-41938](https://redhat.atlassian.net/browse/SAT-41938) — Jira ticket

[SAT-43984]: https://redhat.atlassian.net/browse/SAT-43984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAT-41938]: https://redhat.atlassian.net/browse/SAT-41938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAT-43984]: https://redhat.atlassian.net/browse/SAT-43984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ