### PR TITLE
fix(RHINENG-29785): clean up dead labels for export buttons

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -247,18 +247,6 @@ export default defineMessages({
     description: 'Describes function of export icon',
     defaultMessage: 'Export data',
   },
-  exportJson: {
-    id: 'exportJson',
-    description:
-      'Button text to export/download recommendation table data as json',
-    defaultMessage: 'Export to JSON',
-  },
-  exportCsv: {
-    id: 'exportCsv',
-    description:
-      'Button text to export/download recommendation table data as csv',
-    defaultMessage: 'Export to CSV',
-  },
   exportPdf: {
     id: 'exportPdf',
     description: 'Button text to export/download data as pdf',

--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -546,8 +546,6 @@ const Inventory = ({
           }}
           exportConfig={
             permsExport && {
-              label: intl.formatMessage(messages.exportCsv),
-              label: intl.formatMessage(messages.exportJson),
               onSelect: (_e, fileType) =>
                 downloadReport(
                   exportTable,
@@ -620,8 +618,6 @@ const Inventory = ({
           }}
           exportConfig={
             permsExport && {
-              label: intl.formatMessage(messages.exportCsv),
-              label: intl.formatMessage(messages.exportJson),
               onSelect: (_e, fileType) =>
                 downloadReport(
                   exportTable,

--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -296,8 +296,6 @@ const RulesTable = ({ isTabActive, pathway, onRuleChange }) => {
         }}
         exportConfig={
           envContext.isExportEnabled && {
-            label: intl.formatMessage(messages.exportCsv),
-            label: intl.formatMessage(messages.exportJson),
             onSelect: (_e, fileType) =>
               downloadReport(
                 'hits',

--- a/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
+++ b/src/SmartComponents/SystemAdvisor/SystemAdvisor.js
@@ -604,8 +604,6 @@ const BaseSystemAdvisor = ({
           activeFiltersConfig={activeFiltersConfig}
           exportConfig={
             envContext.isExportEnabled && {
-              label: intl.formatMessage(messages.exportCsv),
-              label: intl.formatMessage(messages.exportJson),
               onSelect: (_e, fileType) =>
                 downloadReport(
                   'hits',


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)
https://redhat.atlassian.net/browse/RHINENG-29785
Removed dead label properties from exportConfig objects in Inventory.js, RulesTable.js, and SystemAdvisor.js. 
The DownloadButton component from @redhat-cloud-services/frontend-components ignores the label prop entirely — it renders its own "Export to CSV" / "Export to JSON" dropdown items internally. Also removed the now-unused exportCsv and exportJson message definitions from Messages.js.

## Summary by Sourcery

Remove dead export label configuration and its unused localization messages.

Bug Fixes:
- Remove obsolete export button labels that were ignored by the download component.

Enhancements:
- Clean up unused CSV and JSON export message definitions and references across inventory, rules, and system advisor views.