### PR TITLE
CVE fix foreman 5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10693,15 +10693,15 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -14001,9 +14001,9 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,8 @@
     "ajv-keywords": ">=5.1.0",
     "schema-utils": ">=4.3.3",
     "minimatch": ">=10.2.5",
-    "fast-uri": ">=3.1.2",
+    "fast-uri": "3.1.4",
+    "brace-expansion": "5.0.8",
     "marked": ">=18.0.4",
     "@swc/helpers": "0.5.21",
     "sanitize-html": "2.17.6"


### PR DESCRIPTION
SAT-47268 — https://github.com/advisories/GHSA-4c8g-83qw-93j6 (fast-uri)
SAT-47681 — https://github.com/advisories/GHSA-3jxr-9vmj-r5cp (brace-expansion)

## Summary by Sourcery

Update dependencies to address reported security vulnerabilities.

Bug Fixes:
- Address security advisories by updating vulnerable dependency versions.

Build:
- Pin fast-uri to version 3.1.4 and add brace-expansion 5.0.8 to the dependency list to resolve CVEs.