### PR TITLE
fix(RHINENG-30318): enable pathway Remediate button for playbook-backed rules

### DIFF
--- a/src/PresentationalComponents/Inventory/Inventory.js
+++ b/src/PresentationalComponents/Inventory/Inventory.js
@@ -176,11 +176,19 @@ const Inventory = ({
     if (!hasPathwayDetails) {
       if (pathway) {
         try {
+          // Fetch the pathway's impacting rules via the shared /rule/ endpoint
+          // (matches hosted/master to limit branch divergence; same
+          // RuleForAccountSerializer as /pathway/<slug>/rules/, so the
+          // resolution_set/has_playbook fields the button check reads are
+          // identical). The backend default_limit is 10, so an explicit limit
+          // is required or the impacting rule that carries a playbook can be
+          // paginated out, leaving the Remediate button permanently disabled.
+          // max_limit=1000 covers the largest pathway.
           let pathwayRules = (
             await Get(
-              `${envContext.BASE_URL}/pathway/${encodeURI(pathway.slug)}/rules/`,
+              `${envContext.RULES_FETCH_URL}`,
               {},
-              {},
+              { pathway: pathway.slug, impacting: true, limit: 1000 },
             )
           )?.data.data;
 
@@ -228,9 +236,9 @@ const Inventory = ({
     if (pathway) {
       const pathways = (
         await Get(
-          `${envContext.BASE_URL}/pathway/${encodeURI(pathway.slug)}/rules/`,
+          `${envContext.RULES_FETCH_URL}`,
           {},
-          {},
+          { pathway: pathway.slug, impacting: true, limit: 1000 },
         )
       )?.data.data;
 
@@ -246,7 +254,9 @@ const Inventory = ({
       pathways.forEach((rec) => {
         let filteredSystems = [];
 
-        systems[rec.rule_id].forEach((system) => {
+        // reports (systems) only keys impacting rules; guard so a rule without
+        // a matching report entry doesn't throw.
+        (systems[rec.rule_id] || []).forEach((system) => {
           if (safeSelectedIds.includes(system)) {
             filteredSystems.push(system);
           }


### PR DESCRIPTION
## Summary

On the pathway Systems tab, the Remediate button never enables for larger pathways because `Inventory.js` fetches `/pathway/<slug>/rules/` without a limit. The backend defaults to 10 rules per page, so if the impacting rule that has a playbook isn't in the first 10, the button's `has_playbook` check never sees it and stays disabled.

## Fix

In `src/PresentationalComponents/Inventory/Inventory.js`, fetch from `/rule/?pathway=<slug>&impacting=true&limit=1000` instead. Same `RuleForAccountSerializer`, but filtered to impacting rules and returned all in one page (converges with hosted/master). Also guard the reports lookup so a rule with no reports entry doesn't throw.

## Testing

Verified on IoP (foreman-5.0):
- Button enables for a host hitting `hardening_ssh_hmac_cipher_rhel8_later`; running the remediation clears the recommendation.
- Stays correctly disabled for `vfs_cache_pressure|VFS_CACHE_PRESSURE_TOO_HIGH` (or others with no playbook).

## Notes

Distinct from RHINENG-29894 (400 Bad Request, `system_type` sent as resolution id; already fixed by PR #2163). Same file, different bug.

JIRA: https://redhat.atlassian.net/browse/RHINENG-30318

## Summary by Sourcery

Ensure pathway remediation availability is determined from the complete set of impacting rules.

Bug Fixes:
- Enable the pathway Systems Remediate button to detect playbook-backed impacting rules across larger pathways.
- Prevent missing reports entries from causing pathway inventory processing errors.