### PR TITLE
fix(RHINENG-25936): Remove double URI encoding from tag filter parameters

### DIFF
--- a/src/PresentationalComponents/Common/Tables.js
+++ b/src/PresentationalComponents/Common/Tables.js
@@ -37,10 +37,7 @@ export const buildTagFilter = (tagFilters) => {
     ? {
         tags: tagFilters.flatMap((tagFilter) =>
           tagFilter.values.map(
-            (tag) =>
-              `${encodeURIComponent(tagFilter.key)}/${encodeURIComponent(
-                tag.tagKey,
-              )}=${encodeURIComponent(tag.value)}`,
+            (tag) => `${tagFilter.key}/${tag.tagKey}=${tag.value}`,
           ),
         ),
       }

--- a/src/PresentationalComponents/Common/__tests__/Tables.tests.js
+++ b/src/PresentationalComponents/Common/__tests__/Tables.tests.js
@@ -1,6 +1,7 @@
 import {
   workloadQueryBuilder,
   mapUpdateMethodFilterToAPISpec,
+  buildTagFilter,
 } from '../Tables';
 import fixtures from './Tables.fixtures';
 
@@ -85,5 +86,140 @@ describe('mapUpdateMethodFilterToAPISpec', () => {
   test('should remove impacting filter when it is equal to empty string', () => {
     const result = mapUpdateMethodFilterToAPISpec({ impacting: '' });
     expect(result).toEqual({});
+  });
+});
+
+describe('buildTagFilter', () => {
+  test('returns empty object when tagFilters is undefined', () => {
+    expect(buildTagFilter(undefined)).toEqual({});
+  });
+
+  test('returns empty object when tagFilters is null', () => {
+    expect(buildTagFilter(null)).toEqual({});
+  });
+
+  test('returns empty tags array when tagFilters is an empty array', () => {
+    expect(buildTagFilter([])).toEqual({ tags: [] });
+  });
+
+  test('builds tag filter from a single namespace with one tag', () => {
+    const tagFilters = [
+      {
+        key: 'insights-client',
+        values: [{ tagKey: 'group', value: 'prod' }],
+      },
+    ];
+
+    expect(buildTagFilter(tagFilters)).toEqual({
+      tags: ['insights-client/group=prod'],
+    });
+  });
+
+  test('builds tag filter from a single namespace with multiple tags', () => {
+    const tagFilters = [
+      {
+        key: 'insights-client',
+        values: [
+          { tagKey: 'group', value: 'prod' },
+          { tagKey: 'env', value: 'us-east-1' },
+        ],
+      },
+    ];
+
+    expect(buildTagFilter(tagFilters)).toEqual({
+      tags: ['insights-client/group=prod', 'insights-client/env=us-east-1'],
+    });
+  });
+
+  test('builds tag filter from multiple namespaces', () => {
+    const tagFilters = [
+      {
+        key: 'insights-client',
+        values: [{ tagKey: 'group', value: 'prod' }],
+      },
+      {
+        key: 'satellite',
+        values: [{ tagKey: 'location', value: 'raleigh' }],
+      },
+    ];
+
+    expect(buildTagFilter(tagFilters)).toEqual({
+      tags: ['insights-client/group=prod', 'satellite/location=raleigh'],
+    });
+  });
+
+  // Tag values with special characters must NOT be URI-encoded by
+  // buildTagFilter, since the HTTP client handles encoding.
+  test('does not URI-encode tag values with special characters', () => {
+    const tagFilters = [
+      {
+        key: 'insights-client',
+        values: [{ tagKey: 'group', value: 'prod & staging' }],
+      },
+    ];
+
+    const result = buildTagFilter(tagFilters);
+
+    // Current (correct): raw value preserved, no encoding
+    expect(result).toEqual({
+      tags: ['insights-client/group=prod & staging'],
+    });
+
+    // Verify it does NOT contain encoded values (the old bug)
+    expect(result.tags[0]).not.toContain('%26');
+    expect(result.tags[0]).not.toContain('%20');
+  });
+
+  test('does not URI-encode tag keys with special characters', () => {
+    const tagFilters = [
+      {
+        key: 'my namespace',
+        values: [{ tagKey: 'tag/key', value: 'value' }],
+      },
+    ];
+
+    const result = buildTagFilter(tagFilters);
+
+    expect(result).toEqual({
+      tags: ['my namespace/tag/key=value'],
+    });
+
+    // Verify no encoding was applied
+    expect(result.tags[0]).not.toContain('%2F');
+    expect(result.tags[0]).not.toContain('%20');
+  });
+
+  test('does not URI-encode spaces in tag key names', () => {
+    const tagFilters = [
+      {
+        key: 'insights-client',
+        values: [{ tagKey: 'host group', value: 'prod' }],
+      },
+    ];
+
+    const result = buildTagFilter(tagFilters);
+
+    expect(result).toEqual({
+      tags: ['insights-client/host group=prod'],
+    });
+
+    expect(result.tags[0]).not.toContain('%20');
+  });
+
+  test('does not URI-encode equals signs in tag values', () => {
+    const tagFilters = [
+      {
+        key: 'ns',
+        values: [{ tagKey: 'expr', value: 'a=b' }],
+      },
+    ];
+
+    const result = buildTagFilter(tagFilters);
+
+    expect(result).toEqual({
+      tags: ['ns/expr=a=b'],
+    });
+
+    expect(result.tags[0]).not.toContain('%3D');
   });
 });


### PR DESCRIPTION
Removed encodeURIComponent() calls from buildTagFilter, which were double-encoding tag namespace, key, and value strings (the axios Qs.stringify already handles encoding).

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Fix tag filter construction to avoid double URI encoding of tag components and align behavior with HTTP client expectations.

Bug Fixes:
- Stop URI-encoding tag namespace, key, and value in buildTagFilter so tags are not double-encoded when sent to the API.

Tests:
- Add comprehensive unit tests for buildTagFilter, including handling of empty inputs and tag components containing spaces, special characters, and equals signs.