### PR TITLE
fix(RHINENG-29782): null safety and error handling in helpers js

### DIFF
--- a/src/PresentationalComponents/Inventory/helpers.js
+++ b/src/PresentationalComponents/Inventory/helpers.js
@@ -60,20 +60,25 @@ export const paginatedRequestHelper = async ({
     Object.assign(options, workloadArrayQueryBuilder(localWorkloadFilter));
   }
 
-  return pathway
-    ? await axios.get(`${SYSTEMS_FETCH_URL}`, {
-        params: { ...options, pathway: pathway.slug },
-        paramsSerializer: (params) =>
-          Qs.stringify(params, { arrayFormat: 'repeat' }),
-      })
-    : await axios.get(
-        `${RULES_FETCH_URL}${encodeURI(rule.rule_id)}/systems_detail/`,
-        {
-          params: options,
+  try {
+    return pathway
+      ? await axios.get(`${SYSTEMS_FETCH_URL}`, {
+          params: { ...options, pathway: pathway.slug },
           paramsSerializer: (params) =>
             Qs.stringify(params, { arrayFormat: 'repeat' }),
-        },
-      );
+        })
+      : await axios.get(
+          `${RULES_FETCH_URL}${encodeURI(rule.rule_id)}/systems_detail/`,
+          {
+            params: options,
+            paramsSerializer: (params) =>
+              Qs.stringify(params, { arrayFormat: 'repeat' }),
+          },
+        );
+  } catch (error) {
+    console.error('Failed to fetch paginated systems data:', error);
+    return { data: [], meta: { count: 0 } };
+  }
 };
 
 /**
@@ -195,7 +200,7 @@ export const getEntities =
      * Systems with last_seen: null exist in Advisor but not in Inventory,
      * which causes 404 errors when querying the Inventory API.
      */
-    const systemsInInventory = fetchedSystems.data.filter(
+    const systemsInInventory = (fetchedSystems?.data || []).filter(
       (system) => system.last_seen !== null,
     );
 
@@ -206,8 +211,9 @@ export const getEntities =
      * querying the Inventory API. We subtract the number of filtered systems
      * from this page to keep the count approximately accurate for pagination.
      */
+    const totalCount = fetchedSystems?.meta?.count || 0;
     const filteredOutCount =
-      fetchedSystems.data.length - systemsInInventory.length;
+      (fetchedSystems?.data || []).length - systemsInInventory.length;
 
     let results = { results: [] };
     if (systemsInInventory.length > 0) {
@@ -235,7 +241,7 @@ export const getEntities =
     }
 
     setCurPageIds(systemsInInventory.map((system) => system.system_uuid));
-    setTotal(Math.max(0, fetchedSystems.meta.count - filteredOutCount));
+    setTotal(Math.max(0, totalCount - filteredOutCount));
     return Promise.resolve({
       results: mergeArraysByDiffKeys(systemsInInventory, results.results).map(
         (item) => {
@@ -245,7 +251,7 @@ export const getEntities =
           };
         },
       ),
-      total: Math.max(0, fetchedSystems.meta.count - filteredOutCount),
+      total: Math.max(0, totalCount - filteredOutCount),
     });
   };
 

--- a/src/PresentationalComponents/Inventory/helpers.test.js
+++ b/src/PresentationalComponents/Inventory/helpers.test.js
@@ -336,6 +336,50 @@ describe('Inventory helpers', () => {
       expect(serialized).not.toContain('category[]');
     });
 
+    it('returns fallback object on network error', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      mockAxiosGet.mockRejectedValue(new Error('Network error'));
+      createOptions.mockReturnValue({ page: 1, per_page: 20 });
+
+      const result = await paginatedRequestHelper({
+        ...mockConfig,
+        rule: { rule_id: 'TEST_RULE' },
+        pathway: null,
+      });
+
+      expect(result).toEqual({ data: [], meta: { count: 0 } });
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to fetch paginated systems data:',
+        expect.any(Error),
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('returns fallback object on server error', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const serverError = new Error('Internal Server Error');
+      serverError.response = { status: 500 };
+
+      mockAxiosGet.mockRejectedValue(serverError);
+      createOptions.mockReturnValue({ page: 1, per_page: 20 });
+
+      const result = await paginatedRequestHelper({
+        ...mockConfig,
+        pathway: { slug: 'test-pathway' },
+      });
+
+      expect(result).toEqual({ data: [], meta: { count: 0 } });
+      expect(consoleErrorSpy).toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+
     describe('workloadFilter handling', () => {
       it('includes workload params in the axios call when workloadFilter is non-empty', async () => {
         const pathway = { slug: 'test-pathway' };
@@ -678,6 +722,105 @@ describe('Inventory helpers', () => {
         },
         true,
       );
+    });
+
+    it('handles paginatedRequestHelper returning fallback data on network error', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      mockAxiosGet.mockRejectedValue(new Error('Network error'));
+
+      const fetchEntities = getEntities(
+        mockHandleRefresh,
+        null,
+        mockSetCurPageIds,
+        mockSetTotal,
+        [],
+        mockSetFullFilters,
+        {},
+        rule,
+        RULES_FETCH_URL,
+        SYSTEMS_FETCH_URL,
+        mockAxios,
+      );
+
+      const result = await fetchEntities(
+        [],
+        config,
+        true,
+        mockDefaultGetEntities,
+      );
+
+      expect(mockDefaultGetEntities).not.toHaveBeenCalled();
+      expect(mockSetCurPageIds).toHaveBeenCalledWith([]);
+      expect(mockSetTotal).toHaveBeenCalledWith(0);
+      expect(result.results).toHaveLength(0);
+      expect(result.total).toBe(0);
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('does not crash when API returns null data or meta', async () => {
+      mockAxiosGet.mockResolvedValue({ data: null, meta: null });
+
+      const fetchEntities = getEntities(
+        mockHandleRefresh,
+        null,
+        mockSetCurPageIds,
+        mockSetTotal,
+        [],
+        mockSetFullFilters,
+        {},
+        rule,
+        RULES_FETCH_URL,
+        SYSTEMS_FETCH_URL,
+        mockAxios,
+      );
+
+      const result = await fetchEntities(
+        [],
+        config,
+        true,
+        mockDefaultGetEntities,
+      );
+
+      expect(mockDefaultGetEntities).not.toHaveBeenCalled();
+      expect(mockSetCurPageIds).toHaveBeenCalledWith([]);
+      expect(mockSetTotal).toHaveBeenCalledWith(0);
+      expect(result.results).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+
+    it('does not crash when API returns empty object', async () => {
+      mockAxiosGet.mockResolvedValue({});
+
+      const fetchEntities = getEntities(
+        mockHandleRefresh,
+        null,
+        mockSetCurPageIds,
+        mockSetTotal,
+        [],
+        mockSetFullFilters,
+        {},
+        rule,
+        RULES_FETCH_URL,
+        SYSTEMS_FETCH_URL,
+        mockAxios,
+      );
+
+      const result = await fetchEntities(
+        [],
+        config,
+        true,
+        mockDefaultGetEntities,
+      );
+
+      expect(mockDefaultGetEntities).not.toHaveBeenCalled();
+      expect(mockSetCurPageIds).toHaveBeenCalledWith([]);
+      expect(mockSetTotal).toHaveBeenCalledWith(0);
+      expect(result.results).toHaveLength(0);
+      expect(result.total).toBe(0);
     });
 
     describe('last_seen null filtering', () => {


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)
https://redhat.atlassian.net/browse/RHINENG-29782


Wrapped paginatedRequestHelper in a try/catch so that network failures and server errors return an empty fallback instead of crashing the Inventory table. Also added optional chaining and fallbacks on fetchedSystems.data and fetchedSystems.meta.count in getEntities to handle cases where the API returns an unexpected shape like null or missing fields. Without these guards, inventory table is prone to crashing.

## Summary by Sourcery

Harden inventory helper data loading against request failures and unexpected API responses.

Bug Fixes:
- Prevent inventory data loading from crashing when paginated requests fail or return null, missing, or malformed response fields.
- Return empty inventory results and zero totals when systems data cannot be fetched.

Tests:
- Add coverage for network and server request failures, null or missing API response fields, and empty response objects.