### PR TITLE
fix(RHINENG-25917): Fix backend endpoint for topics admin

### DIFF
--- a/src/PresentationalComponents/Modals/AddEditTopic.js
+++ b/src/PresentationalComponents/Modals/AddEditTopic.js
@@ -37,11 +37,11 @@ const AddEditTopic = ({ handleModalToggleCallback, isModalOpen, topic }) => {
     try {
       const data = { name, slug, tag, description, enabled, featured };
       if (type === 'DELETE') {
-        await axios.delete(`${BASE_URL}/topic/${slug}`);
+        await axios.delete(`${BASE_URL}/ruletopic/${slug}`);
       } else if (topic.slug) {
-        await axios.put(`${BASE_URL}/topic/${slug}/`, data);
+        await axios.put(`${BASE_URL}/ruletopic/${slug}/`, data);
       } else {
-        await axios.post(`${BASE_URL}/topic/`, data);
+        await axios.post(`${BASE_URL}/ruletopic/`, data);
       }
     } catch (error) {
       addNotification({

--- a/src/PresentationalComponents/Modals/AddEditTopic.test.js
+++ b/src/PresentationalComponents/Modals/AddEditTopic.test.js
@@ -194,7 +194,7 @@ describe('AddEditTopic', () => {
 
       await waitFor(() => {
         expect(mockAxios.post).toHaveBeenCalledWith(
-          '/api/insights/v1/topic/',
+          '/api/insights/v1/ruletopic/',
           expect.objectContaining({
             name: 'New Topic',
             slug: 'newtopic',
@@ -223,14 +223,17 @@ describe('AddEditTopic', () => {
       fireEvent.click(saveButton);
 
       await waitFor(() => {
-        expect(mockAxios.post).toHaveBeenCalledWith('/api/insights/v1/topic/', {
-          name: 'Test Topic',
-          slug: 'testtopic',
-          tag: 'test-tag',
-          description: 'Test Description',
-          enabled: true,
-          featured: true,
-        });
+        expect(mockAxios.post).toHaveBeenCalledWith(
+          '/api/insights/v1/ruletopic/',
+          {
+            name: 'Test Topic',
+            slug: 'testtopic',
+            tag: 'test-tag',
+            description: 'Test Description',
+            enabled: true,
+            featured: true,
+          },
+        );
       });
     });
   });
@@ -257,7 +260,7 @@ describe('AddEditTopic', () => {
 
       await waitFor(() => {
         expect(mockAxios.put).toHaveBeenCalledWith(
-          '/api/insights/v1/topic/original-slug/',
+          '/api/insights/v1/ruletopic/original-slug/',
           expect.objectContaining({
             name: 'Updated Name',
             slug: 'original-slug',
@@ -282,7 +285,7 @@ describe('AddEditTopic', () => {
 
       await waitFor(() => {
         expect(mockAxios.delete).toHaveBeenCalledWith(
-          '/api/insights/v1/topic/topic-to-delete',
+          '/api/insights/v1/ruletopic/topic-to-delete',
         );
       });
     });


### PR DESCRIPTION
Use the correct Advisor API endpoint for topics change requests

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Correct the backend endpoint used by topic administration requests.

Bug Fixes:
- Use the correct Advisor API `ruletopic` endpoint for creating, updating, and deleting topics.

Tests:
- Update topic modal tests to verify requests use the corrected `ruletopic` endpoints.