### PR TITLE
feat(RHINENG-29490): Add new Satellite workload filter option

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -416,6 +416,7 @@ export const FILTER_CATEGORIES = {
       { label: 'Oracle DB', value: 'oracle_db' },
       { label: 'RHEL AI', value: 'rhel_ai' },
       { label: 'SAP', value: 'sap' },
+      { label: 'Satellite', value: 'satellite' },
     ],
   },
 };

--- a/src/PresentationalComponents/RulesTable/helpers.test.js
+++ b/src/PresentationalComponents/RulesTable/helpers.test.js
@@ -29,6 +29,7 @@ jest.mock('../../AppConstants', () => ({
         { label: 'SAP', value: 'sap' },
         { label: 'Ansible Automation Platform', value: 'ansible' },
         { label: 'Microsoft SQL', value: 'mssql' },
+        { label: 'Satellite', value: 'satellite' },
       ],
     },
   },
@@ -228,6 +229,7 @@ describe('filterConfigItems – workload filter', () => {
       { label: 'SAP', value: 'sap' },
       { label: 'Ansible Automation Platform', value: 'ansible' },
       { label: 'Microsoft SQL', value: 'mssql' },
+      { label: 'Satellite', value: 'satellite' },
     ]);
   });
 });


### PR DESCRIPTION
# Description

Associated Jira ticket: https://redhat.atlassian.net/browse/RHINENG-29490

Add new Satellite workload filter option

# How to test the PR

PR is depended on backend change https://github.com/RedHatInsights/advisor-backend/pull/220 - it should be merged first before testing frontend changes

1. enable flag https://insights-stage.unleash.devshift.net/projects/default/features/hbi.ui.workload_filter_satellite
2. Visit Advisor Systems/ Recommendation's details page page
3. Filter by Workload - Satellite option

# Before the change
- no Satellite option in Workload filter menu 

# After the change
- Satellite option is in Workload filter menu 

# Dependent work link
https://github.com/RedHatInsights/advisor-backend/pull/220

# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Add a new 'Satellite' workload option to the Advisor workload filter.

New Features:
- Introduce a 'Satellite' workload filter option in the workload filter configuration.

Tests:
- Extend workload filter helper tests to cover the new 'Satellite' workload option.