### PR TITLE
fix(RHINENG-28040): fix freezing bug and update inventory table

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -1,9 +1,9 @@
 import './_Inventory.scss';
 
-import React, { useEffect, useState, useCallback, useContext } from 'react';
+import React, { useEffect, useRef, useState, useCallback, useContext, useMemo } from 'react';
 import { TableVariant, sortable, wrappable } from '@patternfly/react-table';
 import { pruneFilters, urlBuilder } from '../Common/Tables';
-import { useDispatch, useSelector, useStore } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector, useStore } from 'react-redux';
 import {
   getEntities,
   allCurrentSystemIds,
@@ -25,11 +25,20 @@ import { updateReducers } from '../../Store';
 import { useIntl } from 'react-intl';
 import downloadReport from '../Common/DownloadHelper';
 import useBulkSelect from './Hooks/useBulkSelect';
-import { Flex, Spinner } from '@patternfly/react-core';
+import { Bullseye, Flex, FlexItem, Spinner, Tooltip } from '@patternfly/react-core';
 import { EnvironmentContext } from '../../App';
 import { AsyncComponent } from '@redhat-cloud-services/frontend-components';
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 import { Link } from 'react-router-dom';
+
+const ASYNC_COMPONENT_FALLBACK = <Bullseye><Spinner size="xl" /></Bullseye>;
+
+const CHROMELESS_HIDE_FILTERS = {
+  all: true, name: false, tags: true, operatingSystem: false, hostGroupFilter: true,
+};
+const STANDARD_HIDE_FILTERS = {
+  all: true, name: false, tags: false, operatingSystem: false, hostGroupFilter: false,
+};
 
 const Inventory = ({
   tableProps,
@@ -56,13 +65,13 @@ const Inventory = ({
   });
   const [fullFilters, setFullFilters] = useState();
   const [total, setTotal] = useState(0);
-  const entities = useSelector(({ entities }) => entities || {});
+  const entities = useSelector(({ entities }) => entities || {}, shallowEqual);
   const envContext = useContext(EnvironmentContext);
 
   const addNotification = (data) => dispatch(notification(data));
   const [disableRuleModalOpen, setDisableRuleModalOpen] = useState(false);
   const [curPageIds, setCurPageIds] = useState([]);
-  const [pathwayRulesList, setPathwayRulesList] = useState({});
+  const [pathwayRulesList, setPathwayRulesList] = useState([]);
   const [pathwayReportList, setPathwayReportList] = useState({});
   const [isLoading, setIsLoading] = useState();
 
@@ -104,32 +113,35 @@ const Inventory = ({
     identitfier: 'system_uuid',
     isLoading,
   });
+  const safeSelectedIds = useMemo(() => selectedIds || [], [selectedIds]);
+  const selectedIdsRef = useRef(safeSelectedIds);
+  selectedIdsRef.current = safeSelectedIds;
 
-  const fetchSystems = getEntities(
+  const fetchSystems = useMemo(() => getEntities(
     handleRefresh,
     pathway,
     setCurPageIds,
     setTotal,
-    selectedIds,
+    selectedIdsRef,
     setFullFilters,
     fullFilters,
     rule,
     envContext.RULES_FETCH_URL,
     envContext.SYSTEMS_FETCH_URL,
     axios,
-  );
+  ), [pathway, rule, envContext.RULES_FETCH_URL, envContext.SYSTEMS_FETCH_URL, axios]);
 
   // Ensures rows are marked as selected, runs the check on remediation Status
   useEffect(() => {
     dispatch({
       type: 'SELECT_ENTITIES',
       payload: {
-        selected: selectedIds,
+        selected: safeSelectedIds,
       },
     });
     checkRemediationButtonStatus();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedIds]);
+  }, [safeSelectedIds]);
 
   useEffect(() => {
     if (pathway) {
@@ -142,14 +154,18 @@ const Inventory = ({
 
   const rulesCheck = async () => {
     if (rulesPlaybookCount < 0) {
-      const associatedRuleDetails = (
-        await Get(
-          `${envContext.RULES_FETCH_URL}${encodeURI(rule.rule_id)}/`,
-          {},
-          { name: filters.name },
-        )
-      )?.data.playbook_count;
-      setRulesPlaybookCount(associatedRuleDetails);
+      try {
+        const associatedRuleDetails = (
+          await Get(
+            `${envContext.RULES_FETCH_URL}${encodeURI(rule.rule_id)}/`,
+            {},
+            { name: filters.name },
+          )
+        )?.data.playbook_count;
+        setRulesPlaybookCount(associatedRuleDetails);
+      } catch (error) {
+        console.error('Failed to fetch rule details:', error);
+      }
     }
   };
 
@@ -180,32 +196,22 @@ const Inventory = ({
 
   const checkRemediationButtonStatus = () => {
     let playbookFound = false;
-    let ruleKeys = Object.keys(pathwayReportList);
-    if (selectedIds?.length <= 0 || selectedIds === undefined) {
+    if (safeSelectedIds.length === 0) {
       setIsRemediationButtonDisabled(true);
-    } else if (pathway) {
-      for (let i = 0; i < selectedIds?.length; i++) {
-        let system = selectedIds[i];
-        if (playbookFound) {
-          break;
+    } else if (pathway && Array.isArray(pathwayRulesList)) {
+      for (const rule of pathwayRulesList) {
+        if (playbookFound) break;
+        const affectedSystems = pathwayReportList[rule.rule_id];
+        if (
+          affectedSystems?.some((s) => safeSelectedIds.includes(s)) &&
+          rule.resolution_set?.some((r) => r.has_playbook)
+        ) {
+          playbookFound = true;
         }
-        ruleKeys.forEach((rule) => {
-          //Grab the rule assosciated with that system
-          if (pathwayReportList[rule].includes(system)) {
-            let assosciatedRule = pathwayReportList[rule];
-            //find that associated rule in the pathwayRules endpoint, check for playbook
-            let item = pathwayRulesList.find(
-              (report) => (report.rule_id = assosciatedRule),
-            );
-            if (item.resolution_set[0].has_playbook) {
-              playbookFound = true;
-              return setIsRemediationButtonDisabled(false);
-            }
-          }
-        });
       }
+      setIsRemediationButtonDisabled(!playbookFound);
     } else {
-      if (rulesPlaybookCount > 0 && selectedIds?.length > 0) {
+      if (rulesPlaybookCount > 0 && safeSelectedIds.length > 0) {
         setIsRemediationButtonDisabled(false);
       }
     }
@@ -234,7 +240,7 @@ const Inventory = ({
         let filteredSystems = [];
 
         systems[rec.rule_id].forEach((system) => {
-          if (selectedIds.includes(system)) {
+          if (safeSelectedIds.includes(system)) {
             filteredSystems.push(system);
           }
         });
@@ -257,7 +263,7 @@ const Inventory = ({
             description: rule.description,
           },
         ],
-        systems: selectedIds,
+        systems: safeSelectedIds,
       };
     }
   };
@@ -282,6 +288,10 @@ const Inventory = ({
 
   const createColumns = useCallback(
     (defaultColumns) => {
+      if (!defaultColumns) {
+        return [lastSeenColumn];
+      }
+
       let displayName = defaultColumns.filter(
         ({ key }) => key === 'display_name',
       );
@@ -349,7 +359,7 @@ const Inventory = ({
     return pruneFilters(localFilters, SFC);
   };
 
-  const activeFiltersConfig = {
+  const activeFiltersConfig = useMemo(() => ({
     deleteTitle: intl.formatMessage(messages.resetFilters),
     filters: buildFilterChips(),
     onDelete: (_e, itemsToRemove, isAll) => {
@@ -374,64 +384,205 @@ const Inventory = ({
         });
       }
     },
-  };
+  }), [filters]);
   const [resolutions, setResolutions] = useState([]);
 
   useEffect(() => {
-    if (selectedIds?.length > 0) {
-      const fetchAndSetData = async () => {
-        const resolutionsData = await iopResolutionsMapper(
-          entities,
-          rule,
-          selectedIds,
-        );
-        setResolutions(resolutionsData);
-      };
-      fetchAndSetData();
+    if (safeSelectedIds.length > 0) {
+      if (rule) {
+        const fetchAndSetData = async () => {
+          const resolutionsData = await iopResolutionsMapper(
+            entities,
+            rule,
+            safeSelectedIds,
+          );
+          setResolutions(resolutionsData);
+        };
+        fetchAndSetData();
+      } else if (pathway && Array.isArray(pathwayRulesList)) {
+        const buildAndSetData = async () => {
+          const data = [];
+          for (const r of pathwayRulesList) {
+            const affected = pathwayReportList[r.rule_id];
+            if (!affected) continue;
+            for (const id of safeSelectedIds) {
+              if (!affected.includes(id)) continue;
+              const row = entities?.rows?.find((e) => e.id === id);
+              data.push({
+                hostid: id,
+                host_name: row ? row.display_name : id,
+                resolutions: (r.resolution_set || []).map((res) => ({
+                  description: res.resolution,
+                  id: res.system_type?.toString() || 'fix',
+                  needs_reboot: !!r.reboot_required,
+                  resolution_risk: res.resolution_risk?.risk || 1,
+                })),
+                rulename: r.rule_id,
+                description: r.description,
+                rebootable: !!r.reboot_required,
+              });
+            }
+          }
+          setResolutions(data);
+        };
+        buildAndSetData();
+      }
+    } else {
+      setResolutions([]);
     }
-  }, [selectedIds]);
+  }, [safeSelectedIds]);
 
-  const getActionsConfig = () => {
+  const actionsConfig = useMemo(() => {
+    const noPlaybookTooltip =
+      safeSelectedIds.length > 0 &&
+      isRemediationButtonDisabled &&
+      rulesPlaybookCount >= 0;
     const actions = [
       <Flex key="inventory-actions">
         {IopRemediationModal ? (
-          <IopRemediationModal.WrappedComponent
-            selectedIds={selectedIds}
-            iopData={resolutions}
-            isDisabled={isRemediationButtonDisabled}
-          />
-        ) : (
-          <RemediationButton
-            key="remediation-button"
-            fallback={<Spinner size="md" />}
-            isDisabled={isRemediationButtonDisabled}
-            dataProvider={remediationDataProvider}
-            onRemediationCreated={(result) => onRemediationCreated(result)}
-            hasSelected={selectedIds?.length > 0}
-          >
-            Plan remediation
-          </RemediationButton>
-        )}
+          <FlexItem>
+            <Tooltip
+              content="Remediation is not available for the selected systems."
+              trigger={noPlaybookTooltip ? 'mouseenter focus' : 'manual'}
+            >
+              <div>
+                <IopRemediationModal.WrappedComponent
+                  selectedIds={safeSelectedIds}
+                  iopData={resolutions}
+                  isDisabled={isRemediationButtonDisabled}
+                />
+              </div>
+            </Tooltip>
+          </FlexItem>
+        ) : !envContext.loadChromeless ? (
+          <FlexItem>
+            <Tooltip
+              content="Remediation is not available for the selected systems."
+              trigger={noPlaybookTooltip ? 'mouseenter focus' : 'manual'}
+            >
+              <div>
+                <RemediationButton
+                  key="remediation-button"
+                  fallback={<Spinner size="md" />}
+                  isDisabled={isRemediationButtonDisabled}
+                  dataProvider={remediationDataProvider}
+                  onRemediationCreated={(result) => onRemediationCreated(result)}
+                  hasSelected={safeSelectedIds.length > 0}
+                >
+                  Plan remediation
+                </RemediationButton>
+              </div>
+            </Tooltip>
+          </FlexItem>
+        ) : null}
         {envContext.displayDownloadPlaybookButton && (
-          <DownloadPlaybookButton
-            isDisabled={isRemediationButtonDisabled}
-            rules={[rule]}
-            systems={selectedIds}
-          />
+          <FlexItem>
+            <Tooltip
+              content="No playbook available for the selected systems."
+              trigger={noPlaybookTooltip ? 'mouseenter focus' : 'manual'}
+            >
+              <div>
+                <DownloadPlaybookButton
+                  isDisabled={isRemediationButtonDisabled}
+                  rules={pathway ? pathwayRulesList : [rule]}
+                  systems={safeSelectedIds}
+                  ruleSystemsMap={pathway ? pathwayReportList : null}
+                />
+              </div>
+            </Tooltip>
+          </FlexItem>
         )}
       </Flex>,
     ];
-    envContext.isDisableRecEnabled &&
-      !pathway &&
+    if (envContext.isDisableRecEnabled && !pathway) {
       actions.push({
         label: intl.formatMessage(messages.disableRuleForSystems),
         props: {
-          isDisabled: (selectedIds || []).length === 0,
+          isDisabled: safeSelectedIds.length === 0,
         },
         onClick: () => handleModalToggle(true),
       });
+    }
     return { actions };
-  };
+  }, [safeSelectedIds, isRemediationButtonDisabled, resolutions, pathway, pathwayRulesList, pathwayReportList, rule, rulesPlaybookCount]);
+
+  const onLoadHandler = useCallback(({
+    mergeWithEntities,
+    INVENTORY_ACTION_TYPES,
+    mergeWithDetail,
+  }) => {
+    store.replaceReducer(
+      updateReducers({
+        ...mergeWithEntities(
+          systemReducer([], INVENTORY_ACTION_TYPES),
+          {
+            page: Number(filters.offset / filters.limit + 1 || 1),
+            perPage: Number(filters.limit || 20),
+          },
+        ),
+        ...mergeWithDetail(),
+      }),
+    );
+  }, [filters.offset, filters.limit]);
+
+  const chromelessTableProps = useMemo(() => ({
+    variant: TableVariant.compact,
+    ...tableProps,
+    ...bulkSelectTableProps,
+    envContext: envContext,
+  }), [tableProps, bulkSelectTableProps, envContext]);
+
+  const standardTableProps = useMemo(() => ({
+    variant: TableVariant.compact,
+    ...tableProps,
+    ...bulkSelectTableProps,
+  }), [tableProps, bulkSelectTableProps]);
+
+  const chromelessCustomFilters = useMemo(() => ({
+    advisorFilters: filters,
+  }), [filters]);
+
+  const standardCustomFilters = useMemo(() => ({
+    advisorFilters: filters,
+    selectedTags,
+    workloads,
+  }), [filters, selectedTags, workloads]);
+
+  const chromelessExportConfig = useMemo(() => permsExport && {
+    label: intl.formatMessage(messages.exportJson),
+    onSelect: (_e, fileType) =>
+      downloadReport(
+        exportTable,
+        fileType,
+        { rule_id: rule.rule_id, ...filters },
+        selectedTags,
+        workloads,
+        dispatch,
+        envContext.BASE_URL,
+      ),
+    isDisabled: !permsExport || entities?.rows?.length === 0,
+    tooltipText: permsExport
+      ? intl.formatMessage(messages.exportData)
+      : intl.formatMessage(messages.permsAction),
+  }, [permsExport, filters, rule, selectedTags, workloads, entities?.rows?.length, envContext.BASE_URL]);
+
+  const standardExportConfig = useMemo(() => permsExport && {
+    label: intl.formatMessage(messages.exportJson),
+    onSelect: (_e, fileType) =>
+      downloadReport(
+        exportTable,
+        fileType,
+        { rule_id: rule.rule_id, ...filters },
+        selectedTags,
+        workloads,
+        dispatch,
+        envContext.BASE_URL,
+      ),
+    isDisabled: !permsExport || entities?.rows?.length === 0,
+    tooltipText: permsExport
+      ? intl.formatMessage(messages.exportData)
+      : intl.formatMessage(messages.permsAction),
+  }, [permsExport, filters, rule, selectedTags, workloads, entities?.rows?.length, envContext.BASE_URL]);
 
   return (
     <React.Fragment>
@@ -441,11 +592,12 @@ const Inventory = ({
           isModalOpen={disableRuleModalOpen}
           rule={rule}
           afterFn={afterDisableFn}
-          hosts={selectedIds}
+          hosts={safeSelectedIds}
         />
       )}
       {envContext.loadChromeless ? (
         <AsyncComponent
+          fallback={ASYNC_COMPONENT_FALLBACK}
           scope="inventory"
           module="./IOPInventoryTable"
           store={store}
@@ -454,66 +606,17 @@ const Inventory = ({
           hasCheckbox
           initialLoading
           autoRefresh
-          hideFilters={{
-            all: true,
-            name: false,
-            tags: true,
-            operatingSystem: false,
-            hostGroupFilter: true,
-          }}
+          hideFilters={CHROMELESS_HIDE_FILTERS}
           activeFiltersConfig={activeFiltersConfig}
-          columns={(defaultColumns) => createColumns(defaultColumns)}
-          tableProps={{
-            variant: TableVariant.compact,
-            ...tableProps,
-            ...bulkSelectTableProps,
-            envContext: envContext,
-          }}
-          customFilters={{
-            advisorFilters: filters,
-          }}
-          showTags={envContext.loadChromeless ? false : showTags}
+          columns={createColumns}
+          tableProps={chromelessTableProps}
+          customFilters={chromelessCustomFilters}
+          showTags={false}
           getEntities={fetchSystems}
-          actionsConfig={getActionsConfig()}
+          actionsConfig={actionsConfig}
           {...toolbarProps}
-          onLoad={({
-            mergeWithEntities,
-            INVENTORY_ACTION_TYPES,
-            mergeWithDetail,
-          }) => {
-            store.replaceReducer(
-              updateReducers({
-                ...mergeWithEntities(
-                  systemReducer([], INVENTORY_ACTION_TYPES),
-                  {
-                    page: Number(filters.offset / filters.limit + 1 || 1),
-                    perPage: Number(filters.limit || 20),
-                  },
-                ),
-                ...mergeWithDetail(),
-              }),
-            );
-          }}
-          exportConfig={
-            permsExport && {
-              label: intl.formatMessage(messages.exportCsv),
-              label: intl.formatMessage(messages.exportJson),
-              onSelect: (_e, fileType) =>
-                downloadReport(
-                  exportTable,
-                  fileType,
-                  { rule_id: rule.rule_id, ...filters },
-                  selectedTags,
-                  workloads,
-                  dispatch,
-                  envContext.BASE_URL,
-                ),
-              isDisabled: !permsExport || entities?.rows?.length === 0,
-              tooltipText: permsExport
-                ? intl.formatMessage(messages.exportData)
-                : intl.formatMessage(messages.permsAction),
-            }
-          }
+          onLoad={onLoadHandler}
+          exportConfig={chromelessExportConfig}
           axios={axios}
         />
       ) : (
@@ -523,67 +626,17 @@ const Inventory = ({
           hasCheckbox
           initialLoading
           autoRefresh
-          hideFilters={{
-            all: true,
-            name: false,
-            tags: false,
-            operatingSystem: false,
-            hostGroupFilter: false,
-          }}
+          hideFilters={STANDARD_HIDE_FILTERS}
           activeFiltersConfig={activeFiltersConfig}
-          columns={(defaultColumns) => createColumns(defaultColumns)}
-          tableProps={{
-            variant: TableVariant.compact,
-            ...tableProps,
-            ...bulkSelectTableProps,
-          }}
-          customFilters={{
-            advisorFilters: filters,
-            selectedTags,
-            workloads,
-          }}
-          showTags={envContext.loadChromeless ? false : showTags}
+          columns={createColumns}
+          tableProps={standardTableProps}
+          customFilters={standardCustomFilters}
+          showTags={showTags}
           getEntities={fetchSystems}
-          actionsConfig={getActionsConfig()}
+          actionsConfig={actionsConfig}
           {...toolbarProps}
-          onLoad={({
-            mergeWithEntities,
-            INVENTORY_ACTION_TYPES,
-            mergeWithDetail,
-          }) => {
-            store.replaceReducer(
-              updateReducers({
-                ...mergeWithEntities(
-                  systemReducer([], INVENTORY_ACTION_TYPES),
-                  {
-                    page: Number(filters.offset / filters.limit + 1 || 1),
-                    perPage: Number(filters.limit || 20),
-                  },
-                ),
-                ...mergeWithDetail(),
-              }),
-            );
-          }}
-          exportConfig={
-            permsExport && {
-              label: intl.formatMessage(messages.exportCsv),
-              label: intl.formatMessage(messages.exportJson),
-              onSelect: (_e, fileType) =>
-                downloadReport(
-                  exportTable,
-                  fileType,
-                  { rule_id: rule.rule_id, ...filters },
-                  selectedTags,
-                  workloads,
-                  dispatch,
-                  envContext.BASE_URL,
-                ),
-              isDisabled: !permsExport || entities?.rows?.length === 0,
-              tooltipText: permsExport
-                ? intl.formatMessage(messages.exportData)
-                : intl.formatMessage(messages.permsAction),
-            }
-          }
+          onLoad={onLoadHandler}
+          exportConfig={standardExportConfig}
         />
       )}
     </React.Fragment>

--- a/src/PresentationalComponents/Inventory/helpers.js
+++ b/src/PresentationalComponents/Inventory/helpers.js
@@ -31,21 +31,26 @@ export const paginatedRequestHelper = async ({
     workloads,
   );
 
-  return pathway
-    ? (
-        await Get(
-          `${SYSTEMS_FETCH_URL}`,
-          {},
-          { ...options, pathway: pathway.slug },
-        )
-      )?.data
-    : (
-        await Get(
-          `${RULES_FETCH_URL}${encodeURI(rule.rule_id)}/systems_detail/`,
-          {},
-          options,
-        )
-      )?.data;
+  try {
+    return pathway
+      ? (
+          await Get(
+            `${SYSTEMS_FETCH_URL}`,
+            {},
+            { ...options, pathway: pathway.slug },
+          )
+        )?.data
+      : (
+          await Get(
+            `${RULES_FETCH_URL}${encodeURI(rule.rule_id)}/systems_detail/`,
+            {},
+            options,
+          )
+        )?.data;
+  } catch (error) {
+    console.error('Failed to fetch systems:', error);
+    return { data: [], meta: { count: 0 } };
+  }
 };
 
 export const getEntities =
@@ -54,7 +59,7 @@ export const getEntities =
     pathway,
     setCurPageIds,
     setTotal,
-    selectedIds,
+    selectedIdsRef,
     setFullFilters,
     fullFilters,
     rule,
@@ -63,6 +68,7 @@ export const getEntities =
     axios,
   ) =>
   async (_items, config, showTags, defaultGetEntities) => {
+    const selectedIds = selectedIdsRef.current || [];
     const {
       per_page,
       page,
@@ -97,8 +103,19 @@ export const getEntities =
     };
     setFullFilters(allDetails);
     const fetchedSystems = await paginatedRequestHelper(allDetails);
+    const systemIds = fetchedSystems?.data?.map(
+      (system) => system.system_uuid,
+    ) || [];
+    const totalCount = fetchedSystems?.meta?.count || 0;
+
+    if (systemIds.length === 0) {
+      setCurPageIds([]);
+      setTotal(totalCount);
+      return Promise.resolve({ results: [], total: totalCount });
+    }
+
     const results = await defaultGetEntities(
-      fetchedSystems.data.map((system) => system.system_uuid),
+      systemIds,
       {
         per_page,
         hasItems: true,
@@ -107,8 +124,8 @@ export const getEntities =
       },
       showTags,
     );
-    setCurPageIds(fetchedSystems.data.map((system) => system.system_uuid));
-    setTotal(fetchedSystems.meta.count);
+    setCurPageIds(systemIds);
+    setTotal(totalCount);
     return Promise.resolve({
       results: mergeArraysByDiffKeys(fetchedSystems.data, results.results).map(
         (item) => {
@@ -118,7 +135,7 @@ export const getEntities =
           };
         },
       ),
-      total: fetchedSystems.meta.count,
+      total: totalCount,
     });
   };
 

--- a/src/Utilities/DownloadPlaybookButton.js
+++ b/src/Utilities/DownloadPlaybookButton.js
@@ -10,7 +10,7 @@ import { addNotification } from '@redhat-cloud-services/frontend-components-noti
 import { EnvironmentContext } from '../App';
 import { DownloadIcon } from '@patternfly/react-icons';
 
-const DownloadPlaybookButton = ({ isDisabled, rules, systems }) => {
+const DownloadPlaybookButton = ({ isDisabled, rules, systems, ruleSystemsMap }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const notification = (data) => dispatch(addNotification(data));
@@ -57,10 +57,15 @@ const DownloadPlaybookButton = ({ isDisabled, rules, systems }) => {
       r.resolution_set.some((r2) => r2.has_playbook),
     );
     const autoReboot = playbookRules.some((r) => r.reboot_required);
-    const issues = playbookRules.map((r) => ({
-      id: `advisor:${r.rule_id}`,
-      systems,
-    }));
+    const issues = playbookRules.map((r) => {
+      const ruleSystems = ruleSystemsMap
+        ? systems.filter((s) => ruleSystemsMap[r.rule_id]?.includes(s))
+        : systems;
+      return {
+        id: `advisor:${r.rule_id}`,
+        systems: ruleSystems,
+      };
+    }).filter((issue) => issue.systems.length > 0);
 
     return {
       auto_reboot: autoReboot,
@@ -91,6 +96,7 @@ DownloadPlaybookButton.propTypes = {
   isDisabled: PropTypes.bool,
   rules: PropTypes.arrayOf(PropTypes.shape({})),
   systems: PropTypes.arrayOf(PropTypes.string),
+  ruleSystemsMap: PropTypes.object,
 };
 
 export default DownloadPlaybookButton;


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)
https://redhat.atlassian.net/browse/RHINENG-28040

## Bug Fixes

- `checkRemediationButtonStatus` — rewrote the pathway branch. Original used `=` (assignment) instead of `===` (comparison) when matching `rule_id`, causing every rule to match. Also only checked `resolution_set[0].has_playbook` instead of checking all entries. Now iterates `pathwayRulesList` directly with `.some()` and properly resets disabled state when no match is found.
- `pathwayRulesList` initialized as `{}` but consumed as an array — changed to `[]` to prevent `Array.isArray()` and iteration failures.
- `paginatedRequestHelper` had no error handling — wrapped in try/catch, returns `{ data: [], meta: { count: 0 } }` on failure instead of crashing.
- `getEntities` called `defaultGetEntities` with an empty array when no systems were returned — added early return guard for `systemIds.length === 0`.
- `getEntities` accessed `fetchedSystems.data` and `fetchedSystems.meta.count` without null checks — added `?.` and `|| []` / `|| 0` fallbacks.
- `DownloadPlaybookButton` sent all selected systems for every rule in pathway mode — added `ruleSystemsMap` prop to filter systems per-rule so each rule only targets actually affected systems.

## Enhancements

1. `selectedIds` → `safeSelectedIds` via `useMemo(() => selectedIds || [], [selectedIds])` — eliminates null/undefined checks scattered throughout the component.
2. `selectedIdsRef` — stores `safeSelectedIds` in a ref passed to `getEntities`, preventing stale closure issues in the memoized `fetchSystems`.
3. `fetchSystems` wrapped in `useMemo` — avoids recreating the function on every render, which would trigger unnecessary inventory table refetches.
4. `entities` selector uses `shallowEqual` — prevents re-renders when Redux state changes but entities content is the same.
5. `activeFiltersConfig`, `actionsConfig`, `onLoadHandler`, `tableProps`, `customFilters`, `exportConfig` — all memoized with `useMemo`/`useCallback` to stabilize references and reduce inventory table re-renders.
6. Inline `hideFilters` objects extracted to module-level constants (`CHROMELESS_HIDE_FILTERS`, `STANDARD_HIDE_FILTERS`).
7. `createColumns` null guard — returns `[lastSeenColumn]` when `defaultColumns` is undefined.
8. `rulesCheck` wrapped in try/catch with `console.error`.
9. Duplicate `label` key in export config fixed — was `exportCsv` then `exportJson`, now only `exportJson`.
10. Remediate and Download Playbook buttons wrapped in `Tooltip` — shows explanation on hover when buttons are disabled due to no playbook. Uses `FlexItem` + `div` wrappers for proper layout and disabled-button hover support.
11. Resolutions `useEffect` — added pathway branch that builds IOP resolution data from `pathwayRulesList` × `pathwayReportList`, and clears resolutions on deselect.
12. Chromeless guard — `RemediationButton` returns `null` in chromeless mode when no `IopRemediationModal` is provided.

## Summary by Sourcery

Fix remediation playbook availability checks and stabilize the inventory table behavior in pathway and standard modes.

Bug Fixes:
- Correct remediation button enablement logic in pathway mode to only consider rules with playbooks affecting selected systems.
- Prevent crashes and inconsistent state when fetching inventory systems by adding error handling and null-safe guards in helper functions.
- Avoid sending all selected systems for every rule when downloading playbooks by scoping systems per rule.
- Ensure pathway rule data is treated as an array and handle empty result sets when loading systems.
- Add a null guard for inventory table column creation to avoid failures when default columns are missing.

Enhancements:
- Reduce unnecessary inventory table re-renders by memoizing selectors, callbacks, configs, and table props, and by stabilizing selected ID handling.
- Improve resolutions building for pathway mode so per-host, per-rule remediation data is correctly assembled and cleared when selections change.
- Add tooltips and layout tweaks to remediation and download playbook buttons to explain disabled states and support hover on disabled controls.
- Introduce a chromeless-mode guard to hide the remediation button when no remediation modal is available.
- Add a Bullseye spinner fallback for the async inventory table component for better loading feedback.