### PR TITLE
fix(RHINENG-26571): add missing access check provider to advisor fed module

### DIFF
--- a/src/Modules/SystemDetail.js
+++ b/src/Modules/SystemDetail.js
@@ -80,16 +80,6 @@ const SystemDetailWithContextProviders = (props) => {
   );
 };
 
-SystemDetailWithContextProviders.propTypes = {
-  customItnl: PropTypes.bool,
-  intlProps: PropTypes.shape({
-    locale: PropTypes.string,
-    messages: PropTypes.objectOf(PropTypes.string),
-  }),
-  store: PropTypes.object,
-  IopRemediationModal: PropTypes.elementType,
-};
-
 const SystemDetail = (props) => {
   return (
     <AccessCheck.Provider

--- a/src/Modules/SystemDetail.js
+++ b/src/Modules/SystemDetail.js
@@ -101,4 +101,14 @@ const SystemDetail = (props) => {
   );
 };
 
+SystemDetail.propTypes = {
+  customItnl: PropTypes.bool,
+  intlProps: PropTypes.shape({
+    locale: PropTypes.string,
+    messages: PropTypes.objectOf(PropTypes.string),
+  }),
+  store: PropTypes.object,
+  IopRemediationModal: PropTypes.elementType,
+};
+
 export default SystemDetail;

--- a/src/Modules/SystemDetail.js
+++ b/src/Modules/SystemDetail.js
@@ -9,6 +9,8 @@ import { useHccEnvironmentContext, useFeatureFlag } from '../Utilities/Hooks';
 import { useKesselEnvironmentContext } from '../Utilities/useKesselEnvironmentContext';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useFlagsStatus } from '@unleash/proxy-client-react';
+import { AccessCheck } from '@project-kessel/react-kessel-access-check';
+import { KESSEL_API_BASE_URL } from '../AppConstants';
 
 const SystemDetailContent = ({
   customItnl,
@@ -59,7 +61,7 @@ const SystemDetailWithKessel = (props) => {
   return <SystemDetailContent envContext={envContext} {...props} />;
 };
 
-const SystemDetail = (props) => {
+const SystemDetailWithContextProviders = (props) => {
   const { flagsReady } = useFlagsStatus();
   const isKesselEnabled = useFeatureFlag('advisor.kessel_enabled');
 
@@ -78,7 +80,7 @@ const SystemDetail = (props) => {
   );
 };
 
-SystemDetail.propTypes = {
+SystemDetailWithContextProviders.propTypes = {
   customItnl: PropTypes.bool,
   intlProps: PropTypes.shape({
     locale: PropTypes.string,
@@ -86,6 +88,17 @@ SystemDetail.propTypes = {
   }),
   store: PropTypes.object,
   IopRemediationModal: PropTypes.elementType,
+};
+
+const SystemDetail = (props) => {
+  return (
+    <AccessCheck.Provider
+      baseUrl={window.location.origin}
+      apiPath={KESSEL_API_BASE_URL}
+    >
+      <SystemDetailWithContextProviders {...props} />
+    </AccessCheck.Provider>
+  );
 };
 
 export default SystemDetail;

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -42,6 +42,8 @@ import { EnvironmentContext } from '../../App';
 import { fetchResolutionsData, isAbortError } from './helpers';
 import DownloadPlaybookButton from '../../Utilities/DownloadPlaybookButton';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/';
+import useAdvisorReports from './useAdvisorReports';
+import { InventoryReportFetchFailed } from './EmptyStates';
 
 const BaseSystemAdvisor = ({
   entity,
@@ -76,6 +78,12 @@ const BaseSystemAdvisor = ({
   const selectedTags = useSelector(({ filters }) => filters?.selectedTags);
   const workloads = useSelector(({ filters }) => filters?.workloads);
   const envContext = useContext(EnvironmentContext);
+
+  const {
+    reportsData,
+    loading: reportsLoading,
+    error: reportsError,
+  } = useAdvisorReports(inventoryId, envContext, { skip: false });
 
   const getSelectedItems = (rows) => rows.filter((row) => row.selected);
   const selectedAnsibleRules = useMemo(() => {
@@ -358,17 +366,18 @@ const BaseSystemAdvisor = ({
   const fetchKbaDetails = async (reportsData, signal) => {
     const kbaIds = reportsData.map(({ rule }) => rule.node_id).filter((x) => x);
     try {
-      const kbaDetailsFetch = (
-        await axios.get(
-          `https://access.redhat.com/hydra/rest/search/kcs?q=id:(${kbaIds.join(
-            ` OR `,
-          )})&fq=documentKind:(Solution%20or%20Article)&fl=view_uri,id,publishedTitle&redhat_client=$ADVISOR`,
-          {
-            params: { credentials: 'include' },
-            signal,
-          },
-        )
-      ).response.docs;
+      const kbaDetailsFetch =
+        (
+          await axios.get(
+            `https://access.redhat.com/hydra/rest/search/kcs?q=id:(${kbaIds.join(
+              ` OR `,
+            )})&fq=documentKind:(Solution%20or%20Article)&fl=view_uri,id,publishedTitle&redhat_client=$ADVISOR`,
+            {
+              params: { credentials: 'include' },
+              signal,
+            },
+          )
+        )?.response?.docs || [];
 
       setKbaDetailsData(kbaDetailsFetch);
       setRows(
@@ -478,18 +487,20 @@ const BaseSystemAdvisor = ({
 
   useEffect(() => {
     const dataFetch = async () => {
-      try {
-        const reportsFetch = await axios.get(
-          `${envContext.BASE_URL}/system/${inventoryId}/reports/`,
-          {
-            headers: {
-              credentials: 'include',
-            },
-            signal: abortControllerRef.current.signal,
-          },
-        );
+      if (reportsLoading) {
+        setInventoryReportFetchStatus('pending');
+        return;
+      }
 
-        const activeRuleFirstReportsData = activeRuleFirst(reportsFetch);
+      if (reportsError) {
+        setInventoryReportFetchStatus('failed');
+        setSystemsProfileLoading(false);
+        return;
+      }
+
+      try {
+        const activeRuleFirstReportsData = activeRuleFirst(reportsData);
+
         if (envContext.loadChromeless) {
           const kbaDetailsIOP = getKbaDetailsIOP(activeRuleFirstReportsData);
           setKbaDetailsData(kbaDetailsIOP);
@@ -509,8 +520,8 @@ const BaseSystemAdvisor = ({
             abortControllerRef.current.signal,
           );
         }
-        setInventoryReportFetchStatus('fulfilled');
         setActiveReports(activeRuleFirstReportsData);
+        setInventoryReportFetchStatus('fulfilled');
 
         const profileData = await axios.get(
           `${envContext.INVENTORY_BASE_URL}/hosts/${inventoryId}/system_profile`,
@@ -557,7 +568,7 @@ const BaseSystemAdvisor = ({
       abortControllerRef.current = new AbortController();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [axios, inventoryId, envContext, addNotification]);
+  }, [reportsData, reportsLoading, reportsError, inventoryId]);
   // eslint-disable-next-line react/prop-types
   let display_name = entity?.display_name;
   return inventoryReportFetchStatus === 'fulfilled' &&
@@ -615,6 +626,9 @@ const BaseSystemAdvisor = ({
       )}
       {inventoryReportFetchStatus === 'pending' && (
         <SkeletonTable columns={cols.map((c) => c.title)} variant="compact" />
+      )}
+      {inventoryReportFetchStatus === 'failed' && (
+        <InventoryReportFetchFailed entity={entity} />
       )}
       {inventoryReportFetchStatus === 'fulfilled' && (
         <Fragment>

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisorAssets.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisorAssets.js
@@ -161,9 +161,12 @@ export const useBuildRows = (
       const builtRows = newActiveReportsList.flatMap((value, key) => {
         const rule = value.rule;
         const resolution = value.resolution;
-        const kbaDetail = Object.keys(kbaDetails).length
-          ? kbaDetails.filter((article) => article.id === value.rule.node_id)[0]
-          : {};
+        const kbaDetail =
+          kbaDetails && Array.isArray(kbaDetails) && kbaDetails.length
+            ? kbaDetails.filter(
+                (article) => article.id === value.rule.node_id,
+              )[0]
+            : {};
         const match = rows.find((row) => row?.rule?.rule_id === rule.rule_id);
         const selected = match?.selected;
         const isOpen =

--- a/src/SmartComponents/SystemAdvisor/useAdvisorReports.js
+++ b/src/SmartComponents/SystemAdvisor/useAdvisorReports.js
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import { isAbortError } from './helpers';
+
+const useAdvisorReports = (inventoryId, envContext, { skip = false } = {}) => {
+  const [loading, setLoading] = useState(true);
+  const [reportsData, setReportsData] = useState([]);
+  const [error, setError] = useState(null);
+  const axios = useAxiosWithPlatformInterceptors();
+
+  useEffect(() => {
+    if (skip) {
+      setLoading(false);
+      return;
+    }
+
+    const fetchData = async () => {
+      const abortController = new AbortController();
+
+      try {
+        setLoading(true);
+
+        const reportsResponse = await axios.get(
+          `${envContext.BASE_URL}/system/${inventoryId}/reports/`,
+          {
+            headers: {
+              credentials: 'include',
+            },
+            signal: abortController.signal,
+          },
+        );
+
+        const reportsFetch = Array.isArray(reportsResponse)
+          ? reportsResponse
+          : reportsResponse?.data || [];
+
+        setReportsData(reportsFetch);
+        setLoading(false);
+      } catch (err) {
+        if (isAbortError(err)) {
+          return;
+        }
+        setError(err);
+        setLoading(false);
+      }
+
+      return () => {
+        abortController.abort();
+      };
+    };
+
+    fetchData();
+  }, [inventoryId, envContext, axios, skip]);
+
+  return { reportsData, loading, error };
+};
+
+export default useAdvisorReports;

--- a/src/SmartComponents/SystemAdvisor/useAdvisorReports.js
+++ b/src/SmartComponents/SystemAdvisor/useAdvisorReports.js
@@ -32,7 +32,7 @@ const useAdvisorReports = (inventoryId, envContext, { skip = false } = {}) => {
 
         const reportsFetch = Array.isArray(reportsResponse)
           ? reportsResponse
-          : reportsResponse?.data || [];
+          : reportsResponse.data || [];
 
         setReportsData(reportsFetch);
         setLoading(false);


### PR DESCRIPTION
Associated Jira ticket: # (issue)
https://redhat.atlassian.net/browse/RHINENG-26751
Please include a summary of the change, what this fixes/creates/improves.

Advisor was missing access check provider in inventory system details
For example: https://stage.foo.redhat.com:1337/insights/inventory/000f994b-291f-4dd6-b220-b1cacb95d4ce?appName=advisor

1. Added missing AccessCheck.Provider wrapper to the SystemDetail module federation export to enable Kessel permission checks in the inventory integration. 
3. Fixed race condition in SystemAdvisor data fetching by extracting fetch logic into a useAdvisorReports custom hook, which properly manages loading/error states and prevents state updates on unmounted components. 
4. Added propTypes to the exported SystemDetail component for proper prop validation by module federation consumers.
