### PR TITLE
fix: fetch resolution types from remediations API for pathway remediation

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -410,22 +410,50 @@ const Inventory = ({
         fetchAndSetData();
       } else if (pathway && Array.isArray(pathwayRulesList)) {
         const buildAndSetData = async () => {
-          const data = [];
-          for (const r of pathwayRulesList) {
+          const affectedRules = pathwayRulesList.filter((r) => {
             const affected = pathwayReportList[r.rule_id];
-            if (!affected) continue;
+            return affected?.some((id) => safeSelectedIds.includes(id));
+          });
+
+          let resolutionsByIssue = {};
+          if (affectedRules.length > 0) {
+            try {
+              const issues = affectedRules.map((r) => `advisor:${r.rule_id}`);
+              const response = await fetch(
+                '/insights_cloud/api/remediations/v1/resolutions',
+                {
+                  method: 'POST',
+                  headers: {
+                    'content-type': 'application/json; charset=utf-8',
+                    'X-CSRF-Token': document
+                      .querySelector('meta[name="csrf-token"]')
+                      .getAttribute('content'),
+                  },
+                  body: JSON.stringify({ issues }),
+                },
+              );
+              if (response.ok) {
+                resolutionsByIssue = await response.json();
+              }
+            } catch (err) {
+              console.error('Failed to fetch pathway resolutions:', err);
+            }
+          }
+
+          const data = [];
+          for (const r of affectedRules) {
+            const affected = pathwayReportList[r.rule_id];
+            const issueKey = `advisor:${r.rule_id}`;
+            const apiResolutions =
+              resolutionsByIssue[issueKey]?.resolutions || [];
+
             for (const id of safeSelectedIds) {
               if (!affected.includes(id)) continue;
               const row = entities?.rows?.find((e) => e.id === id);
               data.push({
                 hostid: id,
                 host_name: row ? row.display_name : id,
-                resolutions: (r.resolution_set || []).map((res) => ({
-                  description: res.resolution,
-                  id: res.system_type?.toString() || 'fix',
-                  needs_reboot: !!r.reboot_required,
-                  resolution_risk: res.resolution_risk?.risk || 1,
-                })),
+                resolutions: apiResolutions,
                 rulename: r.rule_id,
                 description: r.description,
                 rebootable: !!r.reboot_required,


### PR DESCRIPTION
## Summary

- **Bug:** Remediating from the pathway systems tab returned `400 Bad Request` — the remediations API rejected with `does not have Ansible resolution "105"`.
- **Root cause:** The pathway branch in `Inventory.js` mapped `resolution_set[].system_type` (always `105` for RHEL) as the resolution `id`, but the remediations API expects the resolution type name (e.g., `"fix"`).
- **Fix:** Fetch resolution data from `/remediations/v1/resolutions` (local Foreman proxy → local remediations API container), matching the approach the single-rule remediation path (`iopResolutionsMapper`) already uses successfully.

## Test plan

- [ ] Navigate to a pathway details page → Systems tab
- [ ] Select an affected host and click **Remediate**
- [ ] Verify the remediation modal shows the correct resolution description
- [ ] Confirm the REX job is created successfully (no `400 Bad Request` or template rendering error)
- [ ] Verify single-rule remediation (from recommendation details page) still works

## Summary by Sourcery

Fetch resolution data from the remediations API for pathway-based remediations so that only affected rules are included and resolutions match API expectations.

Bug Fixes:
- Fix pathway remediation failing with 400 Bad Request by using API-provided resolution types instead of system_type IDs.

Enhancements:
- Align pathway remediation resolution handling with the single-rule remediation flow by reusing API-backed resolution data and limiting processing to affected rules.