### PR TITLE
chore(cicd): copy dependency_helpers.sh for pipeline

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,6 +12,7 @@ RUN mkdir -p /opt/app-root/bin/
 COPY  ./build-tools/universal_build.sh /opt/app-root/bin/universal_build.sh
 COPY ./build-tools/build_app_info.sh /opt/app-root/bin/build_app_info.sh
 COPY ./build-tools/server_config_gen.sh /opt/app-root/bin/server_config_gen.sh
+COPY ./build-tools/dependency_helpers.sh /opt/app-root/bin/dependency_helpers.sh
 
 COPY --chown=default . .
 


### PR DESCRIPTION
The pipeline tries to source dependency_helpers.sh but it wasn't copied into the container.

## Summary by Sourcery

Build:
- Add dependency_helpers.sh to the container image build so it is available at /opt/app-root/bin for pipeline usage.