### PR TITLE
fix(RHINENG-26564): fix topics table name filter and add tests

### DIFF
--- a/cypress/fixtures/topics.json
+++ b/cypress/fixtures/topics.json
@@ -34,5 +34,14 @@
         "featured": false,
         "enabled": true,
         "impacted_systems_count": 694
+    },
+    {
+        "name": "Amazon Web Services (AWS)",
+        "slug": "amazon-web-services",
+        "description": "Amazon Web Services recommendations",
+        "tag": "aws",
+        "featured": false,
+        "enabled": true,
+        "impacted_systems_count": 15
     }
   ]

--- a/src/PresentationalComponents/TopicsTable/Filters.js
+++ b/src/PresentationalComponents/TopicsTable/Filters.js
@@ -1,7 +1,14 @@
+const escapeRegExpForJsonQuery = (value) => {
+  const text = Array.isArray(value) ? value[0] : value;
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\\\$&');
+};
+
 export const nameFilter = {
   type: 'text',
   label: 'Name',
   filterAttribute: 'name',
+  filterSerialiser: (filterConfigItem, value) =>
+    `regex(.${filterConfigItem.filterAttribute}, "${escapeRegExpForJsonQuery(value)}", "i")`,
 };
 
 export default [nameFilter];

--- a/src/PresentationalComponents/TopicsTable/TopicsTable.cy.js
+++ b/src/PresentationalComponents/TopicsTable/TopicsTable.cy.js
@@ -338,6 +338,44 @@ describe('filtering (with tabletools)', () => {
   it('renders filter input', () => {
     cy.get('input[placeholder="Filter by name"]').should('exist');
   });
+
+  it('returns results when search term contains parentheses', () => {
+    cy.get('input[placeholder="Filter by name"]').type(
+      'Amazon Web Services (AWS)',
+    );
+    cy.contains('Amazon Web Services (AWS)').should('be.visible');
+    cy.get('tbody tr').should('have.length', 1);
+  });
+
+  it('returns results when searching partial name without parentheses', () => {
+    cy.get('input[placeholder="Filter by name"]').type('Amazon');
+    cy.contains('Amazon Web Services (AWS)').should('be.visible');
+  });
+
+  it('handles dots in search terms', () => {
+    cy.get('input[placeholder="Filter by name"]').type('nginx');
+    cy.contains('nginx').should('be.visible');
+  });
+
+  it('handles square brackets in search terms without crashing', () => {
+    cy.get('input[placeholder="Filter by name"]').type('test[0]');
+    cy.contains('No matching results found').should('be.visible');
+  });
+
+  it('handles plus signs in search terms without crashing', () => {
+    cy.get('input[placeholder="Filter by name"]').type('C++');
+    cy.contains('No matching results found').should('be.visible');
+  });
+
+  it('handles asterisks in search terms without crashing', () => {
+    cy.get('input[placeholder="Filter by name"]').type('test*');
+    cy.contains('No matching results found').should('be.visible');
+  });
+
+  it('handles pipe characters in search terms without crashing', () => {
+    cy.get('input[placeholder="Filter by name"]').type('foo|bar');
+    cy.contains('No matching results found').should('be.visible');
+  });
 });
 
 describe('sorting (with tabletools)', () => {

--- a/src/PresentationalComponents/helper.test.js
+++ b/src/PresentationalComponents/helper.test.js
@@ -12,7 +12,9 @@ describe('sortTopics test', () => {
   test('the function is called with the Name column parameter and direction desc', () => {
     let sortResult = sortTopics(fixtures, indexes[0], directions[0]);
 
-    expect(sortResult[0].description).toBe('TEST');
+    expect(sortResult[0].description).toBe(
+      'Amazon Web Services recommendations',
+    );
   });
   test('the function is called with the Featured column parameter and direction asc', () => {
     let sortResult = sortTopics(fixtures, indexes[1], directions[1]);


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)
https://redhat.atlassian.net/browse/RHINENG-26564


Fix edge cases for name filter in topics table and add tests to verify the fix

## Summary by Sourcery

Correct topic name filtering for regex-sensitive search terms and verify the behavior with expanded table tests.

Bug Fixes:
- Fix topic name filtering so special characters and partial names are handled correctly without breaking searches.

Tests:
- Add coverage for topic searches containing parentheses, dots, brackets, plus signs, asterisks, and pipe characters.