### PR TITLE
fix(RHINENG-29357): systems table os filter fix and add docs

### DIFF
--- a/docs/os-filter-integration.md
+++ b/docs/os-filter-integration.md
@@ -1,0 +1,414 @@
+# Operating System Filter: Advisor + Inventory Integration
+
+## Overview
+
+The OS filter on the Advisor Systems table (`/insights/advisor/systems`) is a cross-application integration between `insights-advisor-frontend` and `insights-inventory-frontend`. The filter UI is owned by Inventory (loaded via Module Federation / Scalprum), while filter persistence (URL sync, API calls) is handled by Advisor.
+
+This document explains the full data flow for selection, deselection, URL synchronization, and API communication.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────┐
+│        insights-advisor-frontend     │
+│                                      │
+│  SystemsTable.js                     │
+│    ├── Redux: filters.sysState       │
+│    ├── customFilters.advisorFilters   │
+│    ├── getEntities() → API call      │
+│    ├── handleRefresh() → URL sync    │
+│    └── buildFilterChips() → chips    │
+│                                      │
+│  helper.js                           │
+│    └── createOptions() → API params  │
+│                                      │
+│  AppConstants.js                     │
+│    └── SYSTEM_FILTER_CATEGORIES      │
+│                                      │
+│  Common/Tables.js                    │
+│    ├── paramParser() → URL → state   │
+│    ├── urlBuilder() → state → URL    │
+│    └── pruneFilters() → chip data    │
+├──────────────────────────────────────┤
+│    Module Federation boundary        │
+├──────────────────────────────────────┤
+│       insights-inventory-frontend    │
+│                                      │
+│  EntityTableToolbar.js               │
+│    ├── useOperatingSystemFilter()    │
+│    ├── osFilterValue state           │
+│    ├── osFilterChips (native chips)  │
+│    └── onSetFilter() → activeFilters │
+│                                      │
+│  useOperatingSystemFilter.js         │
+│    ├── operatingSystemsValue {}      │
+│    ├── setValue() / setOsValue()     │
+│    ├── handleMajorVersionToggle()    │
+│    └── chips[] (from state → groups) │
+│                                      │
+│  helpers.js                          │
+│    ├── toOsFilterGroups()            │
+│    ├── appendGroupSelection()        │
+│    └── filterGroup() / filterGroupItem() │
+└──────────────────────────────────────┘
+```
+
+---
+
+## Data Structures
+
+### Inventory OS Filter State
+
+The Inventory OS filter uses a nested object keyed by major version group:
+
+```js
+// operatingSystemsValue when RHEL 9.4 and 9.7 are selected:
+{
+  "RHEL-9": {
+    "RHEL-9": null,           // null = some (not all) minor versions selected
+    "RHEL-9-9.4": true,
+    "RHEL-9-9.7": true
+  }
+}
+
+// When ALL minor versions of RHEL 9 are selected:
+{
+  "RHEL-9": {
+    "RHEL-9": true,           // true = all minor versions selected (major toggle)
+    "RHEL-9-9.0": true,
+    "RHEL-9-9.1": true,
+    // ... all versions
+  }
+}
+```
+
+### Inventory Filter Groups (from API)
+
+`toOsFilterGroups()` transforms the API response into PatternFly group filter format:
+
+```js
+[
+  {
+    groupSelectable: true,
+    label: "RHEL-9",        // display label (was groupName, fixed to groupKey)
+    value: "RHEL-9",        // used as groupKey
+    type: "checkbox",
+    major: 9,
+    items: [
+      { label: "RHEL 9.7", value: "RHEL-9-9.7", major: 9, minor: 7 },
+      { label: "RHEL 9.6", value: "RHEL-9-9.6", major: 9, minor: 6 },
+      // ... sorted by minor desc
+    ]
+  },
+  // ... sorted by major desc
+]
+```
+
+### Advisor Redux State (`filters.sysState`)
+
+```js
+{
+  sort: '-last_seen',
+  limit: 20,
+  offset: 0,
+  hits: ['all'],
+  rhel_version: ['9.7', '9.4'],  // flat array of version strings
+  // ... other filters
+}
+```
+
+### Advisor `SYSTEM_FILTER_CATEGORIES` (AppConstants.js)
+
+```js
+{
+  hits: { type: 'checkbox', title: 'total risk', urlParam: 'hits', values: [...] },
+  incident: { type: 'checkbox', title: 'Incidents', urlParam: 'incident', values: [...] },
+  rhel_version: { type: 'checkbox', title: 'Operating system', urlParam: 'rhel_version' },
+  // NOTE: rhel_version has NO `values` property — it cannot enumerate OS versions statically
+  workload: { ... },
+}
+```
+
+---
+
+## Flow 1: User Selects Minor Version (e.g., RHEL 9.4)
+
+```
+User clicks "RHEL 9.4" checkbox
+        │
+        ▼
+[Inventory] useOperatingSystemFilter.onChange()
+  - itemValue !== groupValue → calls setValue(newSelection)
+        │
+        ▼
+[Inventory] appendGroupSelection(newSelection, groups)
+  - Computes group-level flag (true = all selected, null = partial)
+  - Returns normalized selection object
+        │
+        ▼
+[Inventory] setOsValue(fullSelection)
+  - Updates operatingSystemsValue state
+        │
+        ▼
+[Inventory] EntityTableToolbar useEffect([osFilterValue])
+  - Calls onSetFilter(osFilterValue, 'osFilter', debouncedRefresh)
+  - Pushes { osFilter: <value> } into activeFilters array
+  - Triggers table refresh
+        │
+        ▼
+[Advisor] getEntities() callback fires
+  - Receives config.filters containing osFilter
+  - Calls createOptions(advisorFilters, page, per_page, sort, null, filters, ...)
+        │
+        ▼
+[Advisor] createOptions() (helper.js)
+  - buildOsFilter(filters.osFilter) extracts minor version strings
+  - Returns ['9.4'] for single selection
+  - Spreads as: { rhel_version: '9.4' } (joined with comma)
+  - This OVERRIDES any advisorFilters.rhel_version
+        │
+        ▼
+[Advisor] API call: GET /api/insights/v1/system/?rhel_version=9.4&...
+  - Qs.stringify with arrayFormat: 'repeat'
+  - Since rhel_version is already a string (comma-joined), no repeat issue
+        │
+        ▼
+[Advisor] handleRefresh(options)
+  - Whitelists recognized keys (hits, incident, rhel_version, etc.)
+  - Calls urlBuilder() → URL updated to ?rhel_version=9.4&sort=-last_seen&...
+        │
+        ▼
+[Inventory] OS filter chips rendered natively by useOperatingSystemFilter
+  - chip = [{ category: 'Operating system', chips: [{name: 'RHEL 9.4', value: 'RHEL-9-9.4'}] }]
+```
+
+---
+
+## Flow 2: User Selects Major Version (e.g., all of RHEL 9)
+
+```
+User clicks "RHEL-9" group checkbox
+        │
+        ▼
+[Inventory] onChange: itemValue === groupValue → handleMajorVersionToggle(groupValue)
+  - If NOT fully selected: selects ALL minor versions + major flag
+    { "RHEL-9": { "RHEL-9": true, "RHEL-9-9.0": true, "RHEL-9-9.1": true, ... } }
+  - If already fully selected: removes entire group
+    { [groupValue]: _, ...rest } → deselects all
+        │
+        ▼
+[Inventory] setOsValue(newState) → same flow as minor version
+        │
+        ▼
+[Advisor] createOptions() → buildOsFilter() extracts all minor versions
+  - Returns ['9.0', '9.1', '9.2', ...] → joined as '9.0,9.1,9.2,...'
+        │
+        ▼
+API call: ?rhel_version=9.0,9.1,9.2,...
+```
+
+---
+
+## Flow 3: Page Reload with `rhel_version` in URL
+
+```
+Browser loads: /insights/advisor/systems?rhel_version=9.7,9.4&sort=-last_seen&limit=20&offset=0
+        │
+        ▼
+[Advisor] SystemsTable useEffect runs (search is truthy)
+  - paramParser() splits URL params:
+    { rhel_version: ['9.7', '9.4'], sort: ['-last_seen'], ... }
+  - Normalizes: sort → string, offset → number, limit → number
+  - incident normalization (string → array) happens BEFORE combinedFilters
+  - combinedFilters = { ...filters, ...paramsObject }
+  - setFilters(combinedFilters) → Redux updated with rhel_version: ['9.7', '9.4']
+        │
+        ▼
+[Advisor] InventoryTable renders with customFilters:
+  {
+    advisorFilters: {
+      ...filters,                          // includes rhel_version: ['9.7', '9.4']
+      'filter[system_profile]': true
+    },
+    workloads, selectedTags
+  }
+        │
+        ▼
+[Advisor] getEntities() fires
+  - advisorFilters contains rhel_version: ['9.7', '9.4']
+  - createOptions() destructures rhel_version from advisorFilters
+  - Joins to comma string: '9.7,9.4'
+  - osFilter from Inventory is empty (Inventory starts with {} on mount)
+  - Since osFilter is empty, advisorRhelVersion is used
+  - API gets: ?rhel_version=9.7,9.4
+        │
+        ▼
+[Inventory] OS filter UI shows NO checkboxes selected
+  - operatingSystemsValue starts as {} — no URL initialization mechanism
+  - The data IS correctly filtered, but the UI doesn't reflect the URL state
+  - This is a known limitation (see Limitations section)
+```
+
+---
+
+## Flow 4: Chip Deletion
+
+### Single Chip Deletion (Inventory-managed)
+
+```
+User clicks X on "RHEL 9.4" chip
+        │
+        ▼
+[Inventory] EntityTableToolbar.onDeleteFilter()
+  - Calls setOsFilterValue(onDeleteGroupFilter(deleted, osFilterValue))
+  - Removes the specific version from operatingSystemsValue
+        │
+        ▼
+[Inventory] useEffect([osFilterValue]) → onSetFilter → table refresh
+        │
+        ▼
+[Advisor] getEntities() → createOptions() rebuilds API params without 9.4
+```
+
+### "Clear All" Chip Deletion
+
+```
+User clicks "Clear filters"
+        │
+        ▼
+[Advisor] activeFiltersConfig.onDelete(event, items, isAll=true)
+  - Resets Redux to: { sort, limit, offset, hits: ['all'], tags }
+  - rhel_version is removed from Redux state
+        │
+        ▼
+[Inventory] EntityTableToolbar onDeleteFilter
+  - Calls setOsFilterValue([]) → clears OS filter state
+        │
+        ▼
+Both advisor Redux and Inventory local state are cleared
+```
+
+---
+
+## Flow 5: Chip Rendering (Avoiding Duplication)
+
+Two sources can produce OS filter chips:
+
+1. **Inventory chips**: `useOperatingSystemFilter` returns `chip` array with `category: 'Operating system'`
+2. **Advisor chips**: `buildFilterChips()` → `pruneFilters()` could create chips from `filters.rhel_version`
+
+To prevent duplication, `buildFilterChips()` deletes `rhel_version` from `localFilters` before calling `pruneFilters()`. This ensures only Inventory's native chips are shown.
+
+```js
+// SystemsTable.js — buildFilterChips()
+const localFilters = { ...filters };
+delete localFilters.rhel_version;  // Inventory handles OS chips
+return pruneFilters(localFilters, SFC);
+```
+
+---
+
+## Key Functions Reference
+
+### `buildOsFilter(osFilter)` — helper.js
+
+Converts Inventory's nested OS filter state to flat version array:
+
+```js
+// Input:  { "RHEL-9": { "RHEL-9": null, "RHEL-9-9.4": true, "RHEL-9-9.7": true } }
+// Output: ['9.4', '9.7']
+```
+
+Logic: iterates all groups → all entries where value is `true` → extracts the version part after the last `-` → keeps only versions containing `.` (filters out major-only keys).
+
+### `createOptions()` — helper.js
+
+Builds the API query params object. Key `rhel_version` handling:
+
+1. Destructures `rhel_version` from `advisorFilters` (Redux state from URL params on reload)
+2. If present, joins array to comma-separated string
+3. If Inventory's `osFilter` is also present (user interacted with UI), it **overrides** the advisor value
+4. This prevents `Qs.stringify` from generating repeated params (`rhel_version=9.7&rhel_version=9.4`)
+
+### `handleRefresh(options)` — SystemsTable.js
+
+Writes API params back to the URL. Uses a whitelist to prevent polluting the URL with internal params like `filter[system_profile]`:
+
+```js
+const urlKeys = ['hits', 'incident', 'display_name', 'rhel_version',
+                 'workload', 'sort', 'limit', 'offset', 'tags'];
+```
+
+### `paramParser()` — Tables.js
+
+Parses URL query string into state object. Splits comma-separated values into arrays:
+
+```js
+// URL: ?rhel_version=9.7,9.4
+// Output: { rhel_version: ['9.7', '9.4'] }
+```
+
+### `addFilterParam()` — SystemsTable.js
+
+Handles advisor-side filter changes. For `rhel_version`, flattens the Inventory nested object into a flat version array:
+
+```js
+const passValue =
+  param === SFC.rhel_version.urlParam
+    ? Object.values(values || {}).flatMap((majorOsVersion) =>
+        Object.keys(majorOsVersion))
+    : values;
+```
+
+### `pruneFilters()` — Tables.js
+
+Generates chip data for the active filters display. For `rhel_version`, uses a special branch that formats chips as `RHEL <version>` without looking up a `values` array (since `SFC.rhel_version` has no `values`). The non-array fallback uses optional chaining (`category.values?.find(...)?.label`) to prevent crashes when `values` is undefined.
+
+### `handleMajorVersionToggle()` — useOperatingSystemFilter.js
+
+Toggles all minor versions under a major version group. If the group was fully selected, it deselects all. Otherwise, it selects every minor version plus the group flag.
+
+### `appendGroupSelection()` — helpers.js (inventory)
+
+Normalizes the group filter selection after any change. Ensures the group-level key (`RHEL-9`) is `true` when all children are selected, `null` when partial, and removes the group entirely when all children are deselected.
+
+---
+
+## Serialization: URL ↔ API
+
+| Format | Example | Used where |
+|--------|---------|------------|
+| Comma-separated | `rhel_version=9.7,9.4` | URL, API query param |
+| Array | `['9.7', '9.4']` | Redux state, internal |
+| Repeated params | `rhel_version=9.7&rhel_version=9.4` | NOT used (would cause API 400) |
+
+The `createOptions()` function ensures arrays are joined before `Qs.stringify` runs, preventing the repeated params format.
+
+URL encoding note: `%2C` and `,` are equivalent after URL decoding — the web server/browser handles this transparently.
+
+---
+
+## Limitations
+
+1. **No Inventory UI restoration from URL**: When the page loads with `rhel_version` in the URL, the data is correctly filtered via `advisorFilters`, but the Inventory OS filter checkboxes remain unchecked. Inventory's `useOperatingSystemFilter` always initializes with empty state `{}` and has no mechanism to receive initial values from URL params.
+
+2. **Two-way override**: When a user interacts with the OS filter after a URL-based reload, the Inventory `osFilter` takes precedence and replaces the advisor `rhel_version` value. This is correct behavior — user interaction should override URL state.
+
+3. **`rhel_version` has no static values**: Unlike `hits` or `incident`, the `SYSTEM_FILTER_CATEGORIES.rhel_version` entry has no `values` property because OS versions are fetched dynamically from the API. Code that assumes all filter categories have `values` must use optional chaining.
+
+---
+
+## Files Summary
+
+| File | Repo | Role |
+|------|------|------|
+| `src/PresentationalComponents/SystemsTable/SystemsTable.js` | advisor | Main table component, Redux integration, filter chips, URL sync |
+| `src/PresentationalComponents/helper.js` | advisor | `createOptions()`, `buildOsFilter()`, API param construction |
+| `src/PresentationalComponents/Common/Tables.js` | advisor | `paramParser()`, `urlBuilder()`, `pruneFilters()` |
+| `src/AppConstants.js` | advisor | `SYSTEM_FILTER_CATEGORIES` definition |
+| `src/Services/Filters.js` | advisor | Redux slice, initial state |
+| `src/components/InventoryTable/EntityTableToolbar.js` | inventory | Toolbar with all filters, connects OS filter to table |
+| `src/components/filters/useOperatingSystemFilter.js` | inventory | OS filter hook: state, onChange, chips, major toggle |
+| `src/components/filters/helpers.js` | inventory | `toOsFilterGroups()`, `appendGroupSelection()`, group/item builders |

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -461,7 +461,7 @@ export const getImpactingFitlerItems = (hasEdgeDevices) =>
 export const SYSTEM_FILTER_CATEGORIES = {
   hits: {
     type: conditionalFilterType.checkbox,
-    title: 'Total Risk',
+    title: 'total risk',
     urlParam: 'hits',
     values: [
       { label: 'All systems', text: 'All systems', value: 'all' },
@@ -494,6 +494,7 @@ export const SYSTEM_FILTER_CATEGORIES = {
     title: 'Operating system',
     urlParam: 'rhel_version',
   },
+  workload: FILTER_CATEGORIES.workload,
 };
 
 export const exportNotifications = {

--- a/src/PresentationalComponents/Common/Tables.js
+++ b/src/PresentationalComponents/Common/Tables.js
@@ -156,9 +156,10 @@ export const pruneFilters = (localFilters, filterCategories) => {
               })
             : [
                 {
-                  name: category.values.find(
-                    (values) => values.value === String(item[1]),
-                  ).label,
+                  name:
+                    category.values?.find(
+                      (values) => values.value === String(item[1]),
+                    )?.label ?? String(item[1]),
                   value: item[1],
                 },
               ];

--- a/src/PresentationalComponents/Common/Tables.test.js
+++ b/src/PresentationalComponents/Common/Tables.test.js
@@ -1,4 +1,4 @@
-import { workloadArrayQueryBuilder } from './Tables';
+import { pruneFilters, workloadArrayQueryBuilder } from './Tables';
 
 jest.mock(
   '@redhat-cloud-services/frontend-components-utilities/helpers',
@@ -9,7 +9,22 @@ jest.mock(
 );
 
 jest.mock('../../AppConstants', () => ({
-  SYSTEM_FILTER_CATEGORIES: {},
+  SYSTEM_FILTER_CATEGORIES: {
+    rhel_version: {
+      type: 'checkbox',
+      title: 'Operating system',
+      urlParam: 'rhel_version',
+    },
+    hits: {
+      type: 'checkbox',
+      title: 'total risk',
+      urlParam: 'hits',
+      values: [
+        { label: 'All systems', text: 'All systems', value: 'all' },
+        { label: 'Critical', value: '4' },
+      ],
+    },
+  },
   SYSTEM_TYPES: { rhel: 1, ocp: 2 },
   FILTER_CATEGORIES: {},
   BASE_URL: '/api/advisor/v1',
@@ -32,5 +47,63 @@ describe('workloadArrayQueryBuilder', () => {
 
   it('returns {} when called with no argument (default parameter)', () => {
     expect(workloadArrayQueryBuilder()).toEqual({});
+  });
+});
+
+describe('pruneFilters', () => {
+  const { SYSTEM_FILTER_CATEGORIES: SFC } = require('../../AppConstants');
+
+  it('creates RHEL-prefixed chips for rhel_version array values', () => {
+    const filters = { rhel_version: ['9.7', '9.4'] };
+    const result = pruneFilters(filters, SFC);
+
+    expect(result).toEqual([
+      {
+        category: 'Operating system',
+        chips: [
+          { name: 'RHEL 9.7', value: '9.7' },
+          { name: 'RHEL 9.4', value: '9.4' },
+        ],
+        urlParam: 'rhel_version',
+      },
+    ]);
+  });
+
+  it('does not crash when rhel_version is a non-array value (no values property)', () => {
+    const filters = { rhel_version: '9.7' };
+    const result = pruneFilters(filters, SFC);
+
+    expect(result).toEqual([
+      {
+        category: 'Operating system',
+        chips: [{ name: '9.7', value: '9.7' }],
+        urlParam: 'rhel_version',
+      },
+    ]);
+  });
+
+  it('uses category.values lookup for filters that have values defined', () => {
+    const filters = { hits: ['4'] };
+    const result = pruneFilters(filters, SFC);
+
+    expect(result).toEqual([
+      {
+        category: 'Total risk',
+        chips: [{ name: 'Critical', value: '4' }],
+        urlParam: 'hits',
+      },
+    ]);
+  });
+
+  it('returns empty array when no filters match categories', () => {
+    const filters = { unknown_filter: ['value'] };
+    const result = pruneFilters(filters, SFC);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for empty filters', () => {
+    const result = pruneFilters({}, SFC);
+    expect(result).toEqual([]);
   });
 });

--- a/src/PresentationalComponents/SystemsTable/SystemsTable.js
+++ b/src/PresentationalComponents/SystemsTable/SystemsTable.js
@@ -117,6 +117,12 @@ const SystemsTable = () => {
     delete localFilters.sort;
     delete localFilters.offset;
     delete localFilters.limit;
+    delete localFilters.rhel_version;
+
+    if (!isWorkloadFilterEnabled) {
+      const { workload: _, ...filterCategories } = SFC;
+      return pruneFilters(localFilters, filterCategories);
+    }
 
     return pruneFilters(localFilters, SFC);
   };
@@ -151,15 +157,24 @@ const SystemsTable = () => {
   };
 
   const handleRefresh = (options) => {
-    const { display_name, hits } = options;
-    const refreshedFilters = {
-      ...options,
-      ...(display_name && {
-        display_name,
-      }),
-      ...(hits && { hits }),
-    };
-    urlBuilder(refreshedFilters, selectedTags);
+    const urlParams = {};
+    const urlKeys = [
+      'hits',
+      'incident',
+      'display_name',
+      'rhel_version',
+      'workload',
+      'sort',
+      'limit',
+      'offset',
+      'tags',
+    ];
+    urlKeys.forEach((key) => {
+      if (options[key] !== undefined) {
+        urlParams[key] = options[key];
+      }
+    });
+    urlBuilder(urlParams);
   };
 
   const columns = systemsTableColumns(intl, envContext);
@@ -180,10 +195,10 @@ const SystemsTable = () => {
       paramsObject.limit === undefined || isNaN(paramsObject.limit)
         ? (paramsObject.limit = 20)
         : (paramsObject.limit = Number(paramsObject.limit[0]));
-      combinedFilters = { ...filters, ...paramsObject };
       paramsObject.incident !== undefined &&
         !Array.isArray(paramsObject.incident) &&
         (paramsObject.incident = [`${paramsObject.incident}`]);
+      combinedFilters = { ...filters, ...paramsObject };
       setFilters(combinedFilters);
     } else if (
       filters.limit === undefined ||

--- a/src/PresentationalComponents/helper.js
+++ b/src/PresentationalComponents/helper.js
@@ -37,8 +37,15 @@ export const createOptions = (
   // RHINENG-11227: remove system incident filter if it has multiple elements, which will be both
   // 'true' and 'false', because it will result in a 400 BadRequest from the API
   advisorFilters.incident?.length > 1 && delete advisorFilters.incident;
+  const { rhel_version: advisorRhelVersion, ...restAdvisorFilters } =
+    advisorFilters;
   const options = {
-    ...advisorFilters,
+    ...restAdvisorFilters,
+    ...(advisorRhelVersion?.length && {
+      rhel_version: Array.isArray(advisorRhelVersion)
+        ? advisorRhelVersion.join(',')
+        : advisorRhelVersion,
+    }),
     limit: per_page,
     offset: page * per_page - per_page,
     sort: sort,

--- a/src/PresentationalComponents/helper.test.js
+++ b/src/PresentationalComponents/helper.test.js
@@ -122,6 +122,96 @@ describe('createOptions', () => {
     ).toEqual('9.0,9.1,9.5,9.3,9.4,9.2,8.0,8.2');
   });
 
+  it('joins advisorFilters.rhel_version array to comma-separated string', () => {
+    const advisorFiltersWithRhel = {
+      rhel_version: ['9.7', '9.4'],
+    };
+
+    expect(
+      createOptions(
+        advisorFiltersWithRhel,
+        page,
+        per_page,
+        sort,
+        pathway,
+        filters,
+        selectedTags,
+        workloads,
+        SID,
+        systemsPage,
+      ).rhel_version,
+    ).toEqual('9.7,9.4');
+  });
+
+  it('passes through advisorFilters.rhel_version when already a string', () => {
+    const advisorFiltersWithRhel = {
+      rhel_version: '9.7,9.4',
+    };
+
+    expect(
+      createOptions(
+        advisorFiltersWithRhel,
+        page,
+        per_page,
+        sort,
+        pathway,
+        filters,
+        selectedTags,
+        workloads,
+        SID,
+        systemsPage,
+      ).rhel_version,
+    ).toEqual('9.7,9.4');
+  });
+
+  it('osFilter overrides advisorFilters.rhel_version', () => {
+    const advisorFiltersWithRhel = {
+      rhel_version: ['8.0'],
+    };
+    const osFilter = {
+      'RHEL-9': {
+        'RHEL-9': null,
+        'RHEL-9-9.7': true,
+      },
+    };
+
+    expect(
+      createOptions(
+        advisorFiltersWithRhel,
+        page,
+        per_page,
+        sort,
+        pathway,
+        { osFilter },
+        selectedTags,
+        workloads,
+        SID,
+        systemsPage,
+      ).rhel_version,
+    ).toEqual('9.7');
+  });
+
+  it('omits rhel_version when advisorFilters.rhel_version is empty array and no osFilter', () => {
+    const advisorFiltersWithRhel = {
+      rhel_version: [],
+    };
+
+    expect(
+      createOptions(
+        advisorFiltersWithRhel,
+        page,
+        per_page,
+        sort,
+        pathway,
+        filters,
+        selectedTags,
+        workloads,
+        SID,
+        systemsPage,
+      ).rhel_version,
+    ).toBeUndefined();
+  });
+
   it('returns a groups prop as comma-separated string when hostGroupFilter contains strings', () => {
     const hostGroupFilter = ['group1', 'group2'];
 


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)
https://redhat.atlassian.net/browse/RHINENG-29357


Fixes several bugs in the Systems table filters:

- OS filter rhel_version array handling — rhel_version was being passed as an array to Qs.stringify which serialized it as repeated query params instead of the comma-separated format the API expects. Fixed by joining the array into a comma-separated string in createOptions. Also hardened pruneFilters with optional chaining so it doesn't crash when a filter category has no predefined values.

- "Total Risk" filter chip showed inconsistent capitalization because the title was already capitalized before capitalize() ran on it. Changed the source title to lowercase so capitalize() produces the correct result.

- Workload filter chip was missing from the Systems table because workload wasn't included in SYSTEM_FILTER_CATEGORIES. Added it with a conditional so it only appears when the feature flag is enabled.

- URL pollution — handleRefresh was spreading all API options into the URL, including internal keys that don't belong there. Replaced with a whitelist of valid URL params.

Also adds documentation for the OS filter integration flow between advisor and inventory, and new tests for pruneFilters and createOptions.

How to test this



1. Open https://stage.foo.redhat.com:1337/insights/advisor/systems
2. Verify:
  - Select OS filter versions — rhel_version appears in the URL as comma-separated values
  - Clicking a major OS version (e.g. "RHEL 8") selects/deselects all its minor versions
  - "Total risk" chip displays with correct capitalization
  - Workload filter chip appears when feature flag is enabled
  - URL only contains valid filter params (no limit, offset, filter[system_profile], etc.)

## Summary by Sourcery

Fix Systems table filter handling and document the operating-system filter integration.

New Features:
- Add workload filter support to the Systems table when enabled by its feature flag.

Bug Fixes:
- Correctly serialize operating-system version filters as comma-separated API and URL values.
- Prevent filter chip generation from failing for dynamically defined categories without predefined values.
- Correct Total risk chip capitalization and prevent internal API options from polluting the URL.

Documentation:
- Document the Advisor and Inventory operating-system filter integration, including state, URL, API, and chip flows.

Tests:
- Add coverage for operating-system filter serialization, filter precedence, empty values, and resilient filter chip generation.