### PR TITLE
fix(RHINENG-29339): replace date format with timestamp component

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -21,7 +21,6 @@ module.exports = {
         ast: true,
       },
     ],
-    'lodash',
   ],
   env: {
     componentTest: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,6 @@
         "babel-loader": "^10.1.1",
         "babel-plugin-formatjs": "^11.3.3",
         "babel-plugin-istanbul": "^8.0.0",
-        "babel-plugin-lodash": "3.3.4",
         "cypress": "^15.13.1",
         "eslint": "^9.39.2",
         "eslint-plugin-cypress": "^5.2.1",
@@ -9578,19 +9577,6 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/babel-plugin-lodash": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
-      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0-beta.49",
-        "@babel/types": "^7.0.0-beta.49",
-        "glob": "^7.1.1",
-        "lodash": "^4.17.10",
-        "require-package-name": "^2.0.1"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -23641,12 +23627,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
-    "node_modules/require-package-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
-      "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==",
       "dev": true
     },
     "node_modules/requireindex": {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "babel-loader": "^10.1.1",
     "babel-plugin-formatjs": "^11.3.3",
     "babel-plugin-istanbul": "^8.0.0",
-    "babel-plugin-lodash": "3.3.4",
     "cypress": "^15.13.1",
     "eslint": "^9.39.2",
     "eslint-plugin-cypress": "^5.2.1",

--- a/src/PresentationalComponents/ExecutiveReport/BuildExecReport.js
+++ b/src/PresentationalComponents/ExecutiveReport/BuildExecReport.js
@@ -20,7 +20,7 @@ import {
   TOTAL_RISK_CONSTANTS,
   TOTAL_RISK_LABEL,
 } from '../../AppConstants';
-import { truncate } from 'lodash';
+import truncate from 'lodash/truncate';
 import { Text } from '@react-pdf/renderer';
 import { Content, Flex, FlexItem } from '@patternfly/react-core';
 import { InsightsLabel } from '@redhat-cloud-services/frontend-components/InsightsLabel';

--- a/src/PresentationalComponents/Inventory/helpers.js
+++ b/src/PresentationalComponents/Inventory/helpers.js
@@ -2,8 +2,8 @@ import { mergeArraysByDiffKeys } from '../Common/Tables';
 import { createOptions, createSortParam, getCsrfTokenHeader } from '../helper';
 import LastSeenColumnHeader from '../../Utilities/LastSeenColumnHeader';
 import { fitContent } from '@patternfly/react-table';
-import { DateFormat } from '@redhat-cloud-services/frontend-components';
 import React from 'react';
+import { RelativeTimeWithTooltip } from '../../Utilities/dateHelpers';
 import Qs from 'qs';
 
 /**
@@ -362,7 +362,7 @@ export const lastSeenColumn = {
   props: { width: 10 },
   dataLabel: 'Last seen',
   renderFunc: (last_seen) => (
-    <DateFormat date={last_seen} extraTitle={'Last Seen: '} />
+    <RelativeTimeWithTooltip date={last_seen} label="Last Seen: " />
   ),
 };
 export const impactedDateColumn = {
@@ -372,6 +372,6 @@ export const impactedDateColumn = {
   transforms: [fitContent],
   props: { width: 15 },
   renderFunc: (impacted_date) => (
-    <DateFormat date={impacted_date} extraTitle={'First impacted: '} />
+    <RelativeTimeWithTooltip date={impacted_date} label="First impacted: " />
   ),
 };

--- a/src/PresentationalComponents/Inventory/helpers.test.js
+++ b/src/PresentationalComponents/Inventory/helpers.test.js
@@ -1451,12 +1451,12 @@ describe('Inventory helpers', () => {
         expect(typeof lastSeenColumn.renderFunc).toBe('function');
       });
 
-      it('renderFunc returns DateFormat component', () => {
+      it('renderFunc returns RelativeTimeWithTooltip', () => {
         const date = '2024-01-15T10:30:00Z';
         const view = lastSeenColumn.renderFunc(date);
         expect(React.isValidElement(view)).toBe(true);
         expect(view.props.date).toBe(date);
-        expect(view.props.extraTitle).toBe('Last Seen: ');
+        expect(view.props.label).toBe('Last Seen: ');
       });
     });
 
@@ -1473,12 +1473,12 @@ describe('Inventory helpers', () => {
         expect(typeof impactedDateColumn.renderFunc).toBe('function');
       });
 
-      it('renderFunc returns DateFormat component', () => {
+      it('renderFunc returns RelativeTimeWithTooltip', () => {
         const date = '2024-01-10T08:00:00Z';
         const view = impactedDateColumn.renderFunc(date);
         expect(React.isValidElement(view)).toBe(true);
         expect(view.props.date).toBe(date);
-        expect(view.props.extraTitle).toBe('First impacted: ');
+        expect(view.props.label).toBe('First impacted: ');
       });
     });
   });

--- a/src/PresentationalComponents/Modals/IopViewHostAcks.js
+++ b/src/PresentationalComponents/Modals/IopViewHostAcks.js
@@ -5,8 +5,7 @@ import {
   TableHeader,
 } from '@patternfly/react-table/deprecated';
 
-import { Button, Modal } from '@patternfly/react-core';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import { Button, Modal, Timestamp } from '@patternfly/react-core';
 import { List } from 'react-content-loader';
 import { OutlinedBellIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
@@ -86,7 +85,11 @@ const IopViewHostAcks = ({
         },
         {
           title: (
-            <DateFormat date={new Date(item.updated_at)} type="onlyDate" />
+            <Timestamp
+              date={new Date(item.updated_at)}
+              dateFormat="long"
+              style={{ fontSize: 'inherit', fontWeight: 'inherit' }}
+            />
           ),
         },
         {

--- a/src/PresentationalComponents/Modals/ViewHostAcks.js
+++ b/src/PresentationalComponents/Modals/ViewHostAcks.js
@@ -6,7 +6,7 @@ import {
 } from '@patternfly/react-table/deprecated';
 
 import { BASE_URL } from '../../AppConstants';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import { Timestamp } from '@patternfly/react-core';
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 import { List } from 'react-content-loader';
 import { OutlinedBellIcon } from '@patternfly/react-icons';
@@ -83,7 +83,11 @@ const ViewHostAcks = ({
         },
         {
           title: (
-            <DateFormat date={new Date(item.updated_at)} type="onlyDate" />
+            <Timestamp
+              date={new Date(item.updated_at)}
+              dateFormat="long"
+              style={{ fontSize: 'inherit', fontWeight: 'inherit' }}
+            />
           ),
         },
         {

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -16,7 +16,7 @@ import {
 import { InsightsLabel } from '@redhat-cloud-services/frontend-components/InsightsLabel';
 import BellSlashIcon from '@patternfly/react-icons/dist/esm/icons/bell-slash-icon';
 import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import { RelativeTimeWithTooltip } from '../../Utilities/dateHelpers';
 import {
   RuleDetails,
   RuleDetailsMessagesKeys,
@@ -372,13 +372,7 @@ export const buildRows = (
           ),
         },
         {
-          title: (
-            <DateFormat
-              key={key}
-              date={value.publish_date}
-              variant="relative"
-            />
-          ),
+          title: <RelativeTimeWithTooltip date={value.publish_date} />,
         },
         {
           title: (

--- a/src/PresentationalComponents/helper.js
+++ b/src/PresentationalComponents/helper.js
@@ -1,5 +1,5 @@
 import { buildTagFilter, workloadQueryBuilder } from './Common/Tables';
-import { orderBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
 import { exportNotifications } from '../AppConstants';
 
 export const buildOsFilter = (osFilter = {}) => {

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -11,10 +11,10 @@ import {
   CardFooter,
   CardHeader,
   Button,
+  Timestamp,
   Title,
 } from '@patternfly/react-core';
 import BellSlashIcon from '@patternfly/react-icons/dist/esm/icons/bell-slash-icon';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { InvalidObject } from '@redhat-cloud-services/frontend-components/InvalidObject';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import MessageState from '../../PresentationalComponents/MessageState/MessageState';
@@ -195,9 +195,13 @@ const OverviewDetails = (props) => {
                         {recAck.updated_at && (
                           <span>
                             &nbsp;on&nbsp;
-                            <DateFormat
+                            <Timestamp
                               date={new Date(recAck.updated_at)}
-                              type="onlyDate"
+                              dateFormat="long"
+                              style={{
+                                fontSize: 'inherit',
+                                fontWeight: 'inherit',
+                              }}
                             />
                           </span>
                         )}

--- a/src/SmartComponents/Recs/DetailsPathways.js
+++ b/src/SmartComponents/Recs/DetailsPathways.js
@@ -22,7 +22,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import Breadcrumbs from '../../PresentationalComponents/Breadcrumbs/Breadcrumbs';
 import CategoryLabel from '../../PresentationalComponents/Labels/CategoryLabel';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import { Timestamp } from '@patternfly/react-core';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import RuleLabels from '../../PresentationalComponents/Labels/RuleLabels';
 import messages from '../../Messages';
@@ -170,9 +170,10 @@ const PathwayDetails = () => {
             <p className="pf-v6-u-mb-lg">
               {intl.formatMessage(messages.pathwaysDetailsModifieddate, {
                 date: (
-                  <DateFormat
+                  <Timestamp
                     date={new Date(pathway.publish_date)}
-                    type="onlyDate"
+                    dateFormat="long"
+                    style={{ fontSize: 'inherit', fontWeight: 'inherit' }}
                   />
                 ),
               })}

--- a/src/SmartComponents/Recs/DetailsRules.js
+++ b/src/SmartComponents/Recs/DetailsRules.js
@@ -9,7 +9,7 @@ import {
 } from '@redhat-cloud-services/frontend-components/PageHeader';
 import React, { useContext } from 'react';
 import Link from '@redhat-cloud-services/frontend-components/InsightsLink';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import { Timestamp } from '@patternfly/react-core';
 import { Flex } from '@patternfly/react-core/dist/esm/layouts/Flex/Flex';
 import { FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex/FlexItem';
 import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
@@ -99,9 +99,10 @@ export const DetailsRules = ({
                 <span className="pf-v6-u-mr-md">
                   {intl.formatMessage(messages.rulesDetailsModifieddate, {
                     date: (
-                      <DateFormat
+                      <Timestamp
                         date={new Date(rule.publish_date)}
-                        type="onlyDate"
+                        dateFormat="long"
+                        style={{ fontSize: 'inherit', fontWeight: 'inherit' }}
                       />
                     ),
                   })}

--- a/src/SmartComponents/Recs/DetailsRules.test.js
+++ b/src/SmartComponents/Recs/DetailsRules.test.js
@@ -19,8 +19,9 @@ jest.mock('@redhat-cloud-services/frontend-components/InsightsLink', () => {
   return ({ children, ...props }) => <a {...props}>{children}</a>;
 });
 
-jest.mock('@redhat-cloud-services/frontend-components/DateFormat', () => ({
-  DateFormat: () => <span>2024-01-01</span>,
+jest.mock('@patternfly/react-core', () => ({
+  ...jest.requireActual('@patternfly/react-core'),
+  Timestamp: ({ children }) => <span>{children || '2024-01-01'}</span>,
 }));
 
 jest.mock('../../PresentationalComponents/Breadcrumbs/Breadcrumbs', () => {

--- a/src/SmartComponents/Recs/IopRecommendationDetails.js
+++ b/src/SmartComponents/Recs/IopRecommendationDetails.js
@@ -12,10 +12,10 @@ import {
   CardFooter,
   CardHeader,
   Button,
+  Timestamp,
   Title,
 } from '@patternfly/react-core';
 import BellSlashIcon from '@patternfly/react-icons/dist/esm/icons/bell-slash-icon';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { InvalidObject } from '@redhat-cloud-services/frontend-components/InvalidObject';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import MessageState from '../../PresentationalComponents/MessageState/MessageState';
@@ -197,9 +197,13 @@ const IopRecommendationDetails = (props) => {
                         {recAck.updated_at && (
                           <span>
                             &nbsp;on&nbsp;
-                            <DateFormat
+                            <Timestamp
                               date={new Date(recAck.updated_at)}
-                              type="onlyDate"
+                              dateFormat="long"
+                              style={{
+                                fontSize: 'inherit',
+                                fontWeight: 'inherit',
+                              }}
                             />
                           </span>
                         )}

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisorAssets.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisorAssets.js
@@ -1,8 +1,8 @@
 import './SystemAdvisor.scss';
 import React, { useCallback } from 'react';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { RelativeTimeWithTooltip } from '../../Utilities/dateHelpers';
 import InsightsLabel from '@redhat-cloud-services/frontend-components/InsightsLabel';
-import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
 import RuleLabels from '../../PresentationalComponents/Labels/RuleLabels';
 import { ReportDetails } from '@redhat-cloud-services/frontend-components-advisor-components/ReportDetails';
 import {
@@ -202,26 +202,10 @@ export const useBuildRows = (
                 ),
               },
               {
-                title: (
-                  <span>
-                    <DateFormat
-                      date={rule.publish_date}
-                      type="relative"
-                      tooltipProps={{ position: TooltipPosition.bottom }}
-                    />
-                  </span>
-                ),
+                title: <RelativeTimeWithTooltip date={rule.publish_date} />,
               },
               {
-                title: (
-                  <div key={key}>
-                    <DateFormat
-                      date={value.impacted_date}
-                      type="relative"
-                      tooltipProps={{ position: TooltipPosition.bottom }}
-                    />
-                  </div>
-                ),
+                title: <RelativeTimeWithTooltip date={value.impacted_date} />,
               },
               {
                 title: (

--- a/src/Utilities/dateHelpers.js
+++ b/src/Utilities/dateHelpers.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Timestamp, Tooltip } from '@patternfly/react-core';
+
+const second = 1000;
+const minute = second * 60;
+const hour = minute * 60;
+const day = hour * 24;
+const month = day * 30;
+const year = day * 365;
+
+const formatTime = (number, unit) =>
+  `${number} ${number > 1 ? `${unit}s` : unit} ago`;
+
+const relativeTimeTable = [
+  {
+    rightBound: Infinity,
+    description: (diff) => formatTime(Math.round(diff / year), 'year'),
+  },
+  {
+    rightBound: year,
+    description: (diff) => formatTime(Math.round(diff / month), 'month'),
+  },
+  {
+    rightBound: month,
+    description: (diff) => formatTime(Math.round(diff / day), 'day'),
+  },
+  {
+    rightBound: day,
+    description: (diff) => formatTime(Math.round(diff / hour), 'hour'),
+  },
+  {
+    rightBound: hour,
+    description: (diff) => formatTime(Math.round(diff / minute), 'minute'),
+  },
+  { rightBound: minute, description: () => 'Just now' },
+];
+
+export const toRelativeTime = (date) => {
+  const dateObj = date instanceof Date ? date : new Date(date);
+
+  if (isNaN(dateObj.getTime())) {
+    return 'Invalid date';
+  }
+
+  const diff = Date.now() - dateObj.getTime();
+
+  return relativeTimeTable.reduce(
+    (acc, { rightBound, description }) =>
+      rightBound > diff ? description(diff) : acc,
+    dateObj.toUTCString().split(',')[1].slice(0, -7).trim() + ' UTC',
+  );
+};
+
+export const RelativeTimeWithTooltip = ({ date, label = '' }) => {
+  const dateObj = new Date(date);
+  return (
+    <Tooltip
+      content={
+        <span>
+          {label}
+          {dateObj.toUTCString()}
+        </span>
+      }
+    >
+      <Timestamp
+        date={dateObj}
+        style={{ fontSize: 'inherit', fontWeight: 'inherit' }}
+      >
+        {toRelativeTime(date)}
+      </Timestamp>
+    </Tooltip>
+  );
+};
+
+RelativeTimeWithTooltip.propTypes = {
+  date: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)])
+    .isRequired,
+  label: PropTypes.string,
+};

--- a/src/Utilities/dateHelpers.js
+++ b/src/Utilities/dateHelpers.js
@@ -12,6 +12,9 @@ const year = day * 365;
 const formatTime = (number, unit) =>
   `${number} ${number > 1 ? `${unit}s` : unit} ago`;
 
+const formatUtcDate = (dateObj) =>
+  dateObj.toUTCString().split(',')[1].slice(0, -7).trim() + ' UTC';
+
 const relativeTimeTable = [
   {
     rightBound: Infinity,
@@ -48,7 +51,7 @@ export const toRelativeTime = (date) => {
   return relativeTimeTable.reduce(
     (acc, { rightBound, description }) =>
       rightBound > diff ? description(diff) : acc,
-    dateObj.toUTCString().split(',')[1].slice(0, -7).trim() + ' UTC',
+    formatUtcDate(dateObj),
   );
 };
 
@@ -59,7 +62,7 @@ export const RelativeTimeWithTooltip = ({ date, label = '' }) => {
       content={
         <span>
           {label}
-          {dateObj.toUTCString()}
+          {formatUtcDate(dateObj)}
         </span>
       }
     >

--- a/src/Utilities/dateHelpers.test.js
+++ b/src/Utilities/dateHelpers.test.js
@@ -1,0 +1,127 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { toRelativeTime, RelativeTimeWithTooltip } from './dateHelpers';
+
+const FIXED_NOW = new Date('2025-06-15T12:00:00Z').getTime();
+
+beforeAll(() => {
+  jest.spyOn(Date, 'now').mockReturnValue(FIXED_NOW);
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+describe('toRelativeTime', () => {
+  it('returns "Just now" for less than a minute ago', () => {
+    const date = new Date(FIXED_NOW - 30 * 1000);
+    expect(toRelativeTime(date)).toBe('Just now');
+  });
+
+  it('returns minutes ago', () => {
+    const date = new Date(FIXED_NOW - 5 * 60 * 1000);
+    expect(toRelativeTime(date)).toBe('5 minutes ago');
+  });
+
+  it('returns singular minute', () => {
+    const date = new Date(FIXED_NOW - 1 * 60 * 1000);
+    expect(toRelativeTime(date)).toBe('1 minute ago');
+  });
+
+  it('returns hours ago', () => {
+    const date = new Date(FIXED_NOW - 3 * 60 * 60 * 1000);
+    expect(toRelativeTime(date)).toBe('3 hours ago');
+  });
+
+  it('returns singular hour', () => {
+    const date = new Date(FIXED_NOW - 1 * 60 * 60 * 1000);
+    expect(toRelativeTime(date)).toBe('1 hour ago');
+  });
+
+  it('returns days ago', () => {
+    const date = new Date(FIXED_NOW - 10 * 24 * 60 * 60 * 1000);
+    expect(toRelativeTime(date)).toBe('10 days ago');
+  });
+
+  it('returns singular day', () => {
+    const date = new Date(FIXED_NOW - 1 * 24 * 60 * 60 * 1000);
+    expect(toRelativeTime(date)).toBe('1 day ago');
+  });
+
+  it('returns months ago', () => {
+    const date = new Date(FIXED_NOW - 3 * 30 * 24 * 60 * 60 * 1000);
+    expect(toRelativeTime(date)).toBe('3 months ago');
+  });
+
+  it('returns years ago', () => {
+    const date = new Date(FIXED_NOW - 2 * 365 * 24 * 60 * 60 * 1000);
+    expect(toRelativeTime(date)).toBe('2 years ago');
+  });
+
+  it('accepts a date string', () => {
+    const date = new Date(FIXED_NOW - 5 * 60 * 1000).toISOString();
+    expect(toRelativeTime(date)).toBe('5 minutes ago');
+  });
+
+  it('returns "Invalid date" for garbage input', () => {
+    expect(toRelativeTime('not-a-date')).toBe('Invalid date');
+  });
+
+  it('formats the UTC fallback without seconds and with UTC suffix', () => {
+    const date = new Date('2020-03-14T09:26:53Z');
+    const result = toRelativeTime(date);
+    expect(result).toMatch(/years? ago/);
+
+    expect(result).not.toContain('GMT');
+    expect(result).not.toContain(':53');
+  });
+});
+
+describe('RelativeTimeWithTooltip', () => {
+  const testDate = '2025-06-15T10:30:00Z';
+
+  it('renders a Timestamp with relative time text', () => {
+    render(<RelativeTimeWithTooltip date={testDate} />);
+    expect(screen.getByText(/ago|Just now/)).toBeInTheDocument();
+  });
+
+  it('tooltip content uses UTC format without seconds', () => {
+    const dateObj = new Date(testDate);
+
+    const utcString = dateObj.toUTCString();
+    expect(utcString).toContain('GMT');
+
+    const expectedFormat =
+      dateObj.toUTCString().split(',')[1].slice(0, -7).trim() + ' UTC';
+    expect(expectedFormat).not.toContain('GMT');
+    expect(expectedFormat).toMatch(/^\d{1,2} \w+ \d{4} \d{2}:\d{2} UTC$/);
+  });
+
+  it('includes the label in tooltip content', () => {
+    const view = React.createElement(RelativeTimeWithTooltip, {
+      date: testDate,
+      label: 'Last Seen: ',
+    });
+    expect(view.props.label).toBe('Last Seen: ');
+    expect(view.props.date).toBe(testDate);
+  });
+
+  it('defaults label to empty string', () => {
+    const view = React.createElement(RelativeTimeWithTooltip, {
+      date: testDate,
+    });
+    expect(view.props.label).toBeUndefined();
+  });
+
+  it('renders a Timestamp element', () => {
+    render(<RelativeTimeWithTooltip date={testDate} />);
+    expect(screen.getByText(/ago|Just now/).closest('[datetime]')).toBeTruthy();
+  });
+
+  it('accepts a Date object as the date prop', () => {
+    const dateObj = new Date(testDate);
+    render(<RelativeTimeWithTooltip date={dateObj} />);
+    expect(screen.getByText(/ago|Just now/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)
https://redhat.atlassian.net/browse/RHINENG-29339
Please include a summary of the change, what this fixes/creates/improves.


Replaced the DateFormat with Timestamp because it was deprecated, the text and tooltips for timestamps should stay the same and look the same
Removed "babel-plugin-lodash": "3.3.4", because it was causing lint issues and its super old, we don't need it anymore


## Summary by Sourcery

Replace deprecated DateFormat usage with PatternFly Timestamp-based date rendering and introduce a shared relative time helper.

Enhancements:
- Unify relative time display across tables and system advisor views using a new toRelativeTime helper.
- Ensure tooltips continue to show full UTC timestamps while inline text remains visually consistent with previous relative date formatting.
- Update recommendation and pathway details views and host acknowledgement modals to use Timestamp with explicit long date formatting.
- Refactor lodash imports to use direct module paths and remove the babel-plugin-lodash dependency from the build configuration.

Tests:
- Adjust inventory helper tests to assert Timestamp-in-Tooltip rendering instead of DateFormat components.
- Update DetailsRules tests to mock Timestamp usage in place of DateFormat.