### PR TITLE
fix(RHINENG-8555): Handle empty tag filter values

### DIFF
--- a/src/PresentationalComponents/Common/Tables.js
+++ b/src/PresentationalComponents/Common/Tables.js
@@ -37,7 +37,8 @@ export const buildTagFilter = (tagFilters) => {
     ? {
         tags: tagFilters.flatMap((tagFilter) =>
           tagFilter.values.map(
-            (tag) => `${tagFilter.key}/${tag.tagKey}=${tag.value}`,
+            (tag) =>
+              `${tagFilter.key}/${tag.tagKey}=${tag.value != null && tag.value !== '' ? `${tag.value}` : ''}`,
           ),
         ),
       }

--- a/src/PresentationalComponents/Common/__tests__/Tables.tests.js
+++ b/src/PresentationalComponents/Common/__tests__/Tables.tests.js
@@ -206,6 +206,71 @@ describe('buildTagFilter', () => {
     expect(result.tags[0]).not.toContain('%20');
   });
 
+  test('omits value but keeps = when tag value is empty string', () => {
+    const tagFilters = [
+      {
+        key: 'insights-client',
+        values: [{ tagKey: 'group', value: '' }],
+      },
+    ];
+
+    expect(buildTagFilter(tagFilters)).toEqual({
+      tags: ['insights-client/group='],
+    });
+  });
+
+  test('omits value but keeps = when tag value is null', () => {
+    const tagFilters = [
+      {
+        key: 'insights-client',
+        values: [{ tagKey: 'group', value: null }],
+      },
+    ];
+
+    expect(buildTagFilter(tagFilters)).toEqual({
+      tags: ['insights-client/group='],
+    });
+  });
+
+  test('omits value but keeps = when tag value is undefined', () => {
+    const tagFilters = [
+      {
+        key: 'insights-client',
+        values: [{ tagKey: 'group' }],
+      },
+    ];
+
+    expect(buildTagFilter(tagFilters)).toEqual({
+      tags: ['insights-client/group='],
+    });
+  });
+
+  test('preserves tag value when it is 0', () => {
+    const tagFilters = [
+      {
+        key: 'insights-client',
+        values: [{ tagKey: 'priority', value: 0 }],
+      },
+    ];
+
+    expect(buildTagFilter(tagFilters)).toEqual({
+      tags: ['insights-client/priority=0'],
+    });
+  });
+
+  test('preserves tag value when it is false', () => {
+    const tagFilters = [
+      {
+        key: 'insights-client',
+        values: [{ tagKey: 'enabled', value: false }],
+      },
+    ];
+
+    expect(buildTagFilter(tagFilters)).toEqual({
+      tags: ['insights-client/enabled=false'],
+    });
+  });
+
   test('does not URI-encode equals signs in tag values', () => {
     const tagFilters = [
       {


### PR DESCRIPTION
- Sends namespace/key= if there is no value, instead of null

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Handle tag filters with empty or missing values by preserving the key and equals sign in the generated tag string.

Bug Fixes:
- Ensure tag filters with empty, null, or undefined values generate tags in the form namespace/key= instead of using null or omitting the equals sign.

Tests:
- Add unit tests covering tag filters with empty string, null, and undefined values to verify the generated tag format.

Screenshots:
Showing empty values are not sent as 'namespace/key=null' but instead as 'namespace/key=':
<img width="1907" height="495" alt="Screenshot from 2026-06-10 11-48-39" src="https://github.com/user-attachments/assets/a0a55735-cc7d-4582-89e5-d84e6aefac21" />
<img width="1897" height="962" alt="Screenshot from 2026-06-10 11-48-53" src="https://github.com/user-attachments/assets/2b75a8d8-e559-461e-bf01-10b9ba619059" />

The 400 error from the API is fixed in this PR: https://github.com/RedHatInsights/advisor-backend/pull/170