### PR TITLE
feat(RHINENG-23855): Propagate all impacting rules to the Rem. plan when creating from Pathways

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -7,6 +7,7 @@ import { useDispatch, useSelector, useStore } from 'react-redux';
 import {
   getEntities,
   allCurrentSystemIds,
+  fetchAllPathwayRules,
   iopResolutionsMapper,
   impactedDateColumn,
   lastSeenColumn,
@@ -182,13 +183,14 @@ const Inventory = ({
     if (!hasPathwayDetails) {
       if (pathway) {
         try {
-          const rulesRes = await axios.get(
-            `${envContext.BASE_URL}/pathway/${encodeURI(pathway.slug)}/rules/`,
+          const pathwayRulesFromApi = await fetchAllPathwayRules(
+            axios,
+            envContext.BASE_URL,
+            pathway.slug,
           );
           const reportsRes = await axios.get(
             `${envContext.BASE_URL}/pathway/${encodeURI(pathway.slug)}/reports/`,
           );
-          const pathwayRulesFromApi = rulesRes?.data ?? [];
           const pathwayReportRules =
             reportsRes?.data?.rules ?? reportsRes?.rules ?? {};
           setHasPathwayDetails(true);

--- a/src/PresentationalComponents/Inventory/Inventory.test.js
+++ b/src/PresentationalComponents/Inventory/Inventory.test.js
@@ -443,14 +443,17 @@ describe('Inventory - Playbook Count Scenarios', () => {
       );
 
       await waitFor(() => {
-        expect(mockAxiosGet).toHaveBeenCalledWith(
-          expect.stringContaining('/pathway/test-pathway/rules/'),
-        );
+        expect(mockAxiosGet).toHaveBeenCalledWith('/api/insights/v1/rule/', {
+          params: {
+            pathway: 'test-pathway',
+            impacting: true,
+          },
+        });
       });
 
       const calls = mockAxiosGet.mock.calls;
       const ruleCalls = calls.filter(
-        ([url]) => url.includes('/rule/') && !url.includes('/pathway/'),
+        ([url]) => url.includes('/rule/') && url.includes('/test-rule-123/'),
       );
       expect(ruleCalls.length).toBe(0);
     });
@@ -468,9 +471,12 @@ describe('Inventory - Playbook Count Scenarios', () => {
       );
 
       await waitFor(() => {
-        expect(mockAxiosGet).toHaveBeenCalledWith(
-          expect.stringContaining('/pathway/test-pathway/rules/'),
-        );
+        expect(mockAxiosGet).toHaveBeenCalledWith('/api/insights/v1/rule/', {
+          params: {
+            pathway: 'test-pathway',
+            impacting: true,
+          },
+        });
       });
 
       await waitFor(() => {
@@ -494,9 +500,12 @@ describe('Inventory - Playbook Count Scenarios', () => {
       );
 
       await waitFor(() => {
-        expect(mockAxiosGet).toHaveBeenCalledWith(
-          expect.stringContaining('/pathway/test-pathway/rules/'),
-        );
+        expect(mockAxiosGet).toHaveBeenCalledWith('/api/insights/v1/rule/', {
+          params: {
+            pathway: 'test-pathway',
+            impacting: true,
+          },
+        });
       });
 
       await waitFor(() => {
@@ -517,9 +526,12 @@ describe('Inventory - Playbook Count Scenarios', () => {
       );
 
       await waitFor(() => {
-        expect(mockAxiosGet).toHaveBeenCalledWith(
-          expect.stringContaining('/pathway/test-pathway/rules/'),
-        );
+        expect(mockAxiosGet).toHaveBeenCalledWith('/api/insights/v1/rule/', {
+          params: {
+            pathway: 'test-pathway',
+            impacting: true,
+          },
+        });
       });
 
       await waitFor(() => {

--- a/src/PresentationalComponents/Inventory/helpers.js
+++ b/src/PresentationalComponents/Inventory/helpers.js
@@ -68,6 +68,51 @@ export const paginatedRequestHelper = async ({
 };
 
 /**
+ * Fetches all impacting rules for a pathway from the rules endpoint.
+ * Uses the same `/rule/` API filtering as the Pathway Recommendations table
+ * and fetches all pages so remediation logic can work with the full rule set.
+ *
+ * @param {Object} axios Axios instance for making requests
+ * @param {string} baseUrl Base URL for Advisor API
+ * @param {string} pathwaySlug Pathway slug used for filtering rules
+ * @returns {Promise<Array>} Array of all impacting rules for the pathway
+ */
+export const fetchAllPathwayRules = async (axios, baseUrl, pathwaySlug) => {
+  const rulesFetchUrl = `${baseUrl}/rule/`;
+  const options = {
+    pathway: pathwaySlug,
+    impacting: true,
+  };
+  const firstPageResponse = await axios.get(rulesFetchUrl, {
+    params: options,
+  });
+  const pathwayRules = firstPageResponse?.data ?? [];
+  const totalRules = firstPageResponse?.meta?.count ?? pathwayRules.length;
+  const pageLimit = pathwayRules.length;
+
+  if (pageLimit === 0 || totalRules <= pageLimit) {
+    return pathwayRules;
+  }
+
+  const remainingPageRequests = Array.from(
+    { length: Math.ceil((totalRules - pageLimit) / pageLimit) },
+    (_, pageIndex) =>
+      axios.get(rulesFetchUrl, {
+        params: {
+          ...options,
+          limit: pageLimit,
+          offset: pageLimit * (pageIndex + 1),
+        },
+      }),
+  );
+  const remainingPathwayRules = (
+    await Promise.all(remainingPageRequests)
+  ).flatMap((response) => response?.data ?? []);
+
+  return [...pathwayRules, ...remainingPathwayRules];
+};
+
+/**
  * Factory function that creates an entity fetcher for the Inventory table.
  * Fetches systems from Advisor API, filters out systems not in Inventory (last_seen: null),
  * then enriches the data with Inventory API details.

--- a/src/PresentationalComponents/Inventory/helpers.test.js
+++ b/src/PresentationalComponents/Inventory/helpers.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import {
   paginatedRequestHelper,
+  fetchAllPathwayRules,
   getEntities,
   allCurrentSystemIds,
   iopResolutionsMapper,
@@ -330,6 +331,96 @@ describe('Inventory helpers', () => {
       );
       expect(serialized).not.toContain('category[0]');
       expect(serialized).not.toContain('category[]');
+    });
+  });
+
+  describe('fetchAllPathwayRules', () => {
+    const mockAxios = {
+      get: mockAxiosGet,
+    };
+
+    it('returns the first page when the pathway fits in one response', async () => {
+      mockAxiosGet.mockResolvedValueOnce({
+        data: [{ rule_id: 'rule-1' }],
+        meta: { count: 1 },
+      });
+
+      const result = await fetchAllPathwayRules(
+        mockAxios,
+        '/api/insights/v1',
+        'test-pathway',
+      );
+
+      expect(mockAxiosGet).toHaveBeenCalledTimes(1);
+      expect(mockAxiosGet).toHaveBeenCalledWith('/api/insights/v1/rule/', {
+        params: {
+          pathway: 'test-pathway',
+          impacting: true,
+        },
+      });
+      expect(result).toEqual([{ rule_id: 'rule-1' }]);
+    });
+
+    it('fetches the remaining rule pages when a pathway spans multiple pages', async () => {
+      mockAxiosGet
+        .mockResolvedValueOnce({
+          data: [{ rule_id: 'rule-1' }, { rule_id: 'rule-2' }],
+          meta: { count: 5 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ rule_id: 'rule-3' }, { rule_id: 'rule-4' }],
+        })
+        .mockResolvedValueOnce({
+          data: [{ rule_id: 'rule-5' }],
+        });
+
+      const result = await fetchAllPathwayRules(
+        mockAxios,
+        '/api/insights/v1',
+        'test-pathway',
+      );
+
+      expect(mockAxiosGet).toHaveBeenNthCalledWith(
+        1,
+        '/api/insights/v1/rule/',
+        {
+          params: {
+            pathway: 'test-pathway',
+            impacting: true,
+          },
+        },
+      );
+      expect(mockAxiosGet).toHaveBeenNthCalledWith(
+        2,
+        '/api/insights/v1/rule/',
+        {
+          params: {
+            pathway: 'test-pathway',
+            impacting: true,
+            limit: 2,
+            offset: 2,
+          },
+        },
+      );
+      expect(mockAxiosGet).toHaveBeenNthCalledWith(
+        3,
+        '/api/insights/v1/rule/',
+        {
+          params: {
+            pathway: 'test-pathway',
+            impacting: true,
+            limit: 2,
+            offset: 4,
+          },
+        },
+      );
+      expect(result).toEqual([
+        { rule_id: 'rule-1' },
+        { rule_id: 'rule-2' },
+        { rule_id: 'rule-3' },
+        { rule_id: 'rule-4' },
+        { rule_id: 'rule-5' },
+      ]);
     });
   });
 


### PR DESCRIPTION
# Description

Associated Jira ticket: [RHINENG-23855](https://redhat.atlassian.net/browse/RHINENG-23855)
Co-authored-by: Cursor

This fixes fetching of rules when adding Pathway's system to the remediation plan. Code now uses the `GET /rule/?pathway=<slug>&impacting=true` endpoint instead of the `GET /pathway/:slug/rules` in order to filter out non impacting rules with the `impacting=true` filter, and thus avoiding going through all the pathway rules.

# How to test the PR

1. Visit the Pathway Detail page > Systems table.
2. Select a system
3. Open Remediation Creation modal and create remediation
4. Check that remediation plan contains all system-affecting recommendations from the pathway's list of recommendations

The test procedure^^ is the best to be repeated with different systems, or multiple systems at once. It is also good to select all the systems, and check that all Pathway's recommendations (that are listed in the Pathway Detail page > Recommendations table) ale added to the plan.


# Before the change

Despite selecting all the systems, only one recommendation is addded to the plan (one Advisor recommendation is worth 20 action points).
<img width="2502" height="1389" alt="image" src="https://github.com/user-attachments/assets/a2ff7940-6487-434b-9328-7d06283a7880" />



# After the change

All Pathway's recommendations tied to the selected systems are added to the plan.
<img width="2502" height="1389" alt="image" src="https://github.com/user-attachments/assets/7ef6e8aa-406e-494b-b433-f4171a5c729a" />



# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work


[RHINENG-23855]: https://redhat.atlassian.net/browse/RHINENG-23855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Ensure remediation plans created from Pathways include all impacting rules for selected systems by aligning rule fetching with the recommendations view and supporting pagination.

New Features:
- Add a helper to retrieve all impacting rules for a pathway via the generic rules endpoint with full pagination support.

Enhancements:
- Update Inventory remediation creation logic to use the impacting-only rules endpoint so pathway-based plans consider the complete set of relevant rules.

Tests:
- Add unit tests for the new pathway rules fetching helper and update Inventory tests to reflect the new rules endpoint and parameters.