### PR TITLE
fix(RHINENG-26102): Update docs for setting up PDF generator environment

### DIFF
--- a/.claude/pdf-generator-setup.md
+++ b/.claude/pdf-generator-setup.md
@@ -1,0 +1,72 @@
+# Setting Up and Running PDF Generator Environment
+
+To test PDF generation locally, three services must run together: insights-chrome (proxy on port 1337), pdf-generator (server on port 8000), and the advisor frontend (static assets on port 8003). The repos are assumed to be siblings: `../insights-chrome` and `../pdf-generator`.
+
+## Prerequisites
+
+1. **quay.io authentication** (one-time): `podman login quay.io`
+2. Clone [insights-chrome](https://github.com/RedHatInsights/insights-chrome) and [pdf-generator](https://github.com/RedHatInsights/pdf-generator) as sibling directories.
+
+## insights-chrome Setup
+
+In `../insights-chrome/config/webpack.config.js`, ensure the `routes` object inside `nonKonfluxDevServerConfiguration()` includes:
+
+```javascript
+routes: {
+  '/apps/advisor/': { host: 'http://localhost:8003' },
+  '/api/crc-pdf-generator/': { host: 'http://localhost:8000' },
+  // ... existing routes
+}
+```
+
+## pdf-generator Setup
+
+Ensure `../pdf-generator/.env` contains:
+
+```dotenv
+MINIO_ACCESS_KEY="minioadmin"
+MINIO_SECRET_KEY="minioadmin"
+MAX_CONCURRENCY=2
+```
+
+## Starting Services (4 terminals)
+
+**Terminal 1 - insights-chrome:**
+```bash
+cd ../insights-chrome
+npm run dev
+```
+
+**Terminal 2 - pdf-generator containers (MinIO + Redis):**
+```bash
+cd ../pdf-generator
+podman-compose up
+```
+
+**Terminal 3 - pdf-generator server:**
+```bash
+cd ../pdf-generator
+PROXY_AGENT=http://squid.corp.redhat.com:3128/ \
+ASSETS_HOST=https://localhost:1337/ \
+API_HOST=https://console.stage.redhat.com/ \
+npm run start:server
+```
+
+- `ASSETS_HOST` points to insights-chrome where federated module assets are served
+- `API_HOST` is the backend API proxy target (stage or prod console)
+- `PROXY_AGENT` is required when on the corporate VPN
+
+**Terminal 4 - advisor frontend (static build):**
+```bash
+npm run static
+```
+
+This serves the advisor's federated module chunks on port 8003 (the default for `fec static`).
+
+## Access
+
+Open https://stage.foo.redhat.com:1337/insights/advisor and trigger a PDF export (e.g., Executive Report).
+
+## Common Issues
+
+- **504 Gateway Timeout from fetchData**: `API_HOST` is not set or unreachable. Ensure `API_HOST=https://console.stage.redhat.com/` is passed when starting pdf-generator server.

--- a/.claude/skills.md
+++ b/.claude/skills.md
@@ -1,0 +1,16 @@
+# Test Coverage Requirements
+
+- Always write unit tests for new functions and classes. Ensure test coverage is maintained or improved.
+
+# Linting
+
+- After changes, run the linter using 'npm run lint'. Fix any errors. Don't fix warnings.
+
+## Guidelines
+
+- Write tests for all new functionality before marking work as complete
+- Update existing tests when modifying code
+- Ensure tests pass before committing changes
+- Use appropriate testing frameworks (Jest, React Testing Library, Cypress, etc.)
+- Include both positive and negative test cases
+- Test edge cases and error handling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,18 @@ npm start              # Start dev server
 npm run build          # Production build
 npm test               # Run Jest tests
 npm run test:ct        # Run Cypress component tests
+npm run test:openct    # Run Cypress component tests (interactive)
 npm run test:coverage  # Generate coverage report
+npm run lint           # Run all linters (JS + SASS)
 ```
 
+### Development
+
+```bash
+npm install            # Install dependencies (runs ts-patch install via postinstall)
+npm run start:proxy    # Dev server with proxy to stage environment
+npm run static         # Static build (for use with insights-chrome)
+```
 
 ## Architecture Overview
 

--- a/README.md
+++ b/README.md
@@ -32,24 +32,26 @@ Clone the required repositories:
    ```
    Your credentials will be saved persistently and you won't need to login again after reboot.
 
-2. **Configure insights-chrome** - Add routing for advisor and pdf-generator in `config/webpack.config.js` routes object that contain ...(process.env.CHROME_SERVICE && {
-
+2. **Configure insights-chrome** - Add routing for `/apps/advisor/` and `/api/crc-pdf-generator/`
+     in the insights-chrome `config/webpack.config.js` routes object:
    ```javascript
-   '/apps/advisor/': { host: 'http://localhost:8003/' },
-   '/api/crc-pdf-generator/': { host: 'http://localhost:8000/' },
+   routes: {
+     '/apps/advisor/': { host: 'http://localhost:8003' },
+     '/api/crc-pdf-generator/': { host: 'http://localhost:8000' },
+     ...(process.env.CHROME_SERVICE && { ...
    ```
 
 3. **Start services in separate terminals:**
 
    **Terminal 1 - insights-chrome:**
    ```bash
-   cd ~/RH/insights-chrome
+   cd ../insights-chrome
    npm run dev
    ```
 
    **Terminal 2 - pdf-generator containers:**
    ```bash
-   cd ~/RH/pdf-generator
+   cd ../pdf-generator
    cat <<EOF > .env
    MINIO_ACCESS_KEY="minioadmin"
    MINIO_SECRET_KEY="minioadmin"
@@ -60,7 +62,7 @@ Clone the required repositories:
 
    **Terminal 3 - pdf-generator server:**
    ```bash
-   cd ~/RH/pdf-generator
+   cd ../pdf-generator
    PROXY_AGENT=http://squid.corp.redhat.com:3128/ \
    ASSETS_HOST=https://localhost:1337/ \
    API_HOST=https://console.stage.redhat.com/ \

--- a/fec.config.js
+++ b/fec.config.js
@@ -51,20 +51,20 @@ module.exports = {
     exposes: {
       './RootApp': resolve(
         __dirname,
-        `/src/${process.env.NODE_ENV !== 'production' ? 'Dev' : ''}AppEntry`,
+        `./src/${process.env.NODE_ENV !== 'production' ? 'Dev' : ''}AppEntry`,
       ),
-      './SystemDetail': resolve(__dirname, 'src/Modules/SystemDetail'),
+      './SystemDetail': resolve(__dirname, './src/Modules/SystemDetail'),
       './SystemDetailWrapped': resolve(
         __dirname,
-        'src/Modules/SystemDetailWrapped',
+        './src/Modules/SystemDetailWrapped',
       ),
       './BuildExecReport': resolve(
         __dirname,
-        '/src/PresentationalComponents/ExecutiveReport/BuildExecReport',
+        './src/PresentationalComponents/ExecutiveReport/BuildExecReport',
       ),
       './SystemsPdfBuild': resolve(
         __dirname,
-        '/src/PresentationalComponents/Export/SystemsPdfBuild',
+        './src/PresentationalComponents/Export/SystemsPdfBuild',
       ),
       './OverviewDetails': resolve(
         __dirname,


### PR DESCRIPTION
- Adds Claude skill(s) for it
- Piggybacks making exposed paths consistent in fec.config.js

Related to https://redhat.atlassian.net/browse/RHINENG-26102, but only to update the documentation and Claude skills for setting up the PDF generator environment

## Summary by Sourcery

Update local PDF generator environment setup documentation and align module expose paths for consistency.

Enhancements:
- Normalize fec.config.js exposed module paths to use consistent relative resolution.

Documentation:
- Clarify README steps for configuring insights-chrome routing and starting local PDF generator services.
- Add dedicated CLAUDE documentation for setting up and running the PDF generator environment.
- Extend CLAUDE usage docs with additional dev, test, and lint commands.

Chores:
- Add Claude skills guidelines file covering testing and linting expectations.