### PR TITLE
chore(deps): lodash update for cve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "identity-obj-proxy": "3.0.0",
         "jest": "^30.3.0",
         "jest-environment-jsdom": "^30.3.0",
-        "lodash": "4.17.21",
+        "lodash": "^4.18.1",
         "npm-run-all": "4.1.5",
         "prop-types": "^15.8.1",
         "qs": "^6.12.1",
@@ -4883,11 +4883,6 @@
         }
       }
     },
-    "node_modules/@patternfly/react-charts/node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
-    },
     "node_modules/@patternfly/react-component-groups": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-6.4.0.tgz",
@@ -4971,11 +4966,6 @@
         "react": "^17 || ^18 || ^19",
         "react-dom": "^17 || ^18 || ^19"
       }
-    },
-    "node_modules/@patternfly/react-table/node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "node_modules/@patternfly/react-tokens": {
       "version": "6.4.0",
@@ -5486,9 +5476,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-7.3.1.tgz",
-      "integrity": "sha512-+moHAblUPS+ENLw9S9Pn+oMHNyOWY8CbvrrUc3T9Y872feRljrqHaQcXy5JTCipLsm+wf+MvuSImL0L2qQhYAA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-7.4.1.tgz",
+      "integrity": "sha512-Z+b1SfLM8A3j9Vdr+hANNg3h68o8qBBC0ef+fFd2r/ZBRViaSvi92UO9YIyqKXsQor5dYgXZRUcPLKv05OmGRg==",
       "dependencies": {
         "@patternfly/react-component-groups": "^6.0.0",
         "@redhat-cloud-services/frontend-components-utilities": "^7.0.0",
@@ -5513,9 +5503,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-advisor-components": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-advisor-components/-/frontend-components-advisor-components-3.4.0.tgz",
-      "integrity": "sha512-Xhdeh2EedxY21kplg8uDSZbq1aJtsRC1hwcHKjnngk5FhmZ5sCiWrFSNc0EXOrletmyTsBnp66Brn8SRD86uSg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-advisor-components/-/frontend-components-advisor-components-3.5.1.tgz",
+      "integrity": "sha512-8hWqWEAHaxzEvRnuDadBD3pstZMQytlsyf6NB66gzZJdWEVuwQOb9nROSH7f2U3CT7B+RqfpvaCc0NTEz9DUzg==",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^7.0.13",
         "dot": "^1.1.3",
@@ -6227,13 +6217,13 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config": {
-      "version": "6.8.4",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.8.4.tgz",
-      "integrity": "sha512-s/JkvYhD9mT3xtCfZa6P0FE5ZQbzm1DdHO+qI+RsNP3Cxs3SYOWLg2VtwR0PReSf8sQJ5kl2ughrhmU4Ck6PmA==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.9.1.tgz",
+      "integrity": "sha512-bwunLWJetzTv5u5BAa1rn7mv+xfej4ZOAruYmWLKmuoQui+HWmTsO8NT9x+EBlmx7C4bP3l9oy00oHicsj58fw==",
       "dev": true,
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
-        "@redhat-cloud-services/frontend-components-config-utilities": "^4.8.1",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^4.9.0",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.26",
         "@sentry/webpack-plugin": "^4.5.0",
         "@swc/core": "^1.3.76",
@@ -6255,6 +6245,7 @@
         "https-proxy-agent": "^5.0.1",
         "inquirer": "^8.2.4",
         "js-yaml": "^4.1.0",
+        "jsonc-parser": "^3.3.1",
         "jws": "^4.0.0",
         "lodash": "^4.17.21",
         "mini-css-extract-plugin": "^2.9.1",
@@ -6281,9 +6272,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config-utilities": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-4.8.3.tgz",
-      "integrity": "sha512-i1CHHhNqkQz1wJskC0K7JvquCuAkaLffBgrHifUsTnfeh8WtCYyUaulXxUST5uivdVx2v5zqCDLZFmLojOogvg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-4.9.1.tgz",
+      "integrity": "sha512-kBqSTTzTZPa8rn8vW2w5fFtPZYh2Rh5DvMRguRNKXGEOEmigxmiFD2NexWM0Ofi4PzagS1I+zWtyLZqdKo+vyw==",
       "dependencies": {
         "@openshift/dynamic-plugin-sdk-webpack": "^4.0.1",
         "ajv": "^8.17.1",
@@ -6747,9 +6738,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-notifications": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-6.5.1.tgz",
-      "integrity": "sha512-u0p2UlyJhaIXMzOVdD+8Dad36FaBrz/nEc/NzBmTUgfXPRH9zgIY/CCe3KFJ2F8Rk/VowU+vAFmzwnKz5fzvLA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-6.6.1.tgz",
+      "integrity": "sha512-nd63IeBBcle7kPbxaX3/gJfDOujmxIT/rfNTjUBmFMCSZ6pJJA4nD++yeOFt1FvnHIHHCmGKRO2BXiGBRcPm4Q==",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^7.0.13",
         "@redhat-cloud-services/frontend-components-utilities": "^7.0.0"
@@ -6762,9 +6753,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-remediations": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-remediations/-/frontend-components-remediations-4.4.0.tgz",
-      "integrity": "sha512-Ohgy2HmLB06Mzcxa8CGLuMIq2vEGLZOZ6R5odrVCWMwa5BSvG0ILCRvRJ/lU+AArYHgD+YONChbKwoOl4RfKBA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-remediations/-/frontend-components-remediations-4.5.1.tgz",
+      "integrity": "sha512-h/wT/vgLsY9qiDi9tcLvwHN6Js/5H7CvrH/RA/5kqXpnOv5Qyj6w5gMN7DfTL6jFXIJJoAzz9piMHS2dWBvaVA==",
       "dependencies": {
         "@data-driven-forms/pf4-component-mapper": "^4.0.0",
         "@data-driven-forms/react-form-renderer": "^4.0.0",
@@ -8512,14 +8503,14 @@
       "license": "ISC"
     },
     "node_modules/@unleash/proxy-client-react": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-4.2.4.tgz",
-      "integrity": "sha512-FWzKDqE28ZmogdXgL9caqMJTWnrVEMJWly8Ofbo1xNZHsk7R9jcWgozIXCWEPto/qijfyCBoat5xjsduT09l1g==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-4.5.2.tgz",
+      "integrity": "sha512-mxml+6+hH64qpTml768Suf955n5YttCZgmsw1TJYmUJ1pa+X+dBYvAM0Mdg8L+uUU7hz1xFrOeWtgtJRe+17eQ==",
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "unleash-proxy-client": "^3.4.0"
+        "unleash-proxy-client": "^3.7.3"
       }
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
@@ -9741,9 +9732,9 @@
       "license": "MIT"
     },
     "node_modules/bastilian-tabletools": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-2.18.1.tgz",
-      "integrity": "sha512-+SPv07deN2nYpBhWLrO+zW6aAr7vxF2XXwbJeXeVxZmpByvCotf3EDOCDEHICcLSCYZjf5+VBcMxHaM+P/SdHA==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-2.20.0.tgz",
+      "integrity": "sha512-i0Zmnsoatu80lpLTCRoL2sLKHx7yp1FK1QYWknk+eYQtixtP2GZgDpmKQsDBiCwkSzKGFABuZxAabADXqBZKlA==",
       "engines": {
         "node": ">=22.0.0"
       },
@@ -11288,9 +11279,9 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cypress": {
-      "version": "15.13.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.13.1.tgz",
-      "integrity": "sha512-jLkgo75zlwo7PhXp0XJot+zIfFSDzN1SvTml6Xf3ETM1XHRWnH3Q4LAR3orCo/BsnxPnhjG3m5HYSvn9DAtwBg==",
+      "version": "15.14.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.14.1.tgz",
+      "integrity": "sha512-AkuiHNSnmm0a+h/horcvbjmY6dWpCe1Ebp1R0LjMP5I6pjMaNA50Mw1YP/d07pLHJ/sV8FZoGecUWFCJ/Nifpw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -11453,12 +11444,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/cypress/node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true
     },
     "node_modules/cypress/node_modules/supports-color": {
       "version": "8.1.1",
@@ -19058,6 +19043,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -19565,9 +19556,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -26973,10 +26964,9 @@
       }
     },
     "node_modules/unleash-proxy-client": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-3.7.3.tgz",
-      "integrity": "sha512-Cd7ovrhAIpwveNFdtpzs7HO0WeArC2fbjIVGL2Cjza8bHD+jJ1JbSuy3tFuKvvUkbVKq/EGV0RgosEa/3UVLgg==",
-      "license": "Apache-2.0",
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-3.7.8.tgz",
+      "integrity": "sha512-VX0jDcOporeVb1nh4+HGpEZIwcwHl/HP/7cyZxQq3umffN0hx44Tw1u4nmdopmm9s7Hb2BES0pFCIntr/lh3vQ==",
       "peer": true,
       "dependencies": {
         "tiny-emitter": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "identity-obj-proxy": "3.0.0",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",
-    "lodash": "4.17.21",
+    "lodash": "^4.18.1",
     "npm-run-all": "4.1.5",
     "prop-types": "^15.8.1",
     "qs": "^6.12.1",


### PR DESCRIPTION
[CVE-2026-4800](https://access.redhat.com/security/cve/CVE-2026-4800)
https://github.com/RedHatInsights/insights-advisor-frontend/pull/1875
version 4.18.0 is broken 
https://github.com/lodash/lodash/issues/6167

so we have to update to 4.18.1

## Summary by Sourcery

Build:
- Bump lodash in package.json and lockfile from 4.17.21 to ^4.18.1 to address upstream issues and CVEs.