### PR TITLE
Add outage banner controlled by hbi.outage-banner Unleash flag

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import React, { useEffect, useContext, createContext } from 'react';
 import { batch, useDispatch } from 'react-redux';
 import { updateTags, updateWorkloads } from './Services/Filters';
 import MessageState from './PresentationalComponents/MessageState/MessageState';
+import OutageAlert from './PresentationalComponents/OutageAlert/OutageAlert';
 import { AdvisorRoutes } from './Routes';
 import messages from './Messages';
 import { useIntl } from 'react-intl';
@@ -53,14 +54,20 @@ const App = () => {
   return (
     !envContext?.isLoading &&
     (envContext?.isAllowedToViewRec ? (
-      <AdvisorRoutes />
+      <React.Fragment>
+        <OutageAlert />
+        <AdvisorRoutes />
+      </React.Fragment>
     ) : (
-      <MessageState
-        variant="large"
-        icon={LockIcon}
-        title={intl.formatMessage(messages.permsTitle)}
-        text={intl.formatMessage(messages.permsBody)}
-      />
+      <React.Fragment>
+        <OutageAlert />
+        <MessageState
+          variant="large"
+          icon={LockIcon}
+          title={intl.formatMessage(messages.permsTitle)}
+          text={intl.formatMessage(messages.permsBody)}
+        />
+      </React.Fragment>
     ))
   );
 };

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -12,6 +12,12 @@ jest.mock('./Routes', () => ({
 jest.mock('./Utilities/Hooks', () => ({
   useHccEnvironmentContext: jest.fn(),
   useFeatureFlag: jest.fn(),
+  useFeatureVariant: jest.fn(() => ({
+    isEnabled: false,
+    body: undefined,
+    variant: undefined,
+    title: undefined,
+  })),
 }));
 
 jest.mock('./Utilities/useKesselEnvironmentContext', () => ({
@@ -20,6 +26,7 @@ jest.mock('./Utilities/useKesselEnvironmentContext', () => ({
 
 jest.mock('@unleash/proxy-client-react', () => ({
   useFlagsStatus: jest.fn(),
+  useVariant: jest.fn(() => ({ enabled: false, payload: undefined })),
 }));
 
 jest.mock('@project-kessel/react-kessel-access-check', () => ({

--- a/src/PresentationalComponents/OutageAlert/OutageAlert.js
+++ b/src/PresentationalComponents/OutageAlert/OutageAlert.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Alert } from '@patternfly/react-core';
+import { useFeatureVariant } from '../../Utilities/Hooks';
+
+const OutageAlert = () => {
+  const {
+    isEnabled,
+    body = '',
+    variant = 'danger',
+    title = 'The Advisor service is currently unavailable. Please check back later.',
+  } = useFeatureVariant('hbi.outage-banner');
+
+  if (!isEnabled) {
+    return null;
+  }
+
+  return (
+    <Alert title={title} variant={variant} isInline>
+      {body}
+    </Alert>
+  );
+};
+
+export default OutageAlert;

--- a/src/PresentationalComponents/OutageAlert/OutageAlert.test.js
+++ b/src/PresentationalComponents/OutageAlert/OutageAlert.test.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import OutageAlert from './OutageAlert';
+import { useFeatureVariant } from '../../Utilities/Hooks';
+
+jest.mock('../../Utilities/Hooks', () => ({
+  ...jest.requireActual('../../Utilities/Hooks'),
+  useFeatureVariant: jest.fn(),
+}));
+
+describe('OutageAlert', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when feature flag is disabled', () => {
+    useFeatureVariant.mockReturnValue({
+      isEnabled: false,
+      body: undefined,
+      variant: undefined,
+      title: undefined,
+    });
+
+    const { container } = render(<OutageAlert />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders alert with default title when enabled without payload', () => {
+    useFeatureVariant.mockReturnValue({
+      isEnabled: true,
+      body: undefined,
+      variant: undefined,
+      title: undefined,
+    });
+
+    render(<OutageAlert />);
+    expect(
+      screen.getByText(
+        'The Advisor service is currently unavailable. Please check back later.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders alert with custom title from flag payload', () => {
+    useFeatureVariant.mockReturnValue({
+      isEnabled: true,
+      body: 'Scheduled maintenance in progress.',
+      variant: 'warning',
+      title: 'Advisor is undergoing maintenance',
+    });
+
+    render(<OutageAlert />);
+    expect(
+      screen.getByText('Advisor is undergoing maintenance'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Scheduled maintenance in progress.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders with danger variant by default', () => {
+    useFeatureVariant.mockReturnValue({
+      isEnabled: true,
+      body: '',
+      variant: undefined,
+      title: undefined,
+    });
+
+    render(<OutageAlert />);
+    const alertTitle = screen.getByText(
+      'The Advisor service is currently unavailable. Please check back later.',
+    );
+    expect(alertTitle.closest('.pf-v6-c-alert')).toHaveClass('pf-m-danger');
+  });
+
+  it('renders with custom variant from flag payload', () => {
+    useFeatureVariant.mockReturnValue({
+      isEnabled: true,
+      body: '',
+      variant: 'warning',
+      title: 'Partial outage',
+    });
+
+    render(<OutageAlert />);
+    const alertTitle = screen.getByText('Partial outage');
+    expect(alertTitle.closest('.pf-v6-c-alert')).toHaveClass('pf-m-warning');
+  });
+
+  it('calls useFeatureVariant with the correct flag name', () => {
+    useFeatureVariant.mockReturnValue({ isEnabled: false });
+
+    render(<OutageAlert />);
+    expect(useFeatureVariant).toHaveBeenCalledWith('hbi.outage-banner');
+  });
+});

--- a/src/PresentationalComponents/PathwaysTable/PathwaysTable.test.js
+++ b/src/PresentationalComponents/PathwaysTable/PathwaysTable.test.js
@@ -107,6 +107,7 @@ jest.mock('@redhat-cloud-services/frontend-components/ErrorState', () => ({
 jest.mock('@unleash/proxy-client-react', () => ({
   useFlag: jest.fn(() => false),
   useFlagsStatus: jest.fn(() => ({ flagsReady: true })),
+  useVariant: jest.fn(() => ({ enabled: false, payload: undefined })),
   FlagProvider: ({ children }) => children,
 }));
 

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -1,5 +1,9 @@
 import { useEffect, useState, useMemo, useRef, useCallback } from 'react';
-import { useFlag, useFlagsStatus } from '@unleash/proxy-client-react';
+import {
+  useFlag,
+  useFlagsStatus,
+  useVariant,
+} from '@unleash/proxy-client-react';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import {
   BASE_URL,
@@ -11,6 +15,29 @@ export const useFeatureFlag = (flag) => {
   const { flagsReady } = useFlagsStatus();
   const isFlagEnabled = useFlag(flag);
   return flagsReady ? isFlagEnabled : false;
+};
+
+export const useFeatureVariant = (flag) => {
+  const { flagsReady } = useFlagsStatus();
+  const variant = useVariant(flag);
+
+  const isEnabled = flagsReady ? variant.enabled : false;
+
+  let payload;
+  if (flagsReady && variant.payload) {
+    try {
+      payload = JSON.parse(variant.payload.value);
+    } catch {
+      payload = undefined;
+    }
+  }
+
+  return {
+    isEnabled,
+    body: payload?.body,
+    variant: payload?.variant,
+    title: payload?.title,
+  };
 };
 
 export const matchPermissions = (permissionA, permissionB) => {


### PR DESCRIPTION
## Summary by Sourcery

Display a feature-flagged Advisor outage banner with configurable messaging and severity.

New Features:
- Add a configurable inline outage alert that appears across the application when the outage feature flag is enabled.

Enhancements:
- Support feature-flag variants with parsed payload values for alert title, message, and severity.

Tests:
- Add coverage for disabled alerts, default and custom payloads, alert variants, and feature-flag usage.