### PR TITLE
fix(CI): correct Dockerfile for image-build job

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/nodejs-22:latest as builder
+FROM registry.access.redhat.com/ubi9/nodejs-22:latest AS builder
 
 USER root
 
@@ -12,6 +12,7 @@ RUN mkdir -p /opt/app-root/bin/
 COPY  ./build-tools/universal_build.sh /opt/app-root/bin/universal_build.sh
 COPY ./build-tools/build_app_info.sh /opt/app-root/bin/build_app_info.sh
 COPY ./build-tools/server_config_gen.sh /opt/app-root/bin/server_config_gen.sh
+COPY ./build-tools/dependency_helpers.sh /opt/app-root/bin/dependency_helpers.sh
 
 COPY --chown=default . .
 


### PR DESCRIPTION
# Description

Fix for `Container image build and publish / build (pull_request)` job


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Update container image build configuration to ensure required build tools are available in the builder image.

Enhancements:
- Include dependency_helpers.sh in the builder image so CI image-build jobs can use shared dependency helper scripts.

Build:
- Align Containerfile base image stage declaration with standard Docker syntax for multi-stage builds.