### PR TITLE
fix(RHINENG-29294): fix 0 systems in rec details bug

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -53,7 +53,7 @@ const Inventory = ({
     offset: 0,
     sort: '-last_seen',
     name: '',
-    'filter[system_profile][host_type][nil]': true,
+    'filter[system_profile]': true,
   });
   const [fullFilters, setFullFilters] = useState();
   const [total, setTotal] = useState(0);

--- a/src/SmartComponents/Recs/helpers.js
+++ b/src/SmartComponents/Recs/helpers.js
@@ -84,16 +84,16 @@ const getSystemCheckEndpoints = ({ ruleId, pathway, baseUrl }) => {
     return {
       conventionalURL: `${baseUrl}/rule/${encodeURI(
         ruleId,
-      )}/systems_detail/?filter[system_profile][host_type][nil]=true&limit=1`,
+      )}/systems_detail/?filter[system_profile]=true&limit=1`,
       edgeURL: `${baseUrl}/rule/${encodeURI(
         ruleId,
-      )}/systems_detail/?filter[system_profile][host_type]=edge&limit=1`,
+      )}/systems_detail/?filter[system_profile]&limit=1`,
     };
   }
 
   return {
-    conventionalURL: `${baseUrl}/system/?limit=1&filter[system_profile][host_type][nil]=true&pathway=${pathway}`,
-    edgeURL: `${baseUrl}/system/?limit=1&filter[system_profile][host_type]=edge&pathway=${pathway}`,
+    conventionalURL: `${baseUrl}/system/?limit=1&filter[system_profile]&pathway=${pathway}`,
+    edgeURL: `${baseUrl}/system/?limit=1&filter[system_profile]&pathway=${pathway}`,
   };
 };
 


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)
https://redhat.atlassian.net/browse/RHINENG-29294


On foreman-3.16, the systems table sends filter[system_profile][host_type][nil]=true to theAdvisor API, which filters for "conventional" (non-edge) systems by looking for nullhost_type. In a Satellite/Foreman IOP environment, host_type isn't populated the same way as in HCC, so every system gets filtered out — resulting in 0 systems. The fix (already on 3.18/5.0) simplifies it to filter[system_profile]=true, which skips the host type filtering entirely.


how to test:
run the advisor using iop-dev repository or this PR https://github.com/RedHatInsights/insights-advisor-frontend/pull/2102 (you would have to add changes manually to that PR). Open any advisor recommendation to verify that systems table shows the systems instead of an empty state

## Summary by Sourcery

Bug Fixes:
- Fix systems detail and inventory queries that returned zero systems by removing host_type constraints from system_profile filters.