### PR TITLE
fix(RHINENG-30380): resolve page load error

### DIFF
--- a/config/patchFederationForIop.js
+++ b/config/patchFederationForIop.js
@@ -16,9 +16,7 @@ const originalCreateIncludes = federatedModulesUtil.createIncludes;
 
 federatedModulesUtil.createIncludes = (...args) => {
     const includes = originalCreateIncludes(...args);
-    if (includes.chromeProvided) {
-        delete includes.chromeProvided['react/jsx-runtime'];
-        delete includes.chromeProvided['react-intl'];
-    }
+    delete includes.chromeProvided['react/jsx-runtime'];
+    delete includes.chromeProvided['react-intl'];
     return includes;
 };

--- a/custom_routes.json
+++ b/custom_routes.json
@@ -1,6 +1,7 @@
 {
-  "/assets/apps/advisor/*": {
-    "url": "http://host.docker.internal:8003"
+  "/assets/apps/advisor*": {
+    "url": "http://host.docker.internal:8003",
+    "strip_prefix": "/assets"
   },
   "/api/insights/*": {
     "url": "http://host.docker.internal:8000"

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "@cypress/code-coverage": "^3.14.5",
         "@formatjs/cli": "^6.2.12",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.0",
-        "@redhat-cloud-services/frontend-components-config": "^6.13.0",
+        "@redhat-cloud-services/frontend-components-config": "^6.14.3",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.11",
         "@scalprum/core": "^0.7.0",
         "@testing-library/jest-dom": "^6.4.5",
@@ -7583,9 +7583,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.14.2.tgz",
-      "integrity": "sha512-UjLIEdQ9oqF0JstzkcyLkZK1jo455f3MCv4+3grHdrMGu4/IetkBou14p9HXAp662AcxyI+PlEV1u0lNu+vS8A==",
+      "version": "6.14.4",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.14.4.tgz",
+      "integrity": "sha512-L7r2WiXvWHDmUEJkolr/44GSU6QIXF4FQyGN7KsdvtSOUMFoQDcig5kJ3PQoXkHGYEwLWyKqKCqI30nKEQdOzw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -30824,19 +30824,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "extraneous": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@cypress/code-coverage": "^3.14.5",
     "@formatjs/cli": "^6.2.12",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.0",
-    "@redhat-cloud-services/frontend-components-config": "^6.13.0",
+    "@redhat-cloud-services/frontend-components-config": "^6.14.3",
     "@redhat-cloud-services/tsc-transform-imports": "^1.0.11",
     "@scalprum/core": "^0.7.0",
     "@testing-library/jest-dom": "^6.4.5",


### PR DESCRIPTION
To test just run in proxy mode and confirm the app works/loads as normal. 
`export IOP_URL={yourInstance}
  npm run start:proxy:iop`

This resolves the page break issue, as well as updates the config so that when exiting the run with ctrl+c, the container and ports are all killed and dont continue running in the background.

when applying the patch, we shouldnt conditionally check from the chromeProvided thing. When in IOP mode, the container should always kill it. (I only made this mistake in this branch specifically, im unsure why, but the other branches are fine).

The strip prefix stuff: 
 1. The shell app requests: /assets/apps/advisor/fed-mods.json
     - This is what the external IOP instance is configured to look for (hardcoded in its manifest loading logic)
  2. The proxy receives this request and matches it against your route pattern /assets/apps/advisor*
  3. The strip_prefix: "/assets" directive tells Caddy to:
     - Remove /assets from the beginning of the path
     - Leaving: /apps/advisor/fed-mods.json
  4. Caddy forwards to: http://host.docker.internal:8003 + /apps/advisor/fed-mods.json
  5. Your dev server (fec dev-proxy --iop) is actually serving the manifest at /apps/advisor/fed-mods.json (not
     /assets/apps/advisor/...)
     - Because fec dev-proxy uses deployment mode assets/apps which translates to /apps/ as the base URL

  So the mapping is:
  - Shell expects: /assets/apps/advisor/fed-mods.json
  - Dev server has: /apps/advisor/fed-mods.json
  - strip_prefix bridges the gap by rewriting /assets/apps/advisor/ → /apps/advisor/

## Summary by Sourcery

Resolve IOP page loading and shutdown issues while aligning proxy routing and frontend configuration.

Bug Fixes:
- Fix page load failures in IOP mode by consistently removing incompatible federated React runtime modules.
- Ensure IOP development containers and exposed ports are stopped when exiting with Ctrl+C.

Enhancements:
- Update proxy routing to correctly map shell asset requests to the IOP development server.
- Upgrade the frontend components configuration dependency.