### PR TITLE
feat(RHINENG-29494): add Ansible workload hook for /ansible/advisor route

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -58,7 +58,7 @@ import { EnvironmentContext } from '../../App';
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 import { useFeatureFlag } from '../../Utilities/Hooks';
 
-const RulesTable = ({ isTabActive, pathway, onRuleChange }) => {
+const RulesTable = ({ isTabActive, pathway, onRuleChange, defaultFilters }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const envContext = useContext(EnvironmentContext);
@@ -92,9 +92,7 @@ const RulesTable = ({ isTabActive, pathway, onRuleChange }) => {
     ...(pathway ? { pathway } : {}),
   };
 
-  const workloadParams = isWorkloadFilterEnabled
-    ? workloadArrayQueryBuilder(workloadFilter || [])
-    : {};
+  const workloadParams = workloadArrayQueryBuilder(workloadFilter || []);
 
   const {
     data: rules = [],
@@ -219,6 +217,7 @@ const RulesTable = ({ isTabActive, pathway, onRuleChange }) => {
     setSearchText,
     setFilters,
     hasEdgeDevices,
+    defaultFilters,
   );
 
   const isRowExpanded = (rowIndex) => expandedRows.has(rowIndex);
@@ -458,6 +457,7 @@ RulesTable.propTypes = {
   isTabActive: PropTypes.bool,
   pathway: PropTypes.string,
   onRuleChange: PropTypes.func,
+  defaultFilters: PropTypes.object,
 };
 
 export default RulesTable;

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -601,6 +601,7 @@ export const getActiveFiltersConfig = (
   setSearchText,
   setFilters,
   hasEdgeDevice,
+  defaultFilters,
 ) => ({
   deleteTitle: intl.formatMessage(messages.resetFilters),
   filters: buildFilterChips(filters, hasEdgeDevice),
@@ -615,6 +616,7 @@ export const getActiveFiltersConfig = (
         limit: filters.limit,
         offset: filters.offset,
         ...(filters.pathway && { pathway: filters.pathway }),
+        ...(defaultFilters || {}),
       });
     } else {
       itemsToRemove.map((item) => {

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -2,6 +2,7 @@ import './SystemsTable.scss';
 
 import {
   SYSTEM_FILTER_CATEGORIES as SFC,
+  FILTER_CATEGORIES as FC,
   NO_SYSTEMS_REASONS,
 } from '../../AppConstants';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
@@ -40,8 +41,9 @@ import { conditionalFilterType } from '@redhat-cloud-services/frontend-component
 import { EnvironmentContext } from '../../App';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/';
 import { useFeatureFlag } from '../../Utilities/Hooks';
+import PropTypes from 'prop-types';
 
-const SystemsTable = () => {
+const SystemsTable = ({ defaultFilters }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const store = useStore();
@@ -118,7 +120,11 @@ const SystemsTable = () => {
     delete localFilters.offset;
     delete localFilters.limit;
 
-    return pruneFilters(localFilters, SFC);
+    const filterCategories = localFilters.workload
+      ? { ...SFC, workload: FC.workload }
+      : SFC;
+
+    return pruneFilters(localFilters, filterCategories);
   };
 
   const activeFiltersConfig = {
@@ -132,6 +138,7 @@ const SystemsTable = () => {
           offset: filters.offset,
           hits: ['all'],
           tags: selectedTags,
+          ...(defaultFilters || {}),
         });
       } else {
         itemsToRemove.map((item) => {
@@ -166,7 +173,7 @@ const SystemsTable = () => {
 
   useEffect(() => {
     let combinedFilters;
-    if (search) {
+    if (search || window.location.search) {
       const paramsObject = paramParser();
       paramsObject.tags = selectedTags;
       paramsObject.sort !== undefined &&
@@ -196,6 +203,7 @@ const SystemsTable = () => {
         limit: 20,
         hits: ['all'],
         tags: selectedTags,
+        ...(defaultFilters || {}),
       };
       setFilters(combinedFilters);
     }
@@ -230,7 +238,9 @@ const SystemsTable = () => {
           operatingSystem: false,
           systemTypeFilter: false,
           systemType: false,
-          ...(isWorkloadFilterEnabled && { workloadFilter: false }),
+          ...((isWorkloadFilterEnabled || defaultFilters?.workload) && {
+            workloadFilter: false,
+          }),
         }}
         initialLoading
         autoRefresh
@@ -284,14 +294,13 @@ const SystemsTable = () => {
             true,
           );
 
-          // Local table Workload filter;
-          // separate from the global Chrome tag/workload filter handled by createOptions above
           const localWorkloadFilter = filters?.workloadFilter;
-          if (isWorkloadFilterEnabled && localWorkloadFilter?.length) {
-            Object.assign(
-              options,
-              workloadArrayQueryBuilder(localWorkloadFilter),
-            );
+          const workloadValues =
+            isWorkloadFilterEnabled && localWorkloadFilter?.length
+              ? localWorkloadFilter
+              : advisorFilters?.workload;
+          if (workloadValues?.length) {
+            Object.assign(options, workloadArrayQueryBuilder(workloadValues));
           }
 
           let fetchedSystems;
@@ -413,6 +422,10 @@ const SystemsTable = () => {
       />
     )
   );
+};
+
+SystemsTable.propTypes = {
+  defaultFilters: PropTypes.object,
 };
 
 export default SystemsTable;

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -173,7 +173,7 @@ const SystemsTable = ({ defaultFilters }) => {
 
   useEffect(() => {
     let combinedFilters;
-    if (search || window.location.search) {
+    if (search) {
       const paramsObject = paramParser();
       paramsObject.tags = selectedTags;
       paramsObject.sort !== undefined &&

--- a/src/SmartComponents/Recs/List.js
+++ b/src/SmartComponents/Recs/List.js
@@ -59,7 +59,7 @@ const List = () => {
   const useNewPathwaysTable = useFeatureFlag('advisor-tabletools-migration');
   const envContext = useContext(EnvironmentContext);
   const intl = useIntl();
-  const { isReady, defaultFilters } = useAnsibleWorkloadDefault();
+  const { defaultFilters } = useAnsibleWorkloadDefault();
 
   useEffect(() => {
     envContext.updateDocumentTitle('Recommendations - Advisor');
@@ -77,10 +77,6 @@ const List = () => {
 
   const { handleOverviewRefetchReady, handleRuleChange } =
     useOverviewRefetchOnRuleChange();
-
-  if (!isReady) {
-    return null;
-  }
 
   return (
     <React.Fragment>

--- a/src/SmartComponents/Recs/List.js
+++ b/src/SmartComponents/Recs/List.js
@@ -12,6 +12,7 @@ import messages from '../../Messages';
 import OverviewDashbar from '../../PresentationalComponents/OverviewDashbar/OverviewDashbar';
 import RulesTable from '../../PresentationalComponents/RulesTable/RulesTable';
 import { useOverviewRefetchOnRuleChange } from '../../Utilities/Hooks';
+import { useAnsibleWorkloadDefault } from '../../Utilities/hooks/useAnsibleWorkloadDefault';
 import {
   Tab,
   TabTitleText,
@@ -58,6 +59,7 @@ const List = () => {
   const useNewPathwaysTable = useFeatureFlag('advisor-tabletools-migration');
   const envContext = useContext(EnvironmentContext);
   const intl = useIntl();
+  const { isReady, defaultFilters } = useAnsibleWorkloadDefault();
 
   useEffect(() => {
     envContext.updateDocumentTitle('Recommendations - Advisor');
@@ -75,6 +77,10 @@ const List = () => {
 
   const { handleOverviewRefetchReady, handleRuleChange } =
     useOverviewRefetchOnRuleChange();
+
+  if (!isReady) {
+    return null;
+  }
 
   return (
     <React.Fragment>
@@ -174,6 +180,7 @@ const List = () => {
                   <RulesTable
                     isTabActive={activeTab === RECOMMENDATIONS_TAB}
                     onRuleChange={handleRuleChange}
+                    defaultFilters={defaultFilters}
                   />
                 </Tab>
                 <Tab
@@ -209,7 +216,10 @@ const List = () => {
                 </Tab>
               </Tabs>
             ) : (
-              <RulesTable onRuleChange={handleRuleChange} />
+              <RulesTable
+                onRuleChange={handleRuleChange}
+                defaultFilters={defaultFilters}
+              />
             )}
           </StackItem>
         </Stack>

--- a/src/SmartComponents/Systems/List.js
+++ b/src/SmartComponents/Systems/List.js
@@ -6,12 +6,19 @@ import React, { useContext, useEffect } from 'react';
 import SystemsTable from '../../PresentationalComponents/SystemsTable/SystemsTable';
 import messages from '../../Messages';
 import { EnvironmentContext } from '../../App';
+import { useAnsibleWorkloadDefault } from '../../Utilities/hooks/useAnsibleWorkloadDefault';
 
 const List = () => {
   const envContext = useContext(EnvironmentContext);
+  const { isReady, defaultFilters } = useAnsibleWorkloadDefault();
+
   useEffect(() => {
     envContext.updateDocumentTitle('Systems - Advisor');
   }, [envContext]);
+
+  if (!isReady) {
+    return null;
+  }
 
   return (
     <React.Fragment>
@@ -19,7 +26,7 @@ const List = () => {
         <PageHeaderTitle title={`${messages.systems.defaultMessage}`} />
       </PageHeader>
       <section className="pf-v6-l-page__main-section pf-v6-c-page__main-section">
-        <SystemsTable />
+        <SystemsTable defaultFilters={defaultFilters} />
       </section>
     </React.Fragment>
   );

--- a/src/SmartComponents/Systems/List.js
+++ b/src/SmartComponents/Systems/List.js
@@ -10,15 +10,11 @@ import { useAnsibleWorkloadDefault } from '../../Utilities/hooks/useAnsibleWorkl
 
 const List = () => {
   const envContext = useContext(EnvironmentContext);
-  const { isReady, defaultFilters } = useAnsibleWorkloadDefault();
+  const { defaultFilters } = useAnsibleWorkloadDefault();
 
   useEffect(() => {
     envContext.updateDocumentTitle('Systems - Advisor');
   }, [envContext]);
-
-  if (!isReady) {
-    return null;
-  }
 
   return (
     <React.Fragment>

--- a/src/Utilities/hooks/useAnsibleWorkloadDefault.js
+++ b/src/Utilities/hooks/useAnsibleWorkloadDefault.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useLayoutEffect } from 'react';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const WORKLOAD_PARAM = 'workload';
@@ -10,30 +10,18 @@ export const useAnsibleWorkloadDefault = () => {
   const { getBundle } = useChrome();
   const isAnsibleBundle = getBundle() === ANSIBLE_WORKLOAD;
 
-  const url = new URL(window.location);
-  const hasWorkloadParam = url.searchParams.has(WORKLOAD_PARAM);
+  useLayoutEffect(() => {
+    if (!isAnsibleBundle) return;
 
-  const [isReady, setIsReady] = useState(!isAnsibleBundle || hasWorkloadParam);
-
-  const appliedRef = useRef(false);
-
-  useEffect(() => {
-    if (!isAnsibleBundle || appliedRef.current) {
-      return;
+    const url = new URL(window.location);
+    if (!url.searchParams.has(WORKLOAD_PARAM)) {
+      url.searchParams.set(WORKLOAD_PARAM, ANSIBLE_WORKLOAD);
+      window.history.replaceState(window.history.state, '', url.toString());
     }
-
-    appliedRef.current = true;
-
-    const currentUrl = new URL(window.location);
-    if (!currentUrl.searchParams.has(WORKLOAD_PARAM)) {
-      currentUrl.searchParams.set(WORKLOAD_PARAM, ANSIBLE_WORKLOAD);
-      window.history.replaceState(null, null, currentUrl.toString());
-    }
-
-    setIsReady(true);
   }, [isAnsibleBundle]);
 
-  const defaultFilters = isAnsibleBundle ? ANSIBLE_DEFAULT_FILTERS : undefined;
-
-  return { isReady, defaultFilters };
+  return {
+    isReady: true,
+    defaultFilters: isAnsibleBundle ? ANSIBLE_DEFAULT_FILTERS : undefined,
+  };
 };

--- a/src/Utilities/hooks/useAnsibleWorkloadDefault.js
+++ b/src/Utilities/hooks/useAnsibleWorkloadDefault.js
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from 'react';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+
+const WORKLOAD_PARAM = 'workload';
+const ANSIBLE_WORKLOAD = 'ansible';
+
+const ANSIBLE_DEFAULT_FILTERS = { workload: [ANSIBLE_WORKLOAD] };
+
+export const useAnsibleWorkloadDefault = () => {
+  const { getBundle } = useChrome();
+  const isAnsibleBundle = getBundle() === ANSIBLE_WORKLOAD;
+
+  const url = new URL(window.location);
+  const hasWorkloadParam = url.searchParams.has(WORKLOAD_PARAM);
+
+  const [isReady, setIsReady] = useState(!isAnsibleBundle || hasWorkloadParam);
+
+  const appliedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isAnsibleBundle || appliedRef.current) {
+      return;
+    }
+
+    appliedRef.current = true;
+
+    const currentUrl = new URL(window.location);
+    if (!currentUrl.searchParams.has(WORKLOAD_PARAM)) {
+      currentUrl.searchParams.set(WORKLOAD_PARAM, ANSIBLE_WORKLOAD);
+      window.history.replaceState(null, null, currentUrl.toString());
+    }
+
+    setIsReady(true);
+  }, [isAnsibleBundle]);
+
+  const defaultFilters = isAnsibleBundle ? ANSIBLE_DEFAULT_FILTERS : undefined;
+
+  return { isReady, defaultFilters };
+};

--- a/src/Utilities/hooks/useAnsibleWorkloadDefault.test.js
+++ b/src/Utilities/hooks/useAnsibleWorkloadDefault.test.js
@@ -1,0 +1,91 @@
+import { renderHook } from '@testing-library/react';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useAnsibleWorkloadDefault } from './useAnsibleWorkloadDefault';
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const setUrl = (path) => {
+  window.history.pushState({}, '', path);
+};
+
+describe('useAnsibleWorkloadDefault', () => {
+  let replaceStateSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    replaceStateSpy = jest
+      .spyOn(window.history, 'replaceState')
+      .mockImplementation(() => {});
+    setUrl('/ansible/advisor/recommendations');
+  });
+
+  afterEach(() => {
+    replaceStateSpy.mockRestore();
+    setUrl('/');
+  });
+
+  it('returns ready immediately with no defaultFilters for non-ansible bundles', () => {
+    useChrome.mockReturnValue({ getBundle: () => 'insights' });
+
+    const { result } = renderHook(() => useAnsibleWorkloadDefault());
+
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.defaultFilters).toBeUndefined();
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('sets workload param in URL and returns defaultFilters for ansible bundle', () => {
+    useChrome.mockReturnValue({ getBundle: () => 'ansible' });
+
+    const { result } = renderHook(() => useAnsibleWorkloadDefault());
+
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.defaultFilters).toEqual({
+      workload: ['ansible'],
+    });
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    const updatedUrl = replaceStateSpy.mock.calls[0][2];
+    expect(updatedUrl).toContain('workload=ansible');
+  });
+
+  it('does not overwrite existing workload param for ansible bundle', () => {
+    setUrl('/ansible/advisor/recommendations?workload=crowdstrike');
+    useChrome.mockReturnValue({ getBundle: () => 'ansible' });
+
+    const { result } = renderHook(() => useAnsibleWorkloadDefault());
+
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.defaultFilters).toEqual({
+      workload: ['ansible'],
+    });
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not modify URL for non-ansible bundle even with no workload param', () => {
+    setUrl('/insights/advisor/recommendations');
+    useChrome.mockReturnValue({ getBundle: () => 'insights' });
+
+    const { result } = renderHook(() => useAnsibleWorkloadDefault());
+
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.defaultFilters).toBeUndefined();
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('applies workload param only once across re-renders', () => {
+    useChrome.mockReturnValue({ getBundle: () => 'ansible' });
+
+    const { result, rerender } = renderHook(() => useAnsibleWorkloadDefault());
+
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+
+    rerender();
+    rerender();
+
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    expect(result.current.isReady).toBe(true);
+  });
+});


### PR DESCRIPTION
# Description

- When Advisor is accessed under the Ansible bundle (/ansible/advisor), the `workload=ansible` URL parameter and filter are now applied automatically so users see Ansible-relevant recommendations and systems by default.
- Adds `useAnsibleWorkloadDefault` hook that detects the Ansible bundle context, injects the workload query parameter into the URL, and provides `defaultFilters` to preserve the workload selection on filter reset.
- Applies to both the Recommendations (`RulesTable`) and Systems (`SystemsTable`) views.

Associated Jira ticket: # (issue)

add Ansible workload hook for /ansible/advisor/* route

As part of the global tag filter decommission, this PR replicates the Ansible workload pre-selection that insights-chrome previously injected via `GLOBAL_FILTER_UPDATE` for /`ansible/*` routes. The implementation is per-app (in advisor), not in chrome - as agreed by the Frontend CoP.


# How to test the PR

Before testing - make sure flag is enabled to hide global tag filter https://insights-stage.unleash.devshift.net/projects/default/features/platform.chrome.hide.global-filter


1. Visit /ansible/advisor/systems and /ansible/advisor/recommendations - verify `?workloads=ansible` in URL and "Ansible Automation Platform" chip visible
2. Verify table only shows Ansible systems
3. Add other filters (name, status), click "Reset filters" - verify ansible workload stays, other filters cleared
4. Click X on the ansible chip - verify filter is removed, all systems/rules shown
5. Refresh page - verify ansible filter is re-applied
6. Visit /insights/advsior - verify no workload filter is applied



# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Apply a default Ansible workload filter for Advisor routes accessed from the Ansible bundle and wire this default into systems and recommendations tables so their filters, URL parameters, and queries consistently reflect the ansible workload context.

New Features:
- Introduce an Ansible workload default hook that applies a workload=ansible filter when accessing Advisor via the Ansible bundle

Enhancements:
- Propagate default workload filters into systems and recommendations tables to align URL parameters, global filters, and table queries
- Update systems and rules tables to accept configurable default filters and adjust workload filtering behavior to use either local or advisor-provided workload values
- Gate rendering of systems and recommendations pages on readiness of the Ansible workload default hook to avoid flicker or inconsistent initial state