### PR TITLE
fix(RHINENG-25696): fixed chart styles in dark mode

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,3 +1,6 @@
+// PatternFly charts - required for chart dark theme support
+@import '@patternfly/patternfly/patternfly-charts.css';
+
 // Style overrides
 .adv__background--global-100 {
   background-color: var(--pf-v6-global--BackgroundColor--100);

--- a/src/PresentationalComponents/Cards/TotalRiskCard.js
+++ b/src/PresentationalComponents/Cards/TotalRiskCard.js
@@ -18,10 +18,12 @@ import {
   GridItem,
 } from '@patternfly/react-core/dist/esm/layouts/Grid/index';
 import {
-  t_global_icon_color_severity_critical_default,
-  t_global_icon_color_severity_important_default,
-  t_global_icon_color_severity_moderate_default,
-  t_global_background_color_200,
+  t_chart_global_danger_color_100,
+  t_chart_global_warning_color_100,
+  t_chart_global_warning_color_200,
+  t_chart_color_black_300,
+  t_global_text_color_regular,
+  t_global_border_color_default,
 } from '@patternfly/react-tokens';
 
 import React from 'react';
@@ -77,8 +79,21 @@ export const TotalRiskCard = (props) => {
                   top: 10,
                 }}
               >
-                <ChartAxis />
-                <ChartAxis dependentAxis showGrid />
+                <ChartAxis
+                  style={{
+                    tickLabels: { fill: t_global_text_color_regular.var },
+                    axis: { stroke: t_global_border_color_default.var },
+                  }}
+                />
+                <ChartAxis
+                  dependentAxis
+                  showGrid
+                  style={{
+                    tickLabels: { fill: t_global_text_color_regular.var },
+                    axis: { stroke: t_global_border_color_default.var },
+                    grid: { stroke: t_global_border_color_default.var },
+                  }}
+                />
                 <ChartGroup>
                   <ChartBar
                     barWidth={16}
@@ -92,25 +107,25 @@ export const TotalRiskCard = (props) => {
                         name: 'Critical',
                         x: 'Critical',
                         y: critical_risk_count,
-                        fill: t_global_icon_color_severity_critical_default.value,
+                        fill: t_chart_global_danger_color_100.var,
                       },
                       {
                         name: 'Important',
                         x: 'Important',
                         y: high_risk_count,
-                        fill: t_global_icon_color_severity_important_default.value,
+                        fill: t_chart_global_warning_color_100.var,
                       },
                       {
                         name: 'Moderate',
                         x: 'Moderate',
                         y: medium_risk_count,
-                        fill: t_global_icon_color_severity_moderate_default.value,
+                        fill: t_chart_global_warning_color_200.var,
                       },
                       {
                         name: 'Low',
                         x: 'Low',
                         y: low_risk_count,
-                        fill: t_global_background_color_200.value,
+                        fill: t_chart_color_black_300.var,
                       },
                     ]}
                   />

--- a/src/PresentationalComponents/Common/Common.js
+++ b/src/PresentationalComponents/Common/Common.js
@@ -36,7 +36,7 @@ const RebootRequired = (reboot_required) => (
           : 'adv-c-icon-no-reboot-required'
       }
     />
-    <Content className="adv-c-text-system-reboot-message pf-v6-u-font-size-sm">
+    <Content className="adv-c-text-system-reboot-message pf-v6-u-font-size-sm pf-v6-u-ml-sm">
       <Content component={ContentVariants.p}>
         {intl.formatMessage(messages.systemReboot, {
           strong: (str) => strong(str),


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)
https://redhat.atlassian.net/browse/RHINENG-25696
On the right side where text "System reboot is required." there was no break/gap between reboot icon and text, I added a break/gap.
There were a couple of issues with Pathways details tab chart
Chart colours were wrong to begin with + they didn't change with the dark theme
<img width="1280" height="454" alt="image" src="https://github.com/user-attachments/assets/890f8dba-a8bc-47b3-aceb-a5227f845f9e" />



Fixed styles for chart bars and "ticks" to change with a theme
<img width="1280" height="454" alt="image" src="https://github.com/user-attachments/assets/37658616-ae09-41fb-bde4-ab9f96798bd0" />

## Summary by Sourcery

Align chart styling and reboot-required messaging with PatternFly theming and spacing guidelines.

Bug Fixes:
- Ensure chart axis ticks, labels, and grid adopt the correct colors for light and dark themes.
- Correct chart bar colors to use PatternFly chart tokens for risk severity levels.
- Add spacing between the reboot-required icon and its message text to improve readability.

Enhancements:
- Import PatternFly chart styles globally to enable theme-aware chart rendering.