### PR TITLE
Use kessel sdk lib workspace fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@patternfly/react-icons": "^6.4.0",
         "@patternfly/react-table": "^6.4.1",
         "@patternfly/react-tokens": "^6.4.0",
-        "@project-kessel/react-kessel-access-check": "^0.5.0",
+        "@project-kessel/react-kessel-access-check": "^0.5.2",
         "@react-pdf/renderer": "^3.4.4",
         "@redhat-cloud-services/frontend-components": "^7.3.1",
         "@redhat-cloud-services/frontend-components-advisor-components": "^3.4.0",
@@ -5247,9 +5247,9 @@
       }
     },
     "node_modules/@project-kessel/react-kessel-access-check": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@project-kessel/react-kessel-access-check/-/react-kessel-access-check-0.5.0.tgz",
-      "integrity": "sha512-yOQEsX/Z53PSFuiemdGkKNKCRXRVb3Tzo/z8JpmC1uMGm7cT9ny49VqJokRHVuqCLGPH3IqbBd1USD1I2vi1Ew==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@project-kessel/react-kessel-access-check/-/react-kessel-access-check-0.5.2.tgz",
+      "integrity": "sha512-6a9SSyPWdhcJqxOF9hcrbuLfVqcwrkNf21G7prmCBsNoIygvKApe/fHH7o0AzSkVatcfwPhNA3JgdxNffN4wtw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@patternfly/react-icons": "^6.4.0",
     "@patternfly/react-table": "^6.4.1",
     "@patternfly/react-tokens": "^6.4.0",
-    "@project-kessel/react-kessel-access-check": "^0.5.0",
+    "@project-kessel/react-kessel-access-check": "^0.5.2",
     "@react-pdf/renderer": "^3.4.4",
     "@redhat-cloud-services/frontend-components": "^7.3.1",
     "@redhat-cloud-services/frontend-components-advisor-components": "^3.4.0",

--- a/src/Utilities/useDefaultWorkspace.js
+++ b/src/Utilities/useDefaultWorkspace.js
@@ -1,37 +1,36 @@
 import { useState, useEffect } from 'react';
-import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import { fetchDefaultWorkspace } from '@project-kessel/react-kessel-access-check';
+
+let defaultWorkspacePromise = null;
+
+export const resetDefaultWorkspaceCache = () => {
+  defaultWorkspacePromise = null;
+};
 
 export const useDefaultWorkspace = () => {
-  const axios = useAxiosWithPlatformInterceptors();
   const [workspaceId, setWorkspaceId] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
+  const baseUrl = window.location.origin;
 
   useEffect(() => {
-    const fetchDefaultWorkspaceId = async () => {
-      try {
-        setIsLoading(true);
-        const data = await axios.get('/api/rbac/v2/workspaces/', {
-          params: {
-            limit: 1,
-            type: 'default',
-          },
-        });
+    if (!defaultWorkspacePromise) {
+      defaultWorkspacePromise = fetchDefaultWorkspace(baseUrl);
+    }
 
-        const defaultWorkspaceId = data?.data?.[0]?.id || null;
-        setWorkspaceId(defaultWorkspaceId);
+    defaultWorkspacePromise
+      .then((workspace) => {
+        setWorkspaceId(workspace?.id ?? null);
         setError(null);
-      } catch (err) {
+      })
+      .catch((err) => {
+        resetDefaultWorkspaceCache();
         console.error('Failed to fetch default workspace:', err);
         setError(err);
         setWorkspaceId(null);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchDefaultWorkspaceId();
-  }, [axios]);
+      })
+      .finally(() => setIsLoading(false));
+  }, [baseUrl]);
 
   return { workspaceId, isLoading, error };
 };

--- a/src/Utilities/useDefaultWorkspace.test.js
+++ b/src/Utilities/useDefaultWorkspace.test.js
@@ -1,0 +1,77 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { fetchDefaultWorkspace } from '@project-kessel/react-kessel-access-check';
+import {
+  useDefaultWorkspace,
+  resetDefaultWorkspaceCache,
+} from './useDefaultWorkspace';
+
+jest.mock('@project-kessel/react-kessel-access-check', () => ({
+  fetchDefaultWorkspace: jest.fn(),
+}));
+
+describe('useDefaultWorkspace', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetDefaultWorkspaceCache();
+    console.error = jest.fn();
+  });
+
+  it('should return the default workspace', async () => {
+    const mockWorkspaceId = 'workspace-123';
+    fetchDefaultWorkspace.mockResolvedValue({
+      id: mockWorkspaceId,
+      type: 'default',
+      name: 'Default Workspace',
+      created: '2024-01-01',
+      modified: '2024-01-01',
+    });
+
+    const { result } = renderHook(() => useDefaultWorkspace());
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.workspaceId).toBe(mockWorkspaceId);
+    expect(result.current.error).toBe(null);
+    expect(fetchDefaultWorkspace).toHaveBeenCalledWith(window.location.origin);
+  });
+
+  it('should handle workspace fetch error', async () => {
+    const mockError = {
+      code: 400,
+      message: 'Bad request',
+      details: [],
+    };
+    fetchDefaultWorkspace.mockRejectedValue(mockError);
+
+    const { result } = renderHook(() => useDefaultWorkspace());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.workspaceId).toBe(null);
+    expect(result.current.error).toBe(mockError);
+    expect(fetchDefaultWorkspace).toHaveBeenCalledWith(window.location.origin);
+  });
+
+  it('should handle workspace without id', async () => {
+    fetchDefaultWorkspace.mockResolvedValue({
+      type: 'default',
+      name: 'Default Workspace',
+      created: '2024-01-01',
+      modified: '2024-01-01',
+    });
+    const { result } = renderHook(() => useDefaultWorkspace());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.workspaceId).toBe(null);
+    expect(result.current.error).toBe(null);
+  });
+});


### PR DESCRIPTION
# Description


Nothing changes here, it's refactoring PR so we don't have our own implementation but we can reuse helper from sdk library. It will help us avoid inconsistency.

# How to test the PR

1. Navigate to any advisor page
2. Check if api/rbac/v2/workspaces call is made with `type=default & with_ancestors=true` parameters

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Refactor the default workspace hook to rely on the kessel SDK workspace fetch utility, consolidating workspace retrieval logic and reducing custom network handling.

Enhancements:
- Refactor default workspace fetching hook to use the shared kessel SDK helper instead of a local Axios-based implementation.
- Introduce a shared promise for default workspace retrieval to avoid duplicate API calls and centralize error handling.