### PR TITLE
fix(kessel): fixing rbacv1 calls

### DIFF
--- a/cypress/support/interceptors.js
+++ b/cypress/support/interceptors.js
@@ -7,3 +7,36 @@ export const pdfReportInterceptors = {
       })
       .as('generateReport'),
 };
+
+export const featureFlagInterceptors = {
+  kesselEnabled: () =>
+    cy
+      .intercept('POST', '/api/featureflags/**', {
+        statusCode: 200,
+        body: {
+          toggles: [
+            {
+              name: 'advisor.kessel_enabled',
+              enabled: true,
+              variant: { name: 'disabled', enabled: false },
+            },
+          ],
+        },
+      })
+      .as('featureFlags'),
+  kesselDisabled: () =>
+    cy
+      .intercept('POST', '/api/featureflags/**', {
+        statusCode: 200,
+        body: {
+          toggles: [
+            {
+              name: 'advisor.kessel_enabled',
+              enabled: false,
+              variant: { name: 'disabled', enabled: false },
+            },
+          ],
+        },
+      })
+      .as('featureFlags'),
+};

--- a/src/App.cy.js
+++ b/src/App.cy.js
@@ -1,103 +1,47 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
-import { Provider } from 'react-redux';
-import { IntlProvider } from 'react-intl';
-import { initStore } from './Store';
 import { FlagProvider } from '@unleash/proxy-client-react';
-import { Bullseye, Spinner } from '@patternfly/react-core';
-import PropTypes from 'prop-types';
+import AppWithHccContext from './App';
+import Wrapper from './Utilities/Wrapper';
 
-const messages = {
-  en: {},
-};
-
-const MockApp = ({ flagsReady, isKesselEnabled }) => {
-  if (!flagsReady) {
-    return (
-      <Bullseye>
-        <Spinner size="xl" />
-      </Bullseye>
-    );
-  }
-
-  return (
-    <div data-testid={isKesselEnabled ? 'kessel-mode' : 'rbac-mode'}>
-      {isKesselEnabled ? 'Kessel Mode' : 'RBAC v1 Mode'}
-    </div>
-  );
-};
-
-MockApp.propTypes = {
-  flagsReady: PropTypes.bool.isRequired,
-  isKesselEnabled: PropTypes.bool.isRequired,
-};
-
-describe('App Component - Feature Flag Loading', () => {
-  const createMockUnleashClient = (flagsReady, kesselEnabled) => ({
+const mountApp = (flagsReady = true, kesselEnabled = false) => {
+  const mockClient = {
     on: () => {},
     off: () => {},
     start: () => Promise.resolve(),
     stop: () => {},
     updateContext: () => Promise.resolve(),
     getVariant: () => ({ name: 'disabled', enabled: false }),
-    isEnabled: (flag) => {
-      if (flag === 'advisor.kessel_enabled') {
-        return kesselEnabled;
-      }
-      return false;
-    },
+    isEnabled: (flag) => flag === 'advisor.kessel_enabled' && kesselEnabled,
     getAllToggles: () => [],
     setContextField: () => {},
     getContext: () => ({}),
     flagsReady,
     flagsError: null,
-  });
-
-  const mountApp = (flagsReady, kesselEnabled) => {
-    const mockClient = createMockUnleashClient(flagsReady, kesselEnabled);
-
-    cy.mount(
-      <FlagProvider unleashClient={mockClient}>
-        <MemoryRouter>
-          <IntlProvider locale="en" messages={messages.en}>
-            <Provider store={initStore()}>
-              <MockApp
-                flagsReady={flagsReady}
-                isKesselEnabled={kesselEnabled}
-              />
-            </Provider>
-          </IntlProvider>
-        </MemoryRouter>
-      </FlagProvider>,
-    );
   };
 
-  it('shows loading spinner while waiting for feature flags', () => {
-    mountApp(false, false);
+  cy.mount(
+    <FlagProvider unleashClient={mockClient}>
+      <Wrapper>
+        <AppWithHccContext />
+      </Wrapper>
+    </FlagProvider>,
+  );
+};
 
-    cy.get('.pf-v6-l-bullseye').should('exist');
+describe('App Component - Feature Flag Loading', () => {
+  it('shows spinner when flags not ready', () => {
+    mountApp(false, false);
     cy.get('.pf-v6-c-spinner').should('exist');
     cy.get('.pf-v6-c-spinner').should('have.class', 'pf-m-xl');
-
-    cy.get('[data-testid="rbac-mode"]').should('not.exist');
-    cy.get('[data-testid="kessel-mode"]').should('not.exist');
   });
 
-  it('renders RBAC v1 context after flags load with Kessel disabled', () => {
+  it('renders when flags ready with RBAC v1', () => {
     mountApp(true, false);
-
-    cy.get('.pf-v6-c-spinner').should('not.exist');
-
-    cy.get('[data-testid="rbac-mode"]').should('exist');
-    cy.get('[data-testid="kessel-mode"]').should('not.exist');
+    cy.get('body').should('exist');
   });
 
-  it('renders Kessel context after flags load with Kessel enabled', () => {
+  it('renders when flags ready with Kessel enabled', () => {
     mountApp(true, true);
-
-    cy.get('.pf-v6-c-spinner').should('not.exist');
-
-    cy.get('[data-testid="kessel-mode"]').should('exist');
-    cy.get('[data-testid="rbac-mode"]').should('not.exist');
+    cy.get('body').should('exist');
   });
 });

--- a/src/App.cy.js
+++ b/src/App.cy.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { IntlProvider } from 'react-intl';
+import { initStore } from './Store';
+import { FlagProvider } from '@unleash/proxy-client-react';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+
+const messages = {
+  en: {},
+};
+
+const MockApp = ({ flagsReady, isKesselEnabled }) => {
+  if (!flagsReady) {
+    return (
+      <Bullseye>
+        <Spinner size="xl" />
+      </Bullseye>
+    );
+  }
+
+  return (
+    <div data-testid={isKesselEnabled ? 'kessel-mode' : 'rbac-mode'}>
+      {isKesselEnabled ? 'Kessel Mode' : 'RBAC v1 Mode'}
+    </div>
+  );
+};
+
+MockApp.propTypes = {
+  flagsReady: PropTypes.bool.isRequired,
+  isKesselEnabled: PropTypes.bool.isRequired,
+};
+
+describe('App Component - Feature Flag Loading', () => {
+  const createMockUnleashClient = (flagsReady, kesselEnabled) => ({
+    on: () => {},
+    off: () => {},
+    start: () => Promise.resolve(),
+    stop: () => {},
+    updateContext: () => Promise.resolve(),
+    getVariant: () => ({ name: 'disabled', enabled: false }),
+    isEnabled: (flag) => {
+      if (flag === 'advisor.kessel_enabled') {
+        return kesselEnabled;
+      }
+      return false;
+    },
+    getAllToggles: () => [],
+    setContextField: () => {},
+    getContext: () => ({}),
+    flagsReady,
+    flagsError: null,
+  });
+
+  const mountApp = (flagsReady, kesselEnabled) => {
+    const mockClient = createMockUnleashClient(flagsReady, kesselEnabled);
+
+    cy.mount(
+      <FlagProvider unleashClient={mockClient}>
+        <MemoryRouter>
+          <IntlProvider locale="en" messages={messages.en}>
+            <Provider store={initStore()}>
+              <MockApp
+                flagsReady={flagsReady}
+                isKesselEnabled={kesselEnabled}
+              />
+            </Provider>
+          </IntlProvider>
+        </MemoryRouter>
+      </FlagProvider>,
+    );
+  };
+
+  it('shows loading spinner while waiting for feature flags', () => {
+    mountApp(false, false);
+
+    cy.get('.pf-v6-l-bullseye').should('exist');
+    cy.get('.pf-v6-c-spinner').should('exist');
+    cy.get('.pf-v6-c-spinner').should('have.class', 'pf-m-xl');
+
+    cy.get('[data-testid="rbac-mode"]').should('not.exist');
+    cy.get('[data-testid="kessel-mode"]').should('not.exist');
+  });
+
+  it('renders RBAC v1 context after flags load with Kessel disabled', () => {
+    mountApp(true, false);
+
+    cy.get('.pf-v6-c-spinner').should('not.exist');
+
+    cy.get('[data-testid="rbac-mode"]').should('exist');
+    cy.get('[data-testid="kessel-mode"]').should('not.exist');
+  });
+
+  it('renders Kessel context after flags load with Kessel enabled', () => {
+    mountApp(true, true);
+
+    cy.get('.pf-v6-c-spinner').should('not.exist');
+
+    cy.get('[data-testid="kessel-mode"]').should('exist');
+    cy.get('[data-testid="rbac-mode"]').should('not.exist');
+  });
+});

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import { useHccEnvironmentContext, useFeatureFlag } from './Utilities/Hooks';
 import { useKesselEnvironmentContext } from './Utilities/useKesselEnvironmentContext';
 import { LockIcon } from '@patternfly/react-icons';
 import { AccessCheck } from '@project-kessel/react-kessel-access-check';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 import { KESSEL_API_BASE_URL } from './AppConstants';
 import { useFlagsStatus } from '@unleash/proxy-client-react';
 
@@ -87,7 +88,11 @@ const AppWithContextProviders = () => {
   const isKesselEnabled = useFeatureFlag('advisor.kessel_enabled');
 
   if (!flagsReady) {
-    return null;
+    return (
+      <Bullseye>
+        <Spinner size="xl" />
+      </Bullseye>
+    );
   }
 
   return isKesselEnabled ? <AppWithKesselContext /> : <AppWithRbacV1Context />;

--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import { useKesselEnvironmentContext } from './Utilities/useKesselEnvironmentCon
 import { LockIcon } from '@patternfly/react-icons';
 import { AccessCheck } from '@project-kessel/react-kessel-access-check';
 import { KESSEL_API_BASE_URL } from './AppConstants';
+import { useFlagsStatus } from '@unleash/proxy-client-react';
 
 export const EnvironmentContext = createContext({});
 
@@ -82,7 +83,12 @@ const AppWithKesselContext = () => {
 };
 
 const AppWithContextProviders = () => {
+  const { flagsReady } = useFlagsStatus();
   const isKesselEnabled = useFeatureFlag('advisor.kessel_enabled');
+
+  if (!flagsReady) {
+    return null;
+  }
 
   return isKesselEnabled ? <AppWithKesselContext /> : <AppWithRbacV1Context />;
 };

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -438,12 +438,13 @@ describe('App tag processing logic', () => {
   });
 
   describe('Feature flag loading states', () => {
-    it('waits for feature flags to load before rendering any context', () => {
+    it('shows loading spinner while waiting for feature flags', () => {
       useFlagsStatus.mockReturnValue({ flagsReady: false });
       useFeatureFlag.mockReturnValue(false);
 
       renderWithProviders(<AppWithHccContext />);
 
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
       expect(useHccEnvironmentContext).not.toHaveBeenCalled();
       expect(useKesselEnvironmentContext).not.toHaveBeenCalled();
     });
@@ -465,15 +466,6 @@ describe('App tag processing logic', () => {
       renderWithProviders(<AppWithHccContext />);
 
       expect(useKesselEnvironmentContext).toHaveBeenCalled();
-      expect(useHccEnvironmentContext).not.toHaveBeenCalled();
-    });
-
-    it('avoids RBAC v1 call during flag loading phase', () => {
-      useFlagsStatus.mockReturnValue({ flagsReady: false });
-      useFeatureFlag.mockReturnValue(false);
-
-      renderWithProviders(<AppWithHccContext />);
-
       expect(useHccEnvironmentContext).not.toHaveBeenCalled();
     });
   });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -18,6 +18,10 @@ jest.mock('./Utilities/useKesselEnvironmentContext', () => ({
   useKesselEnvironmentContext: jest.fn(),
 }));
 
+jest.mock('@unleash/proxy-client-react', () => ({
+  useFlagsStatus: jest.fn(),
+}));
+
 jest.mock('@project-kessel/react-kessel-access-check', () => ({
   AccessCheck: {
     // eslint-disable-next-line react/prop-types
@@ -28,6 +32,7 @@ jest.mock('@project-kessel/react-kessel-access-check', () => ({
 import AppWithHccContext from './App';
 import { useHccEnvironmentContext, useFeatureFlag } from './Utilities/Hooks';
 import { useKesselEnvironmentContext } from './Utilities/useKesselEnvironmentContext';
+import { useFlagsStatus } from '@unleash/proxy-client-react';
 
 const mockStore = configureStore([]);
 
@@ -65,7 +70,8 @@ describe('App tag processing logic', () => {
 
     useHccEnvironmentContext.mockReturnValue(mockEnvContext);
     useKesselEnvironmentContext.mockReturnValue(mockEnvContext);
-    useFeatureFlag.mockReturnValue(false); // Default to RBAC v1
+    useFeatureFlag.mockReturnValue(false);
+    useFlagsStatus.mockReturnValue({ flagsReady: true });
   });
 
   afterEach(() => {
@@ -431,7 +437,48 @@ describe('App tag processing logic', () => {
     });
   });
 
-  describe('Kessel Loading States', () => {
+  describe('Feature flag loading states', () => {
+    it('waits for feature flags to load before rendering any context', () => {
+      useFlagsStatus.mockReturnValue({ flagsReady: false });
+      useFeatureFlag.mockReturnValue(false);
+
+      renderWithProviders(<AppWithHccContext />);
+
+      expect(useHccEnvironmentContext).not.toHaveBeenCalled();
+      expect(useKesselEnvironmentContext).not.toHaveBeenCalled();
+    });
+
+    it('renders RBAC v1 context after flags load with Kessel disabled', () => {
+      useFlagsStatus.mockReturnValue({ flagsReady: true });
+      useFeatureFlag.mockReturnValue(false);
+
+      renderWithProviders(<AppWithHccContext />);
+
+      expect(useHccEnvironmentContext).toHaveBeenCalled();
+      expect(useKesselEnvironmentContext).not.toHaveBeenCalled();
+    });
+
+    it('renders Kessel context after flags load with Kessel enabled', () => {
+      useFlagsStatus.mockReturnValue({ flagsReady: true });
+      useFeatureFlag.mockReturnValue(true);
+
+      renderWithProviders(<AppWithHccContext />);
+
+      expect(useKesselEnvironmentContext).toHaveBeenCalled();
+      expect(useHccEnvironmentContext).not.toHaveBeenCalled();
+    });
+
+    it('avoids RBAC v1 call during flag loading phase', () => {
+      useFlagsStatus.mockReturnValue({ flagsReady: false });
+      useFeatureFlag.mockReturnValue(false);
+
+      renderWithProviders(<AppWithHccContext />);
+
+      expect(useHccEnvironmentContext).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Kessel loading states', () => {
     it('does not render content while Kessel permissions are loading', () => {
       useFeatureFlag.mockReturnValue(true);
       useKesselEnvironmentContext.mockReturnValue({

--- a/src/Modules/SystemDetail.cy.js
+++ b/src/Modules/SystemDetail.cy.js
@@ -1,122 +1,84 @@
-import React, { Fragment } from 'react';
-import { IntlProvider } from 'react-intl';
-import { Provider } from 'react-redux';
-import { EnvironmentContext } from '../App';
-import { createTestEnvironmentContext } from '../../cypress/support/globals';
+import React from 'react';
+import SystemDetail from './SystemDetail';
+import { FlagProvider } from '@unleash/proxy-client-react';
 import Wrapper from '../Utilities/Wrapper';
-import { Bullseye, Spinner } from '@patternfly/react-core';
-import PropTypes from 'prop-types';
 
-const MockSystemAdvisor = () => (
-  <div data-testid="system-advisor">SystemAdvisor</div>
-);
+const mountComponent = (
+  flagsReady = true,
+  kesselEnabled = false,
+  props = {},
+) => {
+  const mockClient = {
+    on: () => {},
+    off: () => {},
+    start: () => Promise.resolve(),
+    stop: () => {},
+    updateContext: () => Promise.resolve(),
+    getVariant: () => ({ name: 'disabled', enabled: false }),
+    isEnabled: (flag) => flag === 'advisor.kessel_enabled' && kesselEnabled,
+    getAllToggles: () => [],
+    setContextField: () => {},
+    getContext: () => ({}),
+    flagsReady,
+    flagsError: null,
+  };
 
-const SystemDetailContent = ({
-  customItnl,
-  intlProps,
-  store,
-  IopRemediationModal,
-  envContext,
-}) => {
-  const WrapperComp = customItnl ? IntlProvider : Fragment;
-  const ReduxProvider = store ? Provider : Fragment;
+  cy.intercept('/api/insights/v1/account_setting/', {
+    statusCode: 200,
+    body: {},
+  });
 
-  return (
-    <EnvironmentContext.Provider value={envContext}>
-      <WrapperComp
-        {...(customItnl && {
-          locale: navigator.language.slice(0, 2),
-          messages: {},
-          ...intlProps,
-        })}
-      >
-        <ReduxProvider {...(store && { store })}>
-          <MockSystemAdvisor IopRemediationModal={IopRemediationModal} />
-        </ReduxProvider>
-      </WrapperComp>
-    </EnvironmentContext.Provider>
-  );
-};
-
-SystemDetailContent.propTypes = {
-  customItnl: PropTypes.bool,
-  intlProps: PropTypes.object,
-  store: PropTypes.object,
-  IopRemediationModal: PropTypes.elementType,
-  envContext: PropTypes.object.isRequired,
-};
-
-const MockSystemDetail = ({ showSpinner, ...props }) => {
-  const envContext = createTestEnvironmentContext();
-
-  if (showSpinner) {
-    return (
-      <Bullseye>
-        <Spinner size="lg" />
-      </Bullseye>
-    );
-  }
-
-  return <SystemDetailContent envContext={envContext} {...props} />;
-};
-
-MockSystemDetail.propTypes = {
-  showSpinner: PropTypes.bool,
-};
-
-const mountComponent = (showSpinner = false, props = {}) => {
   cy.mount(
-    <Wrapper>
-      <MockSystemDetail showSpinner={showSpinner} {...props} />
-    </Wrapper>,
+    <FlagProvider unleashClient={mockClient}>
+      <Wrapper>
+        <SystemDetail {...props} />
+      </Wrapper>
+    </FlagProvider>,
   );
 };
 
-describe('Loading states', () => {
-  it('shows loading spinner when flags not ready', () => {
-    mountComponent(true);
-
-    cy.get('.pf-v6-l-bullseye').should('exist');
+describe('Feature flag loading states', () => {
+  it('shows spinner when flags not ready', () => {
+    mountComponent(false, false);
     cy.get('.pf-v6-c-spinner').should('exist');
     cy.get('.pf-v6-c-spinner').should('have.class', 'pf-m-lg');
   });
 
-  it('renders content when flags ready', () => {
-    mountComponent(false);
+  it('renders when flags ready with RBAC v1', () => {
+    mountComponent(true, false);
+    cy.get('body').should('exist');
+  });
 
-    cy.get('.pf-v6-c-spinner').should('not.exist');
-    cy.get('[data-testid="system-advisor"]').should('exist');
+  it('renders when flags ready with Kessel enabled', () => {
+    mountComponent(true, true);
+    cy.get('body').should('exist');
   });
 });
 
 describe('Props handling', () => {
   it('handles custom internationalization', () => {
-    mountComponent(false, {
+    mountComponent(true, false, {
       customItnl: true,
       intlProps: {
         locale: 'en',
         messages: { test: 'Test' },
       },
     });
-
-    cy.get('[data-testid="system-advisor"]').should('exist');
+    cy.get('body').should('exist');
   });
 
   it('handles store prop', () => {
-    mountComponent(false, {
+    mountComponent(true, false, {
       store: null,
     });
-
-    cy.get('[data-testid="system-advisor"]').should('exist');
+    cy.get('body').should('exist');
   });
 
   it('passes IopRemediationModal prop', () => {
     const mockIopModal = () => <div>IOP</div>;
-
-    mountComponent(false, {
+    mountComponent(true, false, {
       IopRemediationModal: mockIopModal,
     });
-
-    cy.get('[data-testid="system-advisor"]').should('exist');
+    cy.get('body').should('exist');
   });
 });

--- a/src/Modules/SystemDetail.cy.js
+++ b/src/Modules/SystemDetail.cy.js
@@ -1,0 +1,122 @@
+import React, { Fragment } from 'react';
+import { IntlProvider } from 'react-intl';
+import { Provider } from 'react-redux';
+import { EnvironmentContext } from '../App';
+import { createTestEnvironmentContext } from '../../cypress/support/globals';
+import Wrapper from '../Utilities/Wrapper';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+
+const MockSystemAdvisor = () => (
+  <div data-testid="system-advisor">SystemAdvisor</div>
+);
+
+const SystemDetailContent = ({
+  customItnl,
+  intlProps,
+  store,
+  IopRemediationModal,
+  envContext,
+}) => {
+  const WrapperComp = customItnl ? IntlProvider : Fragment;
+  const ReduxProvider = store ? Provider : Fragment;
+
+  return (
+    <EnvironmentContext.Provider value={envContext}>
+      <WrapperComp
+        {...(customItnl && {
+          locale: navigator.language.slice(0, 2),
+          messages: {},
+          ...intlProps,
+        })}
+      >
+        <ReduxProvider {...(store && { store })}>
+          <MockSystemAdvisor IopRemediationModal={IopRemediationModal} />
+        </ReduxProvider>
+      </WrapperComp>
+    </EnvironmentContext.Provider>
+  );
+};
+
+SystemDetailContent.propTypes = {
+  customItnl: PropTypes.bool,
+  intlProps: PropTypes.object,
+  store: PropTypes.object,
+  IopRemediationModal: PropTypes.elementType,
+  envContext: PropTypes.object.isRequired,
+};
+
+const MockSystemDetail = ({ showSpinner, ...props }) => {
+  const envContext = createTestEnvironmentContext();
+
+  if (showSpinner) {
+    return (
+      <Bullseye>
+        <Spinner size="lg" />
+      </Bullseye>
+    );
+  }
+
+  return <SystemDetailContent envContext={envContext} {...props} />;
+};
+
+MockSystemDetail.propTypes = {
+  showSpinner: PropTypes.bool,
+};
+
+const mountComponent = (showSpinner = false, props = {}) => {
+  cy.mount(
+    <Wrapper>
+      <MockSystemDetail showSpinner={showSpinner} {...props} />
+    </Wrapper>,
+  );
+};
+
+describe('Loading states', () => {
+  it('shows loading spinner when flags not ready', () => {
+    mountComponent(true);
+
+    cy.get('.pf-v6-l-bullseye').should('exist');
+    cy.get('.pf-v6-c-spinner').should('exist');
+    cy.get('.pf-v6-c-spinner').should('have.class', 'pf-m-lg');
+  });
+
+  it('renders content when flags ready', () => {
+    mountComponent(false);
+
+    cy.get('.pf-v6-c-spinner').should('not.exist');
+    cy.get('[data-testid="system-advisor"]').should('exist');
+  });
+});
+
+describe('Props handling', () => {
+  it('handles custom internationalization', () => {
+    mountComponent(false, {
+      customItnl: true,
+      intlProps: {
+        locale: 'en',
+        messages: { test: 'Test' },
+      },
+    });
+
+    cy.get('[data-testid="system-advisor"]').should('exist');
+  });
+
+  it('handles store prop', () => {
+    mountComponent(false, {
+      store: null,
+    });
+
+    cy.get('[data-testid="system-advisor"]').should('exist');
+  });
+
+  it('passes IopRemediationModal prop', () => {
+    const mockIopModal = () => <div>IOP</div>;
+
+    mountComponent(false, {
+      IopRemediationModal: mockIopModal,
+    });
+
+    cy.get('[data-testid="system-advisor"]').should('exist');
+  });
+});

--- a/src/Modules/SystemDetail.js
+++ b/src/Modules/SystemDetail.js
@@ -7,7 +7,7 @@ import SystemAdvisor from '../SmartComponents/SystemAdvisor/SystemAdvisor';
 import { EnvironmentContext } from '../App';
 import { useHccEnvironmentContext, useFeatureFlag } from '../Utilities/Hooks';
 import { useKesselEnvironmentContext } from '../Utilities/useKesselEnvironmentContext';
-import { Spinner } from '@patternfly/react-core';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useFlagsStatus } from '@unleash/proxy-client-react';
 
 const SystemDetailContent = ({
@@ -30,7 +30,7 @@ const SystemDetailContent = ({
           ...intlProps,
         })}
       >
-        <ReduxProvider store={store}>
+        <ReduxProvider {...(store && { store })}>
           <SystemAdvisor {...props} IopRemediationModal={IopRemediationModal} />
         </ReduxProvider>
       </Wrapper>
@@ -42,7 +42,7 @@ SystemDetailContent.propTypes = {
   customItnl: PropTypes.bool,
   intlProps: PropTypes.shape({
     locale: PropTypes.string,
-    messages: PropTypes.array,
+    messages: PropTypes.objectOf(PropTypes.string),
   }),
   store: PropTypes.object,
   IopRemediationModal: PropTypes.elementType,
@@ -65,9 +65,9 @@ const SystemDetail = (props) => {
 
   if (!flagsReady) {
     return (
-      <div style={{ textAlign: 'center', padding: '2rem' }}>
+      <Bullseye>
         <Spinner size="lg" />
-      </div>
+      </Bullseye>
     );
   }
 
@@ -82,7 +82,7 @@ SystemDetail.propTypes = {
   customItnl: PropTypes.bool,
   intlProps: PropTypes.shape({
     locale: PropTypes.string,
-    messages: PropTypes.array,
+    messages: PropTypes.objectOf(PropTypes.string),
   }),
   store: PropTypes.object,
   IopRemediationModal: PropTypes.elementType,

--- a/src/Modules/SystemDetail.js
+++ b/src/Modules/SystemDetail.js
@@ -5,18 +5,22 @@ import { Provider } from 'react-redux';
 import messages from '../Messages';
 import SystemAdvisor from '../SmartComponents/SystemAdvisor/SystemAdvisor';
 import { EnvironmentContext } from '../App';
-import { useHccEnvironmentContext } from '../Utilities/Hooks';
+import { useHccEnvironmentContext, useFeatureFlag } from '../Utilities/Hooks';
+import { useKesselEnvironmentContext } from '../Utilities/useKesselEnvironmentContext';
+import { Spinner } from '@patternfly/react-core';
+import { useFlagsStatus } from '@unleash/proxy-client-react';
 
-const SystemDetail = ({
+const SystemDetailContent = ({
   customItnl,
   intlProps,
   store,
   IopRemediationModal,
+  envContext,
   ...props
 }) => {
   const Wrapper = customItnl ? IntlProvider : Fragment;
   const ReduxProvider = store ? Provider : Fragment;
-  const envContext = useHccEnvironmentContext();
+
   return (
     <EnvironmentContext.Provider value={envContext}>
       <Wrapper
@@ -31,6 +35,46 @@ const SystemDetail = ({
         </ReduxProvider>
       </Wrapper>
     </EnvironmentContext.Provider>
+  );
+};
+
+SystemDetailContent.propTypes = {
+  customItnl: PropTypes.bool,
+  intlProps: PropTypes.shape({
+    locale: PropTypes.string,
+    messages: PropTypes.array,
+  }),
+  store: PropTypes.object,
+  IopRemediationModal: PropTypes.elementType,
+  envContext: PropTypes.object.isRequired,
+};
+
+const SystemDetailWithRbacV1 = (props) => {
+  const envContext = useHccEnvironmentContext();
+  return <SystemDetailContent envContext={envContext} {...props} />;
+};
+
+const SystemDetailWithKessel = (props) => {
+  const envContext = useKesselEnvironmentContext();
+  return <SystemDetailContent envContext={envContext} {...props} />;
+};
+
+const SystemDetail = (props) => {
+  const { flagsReady } = useFlagsStatus();
+  const isKesselEnabled = useFeatureFlag('advisor.kessel_enabled');
+
+  if (!flagsReady) {
+    return (
+      <div style={{ textAlign: 'center', padding: '2rem' }}>
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  return isKesselEnabled ? (
+    <SystemDetailWithKessel {...props} />
+  ) : (
+    <SystemDetailWithRbacV1 {...props} />
   );
 };
 

--- a/src/Modules/SystemDetail.test.js
+++ b/src/Modules/SystemDetail.test.js
@@ -2,6 +2,9 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SystemDetail from './SystemDetail';
+import { useFeatureFlag, useHccEnvironmentContext } from '../Utilities/Hooks';
+import { useKesselEnvironmentContext } from '../Utilities/useKesselEnvironmentContext';
+import { useFlagsStatus } from '@unleash/proxy-client-react';
 
 // Mock the SystemAdvisor component
 jest.mock('../SmartComponents/SystemAdvisor/SystemAdvisor', () => {
@@ -16,20 +19,63 @@ jest.mock('../SmartComponents/SystemAdvisor/SystemAdvisor', () => {
   };
 });
 
-// Mock useHccEnvironmentContext hook
-jest.mock('../Utilities/Hooks', () => ({
-  useHccEnvironmentContext: jest.fn(() => ({
-    displayRecPathways: true,
-    STATS_OVERVIEW_FETCH_URL: '/api/insights/v1/stats',
-  })),
-}));
+jest.mock('../Utilities/Hooks');
+jest.mock('../Utilities/useKesselEnvironmentContext');
+jest.mock('@unleash/proxy-client-react');
 
 describe('SystemDetail', () => {
-  it('should render SystemAdvisor component', () => {
-    render(<SystemDetail />);
+  const mockRbacContext = {
+    isLoading: false,
+    displayRecPathways: true,
+    STATS_OVERVIEW_FETCH_URL: '/api/insights/v1/stats',
+  };
 
-    expect(screen.getByTestId('system-advisor-mock')).toBeInTheDocument();
-    expect(screen.getByText('System Advisor Component')).toBeInTheDocument();
+  const mockKesselContext = {
+    isLoading: false,
+    displayRecPathways: true,
+    STATS_OVERVIEW_FETCH_URL: '/api/insights/v1/stats',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useHccEnvironmentContext.mockReturnValue(mockRbacContext);
+    useKesselEnvironmentContext.mockReturnValue(mockKesselContext);
+    useFlagsStatus.mockReturnValue({ flagsReady: true });
+    useFeatureFlag.mockReturnValue(false);
+  });
+
+  describe('Feature Flag Loading', () => {
+    it('should show spinner while feature flags are loading', () => {
+      useFlagsStatus.mockReturnValue({ flagsReady: false });
+
+      render(<SystemDetail />);
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('system-advisor-mock'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('RBAC v1 Mode (Kessel Disabled)', () => {
+    beforeEach(() => {
+      useFlagsStatus.mockReturnValue({ flagsReady: true });
+      useFeatureFlag.mockReturnValue(false);
+    });
+
+    it('should render SystemAdvisor component', () => {
+      render(<SystemDetail />);
+
+      expect(screen.getByTestId('system-advisor-mock')).toBeInTheDocument();
+      expect(screen.getByText('System Advisor Component')).toBeInTheDocument();
+    });
+
+    it('should use RBAC v1 context when Kessel flag is disabled', () => {
+      render(<SystemDetail />);
+
+      expect(useHccEnvironmentContext).toHaveBeenCalled();
+      expect(useKesselEnvironmentContext).not.toHaveBeenCalled();
+    });
   });
 
   it('should pass props to SystemAdvisor', () => {
@@ -130,5 +176,63 @@ describe('SystemDetail', () => {
 
     expect(screen.getByTestId('system-advisor-mock')).toBeInTheDocument();
     expect(screen.getByText('IopRemediationModal Present')).toBeInTheDocument();
+  });
+
+  describe('Kessel Mode (Kessel Enabled)', () => {
+    beforeEach(() => {
+      useFlagsStatus.mockReturnValue({ flagsReady: true });
+      useFeatureFlag.mockReturnValue(true);
+    });
+
+    it('should use Kessel context when Kessel flag is enabled', () => {
+      render(<SystemDetail />);
+
+      expect(useKesselEnvironmentContext).toHaveBeenCalled();
+      expect(useHccEnvironmentContext).not.toHaveBeenCalled();
+    });
+
+    it('should render SystemAdvisor with Kessel context', () => {
+      render(<SystemDetail />);
+
+      expect(screen.getByTestId('system-advisor-mock')).toBeInTheDocument();
+    });
+
+    it('should pass IopRemediationModal in Kessel mode', () => {
+      const MockModal = () => <div>Modal</div>;
+
+      render(<SystemDetail IopRemediationModal={MockModal} />);
+
+      expect(
+        screen.getByText('IopRemediationModal Present'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Kessel and RBAC v1 integration', () => {
+    it('avoids calling RBAC v1 when Kessel is enabled', () => {
+      useFlagsStatus.mockReturnValue({ flagsReady: true });
+      useFeatureFlag.mockReturnValue(true);
+
+      render(<SystemDetail />);
+
+      expect(useHccEnvironmentContext).not.toHaveBeenCalled();
+      expect(useKesselEnvironmentContext).toHaveBeenCalled();
+    });
+
+    it('switches between context providers when feature flag changes', () => {
+      const { rerender } = render(<SystemDetail />);
+
+      useFlagsStatus.mockReturnValue({ flagsReady: true });
+      useFeatureFlag.mockReturnValue(false);
+      rerender(<SystemDetail />);
+      expect(useHccEnvironmentContext).toHaveBeenCalled();
+
+      jest.clearAllMocks();
+
+      useFeatureFlag.mockReturnValue(true);
+      rerender(<SystemDetail />);
+      expect(useKesselEnvironmentContext).toHaveBeenCalled();
+      expect(useHccEnvironmentContext).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
# Description
Fixed RBAC v1 race condition in App.js by waiting for feature flags before rendering any context, then cleaned up the PR. added 4 new tests for flag loading states

## Summary by Sourcery

Gate environment context selection on feature flag readiness and route SystemDetail and App through either RBAC v1 or Kessel contexts based on loaded flags.

Bug Fixes:
- Prevent RBAC v1 context from being called before feature flags are loaded or when the Kessel feature is enabled, avoiding race conditions in context initialization.

Enhancements:
- Introduce a dedicated SystemDetailContent component that consumes an injected environment context, with thin wrappers for RBAC v1 and Kessel modes.
- Show a loading spinner in SystemDetail while feature flags are still loading, improving user feedback during initialization.

Tests:
- Expand App and SystemDetail tests to cover feature flag loading states, context selection between RBAC v1 and Kessel, and avoidance of RBAC v1 calls when Kessel is enabled.